### PR TITLE
Redirect to perm req info with approvers on create

### DIFF
--- a/grouper/fe/handlers/group_permission_request.py
+++ b/grouper/fe/handlers/group_permission_request.py
@@ -82,7 +82,7 @@ class GroupPermissionRequest(GrouperHandler):
 
         # save off request
         try:
-            permissions.create_request(self.session, self.current_user, group,
+            request = permissions.create_request(self.session, self.current_user, group,
                     permission, form.argument.data, form.reason.data)
         except permissions.RequestAlreadyGranted:
             alerts = [Alert("danger", "This group already has this permission and argument.")]
@@ -104,4 +104,4 @@ class GroupPermissionRequest(GrouperHandler):
                     alerts=alerts,
                     )
         else:
-            return self.redirect("/groups/{}".format(group.name))
+            return self.redirect("/permissions/requests/{}".format(request.id))

--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -56,23 +56,40 @@
 <div class="col-md-6 col-md-offset-3">
 
     {% if statuses[request.status] %}
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">Update Request</h3>
-       </div>
-        <div class="panel-body">
-            <form class="form-horizontal" role="form"
-                  method="post" action="/permissions/requests/{{request.id}}">
-                {% include "forms/permission-request-update.html" %}
-                <div class="form-group">
-                    <div class="col-sm-offset-3 col-sm-4">
-                        <button type="submit" class="btn btn-primary">Submit</button>
-                    </div>
-                </div>
+        {% if can_approve_request  %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Update Request</h3>
+               </div>
+                <div class="panel-body">
+                    <form class="form-horizontal" role="form"
+                          method="post" action="/permissions/requests/{{request.id}}">
+                        {% include "forms/permission-request-update.html" %}
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-sm-4">
+                                <button type="submit" class="btn btn-primary">Submit</button>
+                            </div>
+                        </div>
 
-            </form>
-        </div>
-    </div>
+                    </form>
+                </div>
+            </div>
+        {% else %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Waiting for approval</h3>
+               </div>
+                <div class="panel-body">
+                    This request is pending approval from one of the following groups:
+                    <ul>
+                        {% for approver in approvers %}
+                            <li><a href="/groups/{{ approver }}">{{ approver }}</a></li>
+                        {% endfor %}
+                    </ul>
+
+                </div>
+            </div>
+        {% endif %}
     {% endif %}
 
 


### PR DESCRIPTION
When creating a permission request, instead of redirecting users back to their
group page, show them the permission request status page along with an explicit
list of approvers.

We explicitly exclude global owners from this list, unless there are no other suitable groups to approve the request. 

@rra: Let me know if you feel this suffices to clear up confusion around "who can approve a permission request?" — open to other UI changes as well.

![screenshot from 2017-06-16 17-18-52](https://user-images.githubusercontent.com/73410/27237390-750e0178-52b8-11e7-93f1-14b72dd896ae.png)
