### PR TITLE
Redirect to pending after approving a perm request

### DIFF
--- a/grouper/fe/handlers/permissions_request_update.py
+++ b/grouper/fe/handlers/permissions_request_update.py
@@ -72,4 +72,4 @@ class PermissionsRequestUpdate(GrouperHandler):
                     change_comment_list=change_comment_list, statuses=REQUEST_STATUS_CHOICES,
                     alerts=alerts)
 
-        return self.redirect("/permissions/requests")
+        return self.redirect("/permissions/requests?status=pending")


### PR DESCRIPTION
Otherwise, it's inefficient to approve a bunch of requests in a row.