### PR TITLE
Use the same subject for group join and approvals

### DIFF
--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -111,7 +111,7 @@ class GroupRequestUpdate(GrouperHandler):
         subj = "Re: " + self.render_template(
             'email/pending_request_subj.tmpl',
             group=group.name,
-            user=self.current_user.name
+            user=request.requester.username
         )
 
         send_email(


### PR DESCRIPTION
Previously, we would incorrectly use the approver's email as the requestor for
the purpose of generating the approval email subject.