### PR TITLE
clearer error message when attempt is made to give a non-auditor user

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -103,10 +103,8 @@ def assert_can_join(group, user_or_group, role="member"):
         if user_is_auditor(user_or_group.name):
             return True
         raise UserNotAuditor(
-            "Group `{group}` is an audited group, so user `{user}`, who is not an auditor, "
-            "i.e., lacks `grouper.permission.auditor` permission, may only have 'member' "
-            "role. To become an auditor, obtain the auditor permission, e.g., join the "
-            "group `grouper-auditors`.".format(group=group.name, user=user_or_group.name))
+            "User {} lacks auditing permission, so may only have the member role.".format(
+                user_or_group.name))
 
     # No, this is a group-joining-group case. In this situation we must walk the entire group
     # subtree and ensure that all owners/np-owners/managers are considered auditors. This data

--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -58,8 +58,9 @@ def assert_controllers_are_auditors(group):
                     checked.add(chk_user)
                 else:
                     raise UserNotAuditor(
-                        "User {} has role {} of the {} group, but is not an auditor.".format(
-                            chk_user, info["rolename"], cur_group))
+                        "User {} has role '{}' in the group {} but lacks the auditing "
+                        "permission ('{}').".format(
+                            chk_user, info["rolename"], cur_group, PERMISSION_AUDITOR))
         # Now put subgroups into the queue to examine.
         for chk_group, info in details["subgroups"].iteritems():
             if info["distance"] == 1:
@@ -103,9 +104,9 @@ def assert_can_join(group, user_or_group, role="member"):
         if user_is_auditor(user_or_group.name):
             return True
         raise UserNotAuditor(
-            settings.audited_group_role_change_denied_message or \
-            "The user lacks auditing permission, so may only have the "
-            "\"member\" role in this audited group.")
+            "User {} lacks the auditing permission ('{}') so may only have the "
+            "'member' role in this audited group.".format(
+                user_or_group.name, PERMISSION_AUDITOR))
 
     # No, this is a group-joining-group case. In this situation we must walk the entire group
     # subtree and ensure that all owners/np-owners/managers are considered auditors. This data

--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -103,8 +103,10 @@ def assert_can_join(group, user_or_group, role="member"):
         if user_is_auditor(user_or_group.name):
             return True
         raise UserNotAuditor(
-            "User {} lacks auditing permission, so may only have the member role.".format(
-                user_or_group.name))
+            "Group `{group}` is an audited group, so user `{user}`, who is not an auditor, "
+            "i.e., lacks `grouper.permission.auditor` permission, may only have 'member' "
+            "role. To become an auditor, obtain the auditor permission, e.g., join the "
+            "group `grouper-auditors`.".format(group=group.name, user=user_or_group.name))
 
     # No, this is a group-joining-group case. In this situation we must walk the entire group
     # subtree and ensure that all owners/np-owners/managers are considered auditors. This data

--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -103,8 +103,9 @@ def assert_can_join(group, user_or_group, role="member"):
         if user_is_auditor(user_or_group.name):
             return True
         raise UserNotAuditor(
-            "User {} lacks auditing permission, so may only have the member role.".format(
-                user_or_group.name))
+            settings.audited_group_role_change_denied_message or \
+            "The user lacks auditing permission, so may only have the "
+            "\"member\" role in this audited group.")
 
     # No, this is a group-joining-group case. In this situation we must walk the entire group
     # subtree and ensure that all owners/np-owners/managers are considered auditors. This data

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -90,10 +90,6 @@ def default_settings_path():
     return os.environ.get("GROUPER_SETTINGS", "/etc/grouper.yaml")
 
 settings = Settings({
-    # optional custom message when rejecting an attempt to give a
-    # non-auditor user a non-member role in an audited group
-    "audited_group_role_change_denied_message": None,
-
     "database": None,
     "database_source": None,
     "expiration_notice_days": 7,

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -90,6 +90,10 @@ def default_settings_path():
     return os.environ.get("GROUPER_SETTINGS", "/etc/grouper.yaml")
 
 settings = Settings({
+    # optional custom message when rejecting an attempt to give a
+    # non-auditor user a non-member role in an audited group
+    "audited_group_role_change_denied_message": None,
+
     "database": None,
     "database_source": None,
     "expiration_notice_days": 7,


### PR DESCRIPTION
a non-member role of an audited group