### PR TITLE
Add permissions model, audit log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 .env
 grouper.sqlite
 

--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -9,13 +9,12 @@ import getpass
 import logging
 from mrproxy import UserProxyHandler
 from pprint import pprint
-import sys
-import yaml
-
+from sqlalchemy.exc import IntegrityError
 
 import grouper
 from grouper import models
 from grouper.capabilities import Capabilities
+from grouper.constants import SYSTEM_PERMISSIONS
 from grouper.graph import GroupGraph
 from grouper.settings import settings
 from grouper.util import get_loglevel
@@ -33,6 +32,21 @@ def make_session():
 def sync_db_command(args):
     db_engine = models.get_db_engine(settings["database"])
     models.Model.metadata.create_all(db_engine)
+
+    # Add some basic database structures we know we will need if they don't exist.
+    session = make_session()
+    for name, description in SYSTEM_PERMISSIONS:
+        test = models.Permission.get(session, name)
+        if test:
+            continue
+        permission = models.Permission(name=name, description=description)
+        try:
+            permission.add(session)
+            session.flush()
+        except IntegrityError:
+            session.rollback()
+            raise Exception('Failed to create permission: %s' % (name, ))
+        session.commit()
 
 
 def user_proxy_command(args):
@@ -108,7 +122,6 @@ def main():
                         version="%%(prog)s %s" % grouper.__version__,
                         help="Display version information.")
 
-
     subparsers = parser.add_subparsers(dest="command")
 
     sync_db_parser = subparsers.add_parser("sync_db", help="Apply database schema to database.")
@@ -139,7 +152,6 @@ def main():
     capabilities_rm_parser = capabilities_subparser.add_parser("rm", help="Remove capabilities from a user.")
     capabilities_rm_parser.add_argument("username")
     capabilities_rm_parser.add_argument("capability", choices=Capabilities.words.keys())
-
 
     args = parser.parse_args()
     settings.update_from_config(args.config)

--- a/grouper/capabilities.py
+++ b/grouper/capabilities.py
@@ -7,4 +7,5 @@ Capabilities = bittle.FlagWord([
                     # as well as set/unset capabilities on a User account.
     "group_admin",  # Allows a User to approve/deny/revoke membership to
                     # any group.
+    "permission_admin",  # Allows a User to manipulate any permission.
 ])

--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -1,3 +1,23 @@
 
+# These regexes must not include line anchors ('^', '$'). Those will be added by the
+# ValidateRegex library function and anybody else who needs them.
 USER_VALIDATION = r"(?P<username>[\-\w\.]+)"
 GROUP_VALIDATION = r"(?P<groupname>[\-\w\.]+)"
+# TODO: probably need a PERMISSION_WILDCARD which allows 'foo.*' and PERMISSION shouldn't
+PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
+ARGUMENT_VALIDATION = r"(?P<argument>|\*|(?:[a-z0-9]+[_\-\.]?)*[a-z0-9]+(?:\.\*)?)"
+
+# Permissions that are always created and are reserved.
+SYSTEM_PERMISSIONS = [
+    ('grouper.permission.create', 'Ability to create permissions within Grouper.'),
+    ('grouper.permission.grant', 'Ability to grant a permission to a group.'),
+]
+
+# A list of regular expressions that are reserved anywhere names are created. I.e., if a regex
+# in this list is matched, a permission cannot be created in the UI. Same with group names.
+# These are case insensitive.
+RESERVED_NAMES = [
+    r"^grouper",
+    r"^admin",
+    r"^test",
+]

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -1,14 +1,19 @@
 from . import handlers
