### PR TITLE
Send approval emails as replies for threading, message IDs, etc

### DIFF
--- a/grouper/email_util.py
+++ b/grouper/email_util.py
@@ -167,6 +167,9 @@ def get_email_from_template(recipient_list, subject, template, settings, context
     msg.attach(text)
     msg.attach(html)
 
+    if "references_header" in context:
+        msg["References"] = msg["In-Reply-To"] = context["references_header"]
+
     return msg
 
 

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -110,6 +110,7 @@ class GroupJoin(GrouperHandler):
                     "reason": form.data["reason"],
                     "expiration": expiration,
                     "role": form.data["role"],
+                    "references_header": request.reference_id,
                     }
 
             subj = self.render_template(

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -80,7 +80,7 @@ class GroupJoin(GrouperHandler):
         elif group.auto_expire:
             expiration = datetime.utcnow() + group.auto_expire
 
-        request_id = group.add_member(
+        request = group.add_member(
             requester=self.current_user,
             user_or_group=member,
             reason=form.data["reason"],
@@ -105,7 +105,7 @@ class GroupJoin(GrouperHandler):
             email_context = {
                     "requester": member.name,
                     "requested_by": self.current_user.name,
-                    "request_id": request_id,
+                    "request_id": request.id,
                     "group_name": group.name,
                     "reason": form.data["reason"],
                     "expiration": expiration,

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -108,11 +108,16 @@ class GroupRequestUpdate(GrouperHandler):
             if user.name != self.current_user.name and user.name != request.requester.username
         ]
 
+        subj = "Re: " + self.render_template(
+            'email/pending_request_subj.tmpl',
+            group=group.name,
+            user=self.current_user.name
+        )
+
         send_email(
             self.session,
             approver_mail_to,
-            "Request to join {} by {} has been {}".format(group.groupname,
-                request.requester.name, form.data['status']),
+            subj,
             "approver_request_updated",
             settings,
             {

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -127,6 +127,7 @@ class GroupRequestUpdate(GrouperHandler):
                 'status': form.data['status'],
                 'role': edge.role,
                 'reason': form.data['reason'],
+                'references_header': request.reference_id,
             },
         )
 

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -28,6 +28,7 @@ from grouper.models.counter import Counter
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
+from grouper.util import reference_id
 from .constants import ILLEGAL_NAME_CHARACTER, MAX_NAME_LENGTH
 from .email_util import send_async_email
 from .settings import settings
@@ -682,6 +683,11 @@ class Request(Model, CommentObjectMixin):
     )
 
     changes = Column(Text, nullable=False)
+
+    @property
+    def reference_id(self):
+        # type: () -> str
+        return reference_id(settings, "group", self)
 
     def get_on_behalf(self):
         obj_type = OBJ_TYPES_IDX[self.on_behalf_obj_type]

--- a/grouper/model_soup.py
+++ b/grouper/model_soup.py
@@ -314,7 +314,7 @@ class Group(Model, CommentObjectMixin):
 
         Counter.incr(self.session, "updates")
 
-        return request.id
+        return request
 
     def my_permissions(self):
 

--- a/grouper/models/permission_request.py
+++ b/grouper/models/permission_request.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import relationship
 
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.base.model_base import Model
+from grouper.settings import settings
+from grouper.util import reference_id
 
 
 class PermissionRequest(Model):
@@ -29,3 +31,8 @@ class PermissionRequest(Model):
     requested_at = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     status = Column(Enum(*REQUEST_STATUS_CHOICES), default="pending", nullable=False)
+
+    @property
+    def reference_id(self):
+        # type: () -> str
+        return reference_id(settings, "permission", self)

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -642,11 +642,15 @@ def update_request(session, request, user, new_status, comment):
     session.commit()
 
     # send notification
+
+    subj_template = 'email/pending_permission_request_subj.tmpl'
+    subject = "Re: " + get_template_env().get_template(subj_template).render(
+        permission=request.permission.name, group=request.group.name
+    )
+
     if new_status == "actioned":
-        subject = "Request for Permission Actioned"
         email_template = "permission_request_actioned"
     else:
-        subject = "Request for Permission Cancelled"
         email_template = "permission_request_cancelled"
 
     email_context = {

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -433,6 +433,7 @@ def create_request(session, user, group, permission, argument, reason):
             "argument": argument,
             "reason": reason,
             "request_id": request.id,
+            "references_header": request.reference_id,
             }
 
     # TODO: would be nicer if it told you which group you're an approver of

--- a/grouper/util.py
+++ b/grouper/util.py
@@ -95,3 +95,19 @@ def singleton(f):
                     initialized[0] = True
         return value[0]
     return wrapped
+
+
+def reference_id(settings, request_type, request):
+    """Generates the 'References' for a request"""
+    # type: (dict, str, Any) -> str
+    try:
+        domain = settings['service_account_email_domain']
+    except KeyError:
+        domain = "grouper.local"
+    return "{type}.{id}.{ts}@{prefix}.{domain}".format(
+        type=request_type,
+        id=request.id,
+        ts=request.requested_at,
+        prefix="grouper-internal",
+        domain=domain,
+    )


### PR DESCRIPTION
Makes it a bit easier to manage all the spam from an active organisation.