### PR TITLE
Expose keys in users API

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -45,8 +45,8 @@ class Users(GraphHandler):
             if not username:
                 return self.success({
                     "users": [
-                        username
-                        for username in self.graph.users
+                        user
+                        for user in self.graph.users
                     ],
                 })
 
@@ -56,6 +56,7 @@ class Users(GraphHandler):
             details = self.graph.get_user_details(username, cutoff)
 
             out = {"user": {"name": username}}
+            out["user"].update(self.graph.user_metadata.get(username, {}))
             out.update(details)
             return self.success(out)
 
@@ -68,8 +69,8 @@ class Groups(GraphHandler):
             if not groupname:
                 return self.success({
                     "groups": [
-                        groupname
-                        for groupname in self.graph.groups
+                        group
+                        for group in self.graph.groups
                     ],
                 })
 

--- a/grouper/fe/handlers.py
+++ b/grouper/fe/handlers.py
@@ -505,7 +505,7 @@ class PublicKeyAdd(GrouperHandler):
         pubkey = sshpubkey.PublicKey.from_str(form.data["public_key"])
         db_pubkey = PublicKey(
             user=user,
-            public_key=pubkey.key,
+            public_key='%s %s %s' % (pubkey.key_type, pubkey.key, pubkey.comment),
             fingerprint=pubkey.fingerprint,
         )
         try:
@@ -554,7 +554,7 @@ class PublicKeyDelete(GrouperHandler):
         if not key:
             return self.notfound()
 
-        self.session.delete(key)
+        key.delete(self.session)
         self.session.commit()
 
         return self.redirect("/users/{}".format(user.name))

--- a/grouper/models.py
+++ b/grouper/models.py
@@ -52,12 +52,16 @@ class Session(_Session):
 
     _add = _Session.add
     _add_all = _Session.add_all
+    _delete = _Session.delete
 
     def add(self, *args, **kwargs):
         raise NotImplementedError("Use add method on models instead.")
 
     def add_all(self, *args, **kwargs):
         raise NotImplementedError("Use add method on models instead.")
+
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError("Use delete method on models instead.")
 
 
 Session = sessionmaker(class_=Session)
@@ -90,6 +94,10 @@ class Model(object):
 
     def add(self, session):
         session._add(self)
+        return self
+
+    def delete(self, session):
+        session._delete(self)
         return self
 
 
@@ -769,3 +777,13 @@ class PublicKey(Model):
     public_key = Column(Text, nullable=False, unique=True)
     fingerprint = Column(String(length=64), nullable=False)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    def add(self, session):
+        super(PublicKey, self).add(session)
+        Counter.incr(session, "updates")
+        return self
+
+    def delete(self, session):
+        super(PublicKey, self).delete(session)
+        Counter.incr(session, "updates")
+        return self


### PR DESCRIPTION
This exposes the list of public keys in the /users/ API method so that
we can consume that data.

This also fixes a bug where the key we stored was just the key...
without the key type or comment.
