### PR TITLE
Show pending join request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 grouper.sqlite
 
 __pycache__

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import label, literal
 
 
-from .util import GrouperHandler
+from .util import GrouperHandler, Alert
 from .forms import GroupForm, GroupJoinForm, GroupRequestModifyForm
 from ..models import (
     User, Group, Request, GROUP_JOIN_CHOICES,
@@ -139,9 +139,14 @@ class GroupView(GrouperHandler):
 
         num_pending = group.my_requests("pending").count()
 
+        alerts = []
+        self_pending = group.my_requests("pending", user=self.current_user).count()
+        if self_pending:
+            alerts.append(Alert('info', 'You have a pending request to join this group.', None))
+
         self.render(
             "group.html", group=group, members=members, groups=groups,
-            num_pending=num_pending
+            num_pending=num_pending, alerts=alerts
         )
 
 

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -470,7 +470,7 @@ class Group(Model):
 
         return groups
 
-    def my_requests(self, status=None):
+    def my_requests(self, status=None, user=None):
 
         members = self.session.query(
             label("type", literal(1)),
@@ -506,6 +506,12 @@ class Group(Model):
         if status:
             requests = requests.filter(
                 Request.status == status
+            )
+
+        if user:
+            requests = requests.filter(
+                Request.on_behalf_obj_pk == user.id,
+                Request.on_behalf_obj_type == 0
             )
 
         return requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-mrproxy==0.2.1
+mrproxy==0.3.2
 py==1.4.20
 pytest==2.5.2


### PR DESCRIPTION
When you have requested to join a group, this makes the 'Join' button
transition to a disabled 'Join Pending' button to indicate that
something is different.

This adds an ability to filter a group's open requests by a given user.
