### PR TITLE
Change shebangs to use python2

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 from contextlib import closing

--- a/bin/grouper-ctl
+++ b/bin/grouper-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """ Command-line interface to various grouper administrative commands."""
 

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 from contextlib import closing

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import setuptools  # noqa

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import optparse
 import subprocess


### PR DESCRIPTION
Currently, the codebase only supports Python 2. Some installations now
have the default python binary point to the Python 3 binary, which
breaks Merou. This changes the shebangs on executable files to
explicitly use the python2 binary to better handle changing defaults.

Signed-off-by: Tyler O'Meara <tomeara@quora.com>