### PR TITLE
Fix py2 syntax errors in bin/grouper-fe

### DIFF
--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -76,8 +76,9 @@ def main(args, sentry_client):
     address = args.address or settings.address
     port = args.port or settings.port
 
-    ssl_contexts = list(filter(bool, p.get_ssl_context() for p in get_plugins()))
+    ssl_contexts = list(filter(bool, (p.get_ssl_context() for p in get_plugins())))
     assert len(ssl_contexts) <=1, "Plugins returned more than one ssl.SSLContext!"
+    ssl_context = ssl_contexts[0] if ssl_contexts else None
 
     logging.info(
         "Starting application server with %d processes on port %d",
@@ -85,7 +86,7 @@ def main(args, sentry_client):
     )
     server = tornado.httpserver.HTTPServer(
             application,
-            ssl_options=next(ssl_contexts, None)
+            ssl_options=ssl_context
     )
     server.bind(port, address=address)
     server.start(settings.num_processes)


### PR DESCRIPTION
Having a generator expression as an argument to a function when there
are no other arguments is a syntax error in Python 2. Additionally, we
were calling next() on a list object, which raises an exception as lists
are not iterators in Python 2.

Signed-off-by: Tyler O'Meara <tomeara@quora.com>