### PR TITLE
Create graph and update threads after worker forking

### DIFF
--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -63,16 +63,6 @@ def main(args, sentry_client):
 
     application = get_application(Session, settings, sentry_client, args.deployment_name)
 
-    settings.start_config_thread(args.config, "fe")
-
-    with closing(Session()) as session:
-        graph = Graph()
-        graph.update_from_db(session)
-
-    refresher = DbRefreshThread(settings, graph, settings.refresh_interval, sentry_client)
-    refresher.daemon = True
-    refresher.start()
-
     address = args.address or settings.address
     port = args.port or settings.port
 
@@ -88,7 +78,22 @@ def main(args, sentry_client):
             ssl_options=next(ssl_contexts, None)
     )
     server.bind(port, address=address)
+    # When using multiple processes, the forking happens here
     server.start(settings.num_processes)
+
+    # Create the Graph and start the config / graph update threads post fork to ensure each
+    # process gets updated.
+
+    settings.start_config_thread(args.config, "fe")
+
+    with closing(Session()) as session:
+        graph = Graph()
+        graph.update_from_db(session)
+
+    refresher = DbRefreshThread(settings, graph, settings.refresh_interval, sentry_client)
+    refresher.daemon = True
+    refresher.start()
+
     try:
         tornado.ioloop.IOLoop.instance().start()
     except KeyboardInterrupt:


### PR DESCRIPTION
Previously, the Graph object, the config update thread, and the graph
update thread were being created before forking out the HTTP worker
processes. This resulted in the Graph getting updated in the main
process but not any of the worker processes; so the worker processes
were serving stale data.

This commit changes it so that the Graph object and both update threads
are created after forking; so there is an independent set of these for
each worker process. This approach was taken instead of having shared
memory between the processes as it makes for a substantially simpler
implementation, and the duplicate memory impact is relatively small.

Signed-off-by: Tyler O'Meara <tomeara@quora.com>