-from ..constants import USER_VALIDATION, GROUP_VALIDATION
+from ..constants import USER_VALIDATION, GROUP_VALIDATION, PERMISSION_VALIDATION
+
 HANDLERS = [
-
     (r"/", handlers.Index),
-    (r"/search", handlers.Search),
-
-    (r"/users", handlers.UsersView),
-
     (r"/groups", handlers.GroupsView),
-
+    (r"/permission/{}".format(PERMISSION_VALIDATION), handlers.PermissionView),
+    (r"/permissions", handlers.PermissionsView),
+    (r"/permissions/create", handlers.PermissionsCreate),
+    (r"/permissions/grant/{}".format(GROUP_VALIDATION), handlers.PermissionsGrant),
+    (
+        r"/permissions/{}/revoke/(?P<mapping_id>[0-9+])".format(PERMISSION_VALIDATION),
+        handlers.PermissionsRevoke
+    ),
+    (r"/search", handlers.Search),
+    (r"/users", handlers.UsersView),
 ]
 
 for regex in (r"(?P<user_id>[0-9]+)", USER_VALIDATION):

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -32,6 +32,7 @@
                     <li class="{{is_active('/')}}"><a href="/">Home</a></li>
                     <li class="{{is_active('/groups')}}"><a href="/groups">Groups</a></li>
                     <li class="{{is_active('/users')}}"><a href="/users">Users</a></li>
+                    <li class="{{is_active('/permissions')}}"><a href="/permissions">Permissions</a></li>
                     <li class="{{is_active('/help')}}"><a href="/help">Help</a></li>
                 </ul>
 
@@ -55,7 +56,7 @@
                                 <div class="col-md-12">
                                     <div class="alert alert-{{alert.severity}} alert-dismissable">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                        <strong>{{alert.heading}}</strong> {{alert.message}}
+                                        <strong>{{alert.heading}}</strong> {{alert.message|e}}
                                     </div>
                                 </div>
                             </div>

--- a/grouper/fe/templates/forms/permission-grant.html
+++ b/grouper/fe/templates/forms/permission-grant.html
@@ -1,0 +1,16 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+{{ form_field(form.permission, 3, 8, class_="form-control") }}
+{{ form_field(form.argument, 3, 8, class_="form-control") }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/permission.html
+++ b/grouper/fe/templates/forms/permission.html
@@ -1,0 +1,17 @@
+{% macro form_field(field, label_width, field_width) -%}
+    <div class="form-group {% if field.errors %}has-error{% endif %}">
+        <label for="{{field.label.field_id}}"
+               class="col-sm-{{label_width}} control-label">
+            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+        </label>
+        <div class="col-sm-{{field_width}}">
+            {{ field(**kwargs) }}
+        </div>
+    </div>
+{%- endmacro %}
+
+
+{{ form_field(form.name, 3, 8, class_="form-control") }}
+{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel, member_panel %}
+{% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel %}
 
 {% block heading %}
     <a href="/groups">Groups</a>
@@ -69,6 +69,16 @@
     </div>
     <div class="col-md-5">
         {{ group_panel(400, groups) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ permission_panel(400, permissions, group=group, can_grant=current_user.my_grantable_permissions()) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ log_entry_panel(400, log_entries) }}
     </div>
 </div>
 

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -54,7 +54,7 @@
                     <span aria-hidden="true">&times;</span>
                     <span class="sr-only">Close</span>
                 </button>
-                <h4 class="modal-title">Join Group</h4>
+                <h4 class="modal-title">Create Group</h4>
            </div>
             <div class="modal-body">
                 <form id="createForm" class="form-horizontal" role="form"

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -10,4 +10,7 @@
 
 {% block content %}
 
+<h3>What is a direct permission?</h3>
+<p>write something about direct vs indirect permissions</p>
+
 {% endblock %}

--- a/grouper/fe/templates/index.html
+++ b/grouper/fe/templates/index.html
@@ -1,14 +1,10 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel %}
+{% from 'macros/ui.html' import group_panel, public_key_panel %}
 
 {% block heading %}
     Profile
 {% endblock %}
 
 {% block content %}
-<div class="row">
-    <div class="col-md-5">
-        {{ group_panel(400, groups, True) }}
-    </div>
-</div>
+This page is presently not used.
 {% endblock %}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -1,4 +1,4 @@
