### PR TITLE
Allow dashes in usernames

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -10,7 +10,7 @@ NAME_VALIDATION = _NAME_VALIDATION.format("name")
 NAME2_VALIDATION = _NAME_VALIDATION.format("name2")
 
 # This regex is specifically to validate usernames.
-USERNAME_VALIDATION = r"(?P<name>\w+@\w+[\.\w]+)"
+USERNAME_VALIDATION = r"(?P<name>[\w-]+@\w+[\.\w]+)"
 
 # UserToken validators
 TOKEN_SECRET_VALIDATION = r"(?P<token_secret>[a-f0-9]{40})"


### PR DESCRIPTION
There wasn't a strong rationale for rejecting these originally, and
dashes are a common convention in usernames (often considered
preferrable to underscores since they don't require shifting).