-{% macro public_key_panel(max_height, user, public_keys, can_control) -%}
+{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h3 class="panel-title">My Public Keys</h3>
@@ -128,6 +128,134 @@
     </div>
 {%- endmacro %}
 
+{% macro log_entry_panel(max_height, log_entries) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Recent Activity</h3>
+        </div>
+        <div style="
+            max-height: {{max_height}}px;
+            padding: 2px;
+            overflow-y: scroll;
+        ">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Date</th>
+                        <th class="col-sm-2">Actor</th>
+                        <th class="col-sm-2">Action</th>
+                        <th class="col-sm-2">Description</th>
+                        <th class="col-sm-2">Extra</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for entry in log_entries %}
+                    <tr>
+                        <td class="col-sm-2">{{ entry.log_time|print_date }}</td>
+                        <td class="col-sm-2">
+                            <a href="/users/{{ entry.actor.name }}">{{ entry.actor.name }}</a>
+                        </td>
+                        <td class="col-sm-2">{{ entry.action }}</td>
+                        <td class="col-sm-2">{{ entry.description }}</td>
+                        <td class="col-sm-2">
+                            {% if entry.on_group %}
+                                Group: <a href="/groups/{{ entry.on_group.name }}">{{ entry.on_group.name }}</a><br />
+                            {% endif %}
+                            {% if entry.on_permission %}
+                                Permission: <a href="/permission/{{ entry.on_permission.name }}">{{ entry.on_permission.name }}</a><br />
+                            {% endif %}
+                            {% if entry.on_user %}
+                                User: <a href="/users/{{ entry.on_user.name }}">{{ entry.on_user.name }}</a><br />
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                {% if not log_entries %}
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <em>No activity found.</em>
+                        </td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{%- endmacro %}
+
+{% macro permission_panel(max_height, mappings, group=None, can_grant=False, show_via=False) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">My Permissions</h3>
+        </div>
+        <div style="
+            max-height: {{max_height}}px;
+            padding: 2px;
+            overflow-y: scroll;
+        ">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Permission</th>
+                        <th class="col-sm-2">Argument</th>
+                        {% if show_via %}
+                            <th class="col-sm-2">From Group</th>
+                        {% endif %}
+                        {% if can_grant %}
+                            <th class="col-sm-2"></th>
+                        {% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                {% for map in mappings %}
+                    <tr>
+                        <td><a href="/permission/{{map.name}}">{{ map.name }}</a></td>
+                        <td class="col-sm-2">{{map.argument|default("(unargumented)", True)}}</td>
+                        {% if show_via %}
+                            <td class="col-sm-2"><a href="/groups/{{map.groupname}}">{{map.groupname}}</a></td>
+                        {% endif %}
+                        {% if can_grant %}
+                            <td class="col-sm-2">
+                                <a class="btn btn-default btn-xs" href="/permissions/{{ map.name }}/revoke/{{ map.mapping_id }}">
+                                <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span> Revoke
+                                </a>
+                            </td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                {% if show_via %}
+                    <tr>
+                        <td colspan="5" class="text-center"><strong>
+                            Only direct permissions granted from a group you are a member of are shown.
+                            Permissions indirectly granted are not shown.
+                        </strong></td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="5" class="text-center"><strong>
+                            Only permissions that this group grants are shown here.
+                        </strong></td>
+                    </tr>
+                {% endif %}
+                {% if not mappings %}
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <em>No permissions found.</em>
+                        </td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+        {% if group and can_grant %}
+        <div class='panel-footer'>
+            <a class="btn btn-default btn-sm" href="/permissions/grant/{{ group.name }}">
+            <span class="glyphicon glyphicon-plus"></span> Add Permission
+            </a>
+        </div>
+        {% endif %}
+    </div>
+{%- endmacro %}
 
 {% macro dropdown(key, current, values, allow_none=False) -%}
     <div class="btn-group">

--- a/grouper/fe/templates/permission-create.html
+++ b/grouper/fe/templates/permission-create.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/permissions">Permissions</a>
+{% endblock %}
+
+{% block subheading %}
+    Create
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Create Permission</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/permissions/create">
+                {% include "forms/permission.html" %}
+                <div class="form-permission">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permission-grant.html
+++ b/grouper/fe/templates/permission-grant.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/permissions">Permissions</a>
+{% endblock %}
+
+{% block subheading %}
+    Grant Permission to {{ group.name }}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Grant Permission to {{ group.name }}</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/permissions/grant/{{ group.name }}">
+                {% include "forms/permission-grant.html" %}
+                <div class="form-permission">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permission-revoke.html
+++ b/grouper/fe/templates/permission-revoke.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Revoke Permission
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Revoke Permission</h3>
+       </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/permissions/{{ mapping.permission.name}}/revoke/{{ mapping.id }}">
+                <div class="form-group text-center">
+                    Revoke permission <strong>{{ mapping.permission.name }}:{{ mapping.argument }}</strong>
+                    from group <a href="/groups/{{ mapping.group.name }}">{{ mapping.group.name }}</a>?
+                </div>
+                {{ xsrf_form() }}
+                <div class="form-group text-center">
+                    <button type="submit" class="btn btn-primary">Revoke Permission</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import log_entry_panel, paginator, dropdown with context %}
+
+{% block heading %}
+    Permissions
+{% endblock %}
+
+{% block subheading %}
+    {{ permission.name }}
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-10 col-md-offset-1">
+        <table class="table table-elist">
+            <thead>
+                <tr>
+                    <th class="col-sm-2">Group</th>
+                    <th class="col-sm-5">Argument</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for mapped_group in mapped_groups %}
+                <tr>
+                    <td><a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a></td>
+                    <td>{{mapped_group.argument|default("(unargumented)", True)}}</td>
+                </tr>
+            {% endfor %}
+            {% if not mapped_groups %}
+                <tr>
+                    <td colspan="2" class="text-center"><em>This permission is not mapped to any
+                    groups. To grant this permission to a group, visit the group page.</em></td>
+                </tr>
+            {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-10 col-md-offset-1">
+        {{ log_entry_panel(400, log_entries) }}
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import paginator, dropdown with context %}
+
+{% block heading %}
+    Permissions
+{% endblock %}
+
+{% block subheading %}
+    {{total}} permission(s)
+{% endblock %}
+
+{% block headingbuttons %}
+    {{ dropdown("limit", limit, [10, 25, 50]) }}
+    {{ paginator(offset, limit, total) }}
+    {% if can_create %}
+    <a class="btn btn-success" href="/permissions/create">
+        <i class="fa fa-plus"></i> Create
+    </a>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-10 col-md-offset-1">
+        <table class="table table-elist">
+            <thead>
+                <tr>
+                    <th class="col-sm-2">Name</th>
+                    <th class="col-sm-5">Description</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for permission in permissions %}
+                <tr>
+                    <td><a href="/permission/{{permission.name}}">{{permission.name}}</a></td>
+                    <td>{{permission.description|default("", True)}}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import group_panel, public_key_panel %}
+{% from 'macros/ui.html' import group_panel, public_key_panel, permission_panel, log_entry_panel %}
 
 {% block heading %}
     <a href="/users">Users</a>
@@ -29,8 +29,18 @@
     <div class="col-md-5">
         {{ group_panel(400, groups, True) }}
     </div>
-    <div class="col-md-6">
+    <div class="col-md-7">
         {{ public_key_panel(400, user, public_keys, can_control) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ permission_panel(400, permissions, show_via=True) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ log_entry_panel(400, log_entries) }}
     </div>
 </div>
 


### PR DESCRIPTION
This adds a basic permissions model and audit log to the FE. The
permissions model is not yet exposed in the API.

Also, we don't have fine-grained control over granting/creating
permissions, at the moment manipulation requires the permission_admin
capability on your user account.
