### PR TITLE
Rename internal service account APIs to role user

### DIFF
--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -5,7 +5,7 @@ from grouper.ctl.util import ensure_valid_username, make_session
 from grouper.models.audit_log import AuditLog
 from grouper.models.user_token import UserToken  # noqa: HAX(herb) workaround user -> user_token dep
 from grouper.models.user import User
-from grouper.service_account import disable_service_account, enable_service_account
+from grouper.role_user import disable_role_user, enable_role_user
 from grouper.user import disable_user, enable_user, get_all_users
 from grouper.user_metadata import set_user_metadata
 
@@ -48,7 +48,7 @@ def user_command(args):
             else:
                 logging.info("{}: User found, disabling...".format(username))
                 if user.role_user:
-                    disable_service_account(session, user)
+                    disable_role_user(session, user)
                 else:
                     disable_user(session, user)
                 AuditLog.log(session, user.id, 'disable_user',
@@ -67,7 +67,7 @@ def user_command(args):
             else:
                 logging.info("{}: User found, enabling...".format(username))
                 if user.role_user:
-                    enable_service_account(session, user,
+                    enable_role_user(session, user,
                         preserve_membership=args.preserve_membership, user=user)
                 else:
                     enable_user(session, user, user, preserve_membership=args.preserve_membership)

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -339,7 +339,7 @@ class UserPasswordForm(Form):
     ])
 
 
-class ServiceAccountCreateForm(Form):
+class RoleUserCreateForm(Form):
     name = StringField("Name", [
         validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
         validators.DataRequired(),

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -9,7 +9,7 @@ from grouper.fe.util import Alert, GrouperHandler
 from grouper.group import get_all_groups
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group, InvalidRoleForMember
-from grouper.service_account import get_service_account, is_service_account
+from grouper.role_user import get_role_user, is_role_user
 from grouper.user import get_all_enabled_users, get_user_or_group, user_role
 from grouper.user_group import user_can_manage_group
 
@@ -80,9 +80,9 @@ class GroupAdd(GrouperHandler):
             )
 
         member = get_user_or_group(self.session, form.data["member"])
-        if member.type == "User" and is_service_account(self.session, member):
+        if member.type == "User" and is_role_user(self.session, member):
             # For service accounts, we want to always add the group to other groups, not the user
-            member = get_service_account(self.session, user=member).group
+            member = get_role_user(self.session, user=member).group
         if not member:
             form.member.errors.append("User or group not found.")
         elif (member.type, member.name) in group.my_members():

--- a/grouper/fe/handlers/group_disable.py
+++ b/grouper/fe/handlers/group_disable.py
@@ -1,7 +1,7 @@
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.service_account import is_service_account
+from grouper.role_user import is_role_user
 from grouper.user import user_role
 
 
@@ -18,7 +18,7 @@ class GroupDisable(GrouperHandler):
         # Enabling and disabling service accounts via the group endpoints is forbidden
         # because we need the preserve_membership data that is only available via the
         # UserEnable form.
-        if is_service_account(self.session, group=group):
+        if is_role_user(self.session, group=group):
             return self.forbidden()
 
         group.disable()

--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -5,7 +5,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
 from grouper.models.group import Group
-from grouper.service_account import is_service_account
+from grouper.role_user import is_role_user
 from grouper.user_group import user_can_manage_group
 
 
@@ -38,7 +38,7 @@ class GroupEdit(GrouperHandler):
             )
 
         if (group.groupname != form.data["groupname"] and
-                is_service_account(self.session, group=group)):
+                is_role_user(self.session, group=group)):
             form.groupname.errors.append("You cannot change the name of service account groups")
             return self.render(
                 "group-edit.html", group=group, form=form,

--- a/grouper/fe/handlers/group_enable.py
+++ b/grouper/fe/handlers/group_enable.py
@@ -1,7 +1,7 @@
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.service_account import is_service_account
+from grouper.role_user import is_role_user
 from grouper.user import user_role
 
 
@@ -18,7 +18,7 @@ class GroupEnable(GrouperHandler):
         # Enabling and disabling service accounts via the group endpoints is forbidden
         # because we need the preserve_membership data that is only available via the
         # UserEnable form.
-        if is_service_account(self.session, group=group):
+        if is_role_user(self.session, group=group):
             return self.forbidden()
 
         group.enable()

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -2,7 +2,7 @@ from grouper.fe.forms import GroupRemoveForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.service_account import get_service_account, is_service_account
+from grouper.role_user import get_role_user, is_role_user
 from grouper.user import get_user_or_group
 from grouper.user_group import user_can_manage_group
 
@@ -34,8 +34,8 @@ class GroupRemove(GrouperHandler):
                 reason="Can't remove yourself. Leave group instead."
             )
 
-        if (is_service_account(self.session, group=group) and
-                get_service_account(self.session, group=group).user.name == removed_member.name):
+        if (is_role_user(self.session, group=group) and
+                get_role_user(self.session, group=group).user.name == removed_member.name):
             return self.send_error(
                 status_code=400,
                 reason="Can't remove a service account user from the service account group."

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,7 +1,7 @@
 from grouper.fe.handlers.template_variables import get_group_view_template_vars
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
-from grouper.service_account import is_service_account
+from grouper.role_user import is_role_user
 
 
 class GroupView(GrouperHandler):
@@ -12,7 +12,7 @@ class GroupView(GrouperHandler):
         if not group:
             return self.notfound()
 
-        if is_service_account(self.session, group=group):
+        if is_role_user(self.session, group=group):
             return self.redirect("/service/{}".format(group.groupname))
 
         self.render(

--- a/grouper/fe/handlers/public_key_add.py
+++ b/grouper/fe/handlers/public_key_add.py
@@ -5,7 +5,7 @@ from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 
 
 class PublicKeyAdd(GrouperHandler):
@@ -13,7 +13,7 @@ class PublicKeyAdd(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -4,7 +4,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.user import User
 from grouper.public_key import add_tag_to_public_key, DuplicateTag, get_public_key, KeyNotFound
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -13,7 +13,7 @@ class PublicKeyAddTag(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None, key_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_delete.py
+++ b/grouper/fe/handlers/public_key_delete.py
@@ -4,7 +4,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.public_key import delete_public_key, get_public_key, KeyNotFound
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -13,7 +13,7 @@ class PublicKeyDelete(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None, key_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_remove_tag.py
+++ b/grouper/fe/handlers/public_key_remove_tag.py
@@ -3,7 +3,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.user import User
 from grouper.public_key import get_public_key, KeyNotFound, remove_tag_from_public_key, TagNotOnKey
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -12,7 +12,7 @@ class PublicKeyRemoveTag(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def post(self, user_id=None, name=None, key_id=None, tag_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/role_user_create.py
+++ b/grouper/fe/handlers/role_user_create.py
@@ -1,14 +1,14 @@
 from sqlalchemy.exc import IntegrityError
 
-from grouper.fe.forms import ServiceAccountCreateForm
+from grouper.fe.forms import RoleUserCreateForm
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
-from grouper.service_account import create_service_account
+from grouper.role_user import create_role_user
 
 
-class ServiceAccountCreate(GrouperHandler):
+class RoleUserCreate(GrouperHandler):
     def get(self):
-        form = ServiceAccountCreateForm()
+        form = RoleUserCreateForm()
         return self.render(
             "service-account-create.html", form=form,
         )
@@ -17,7 +17,7 @@ class ServiceAccountCreate(GrouperHandler):
         if "@" not in self.request.arguments["name"][0]:
             self.request.arguments["name"][0] += "@" + settings.service_account_email_domain
 
-        form = ServiceAccountCreateForm(self.request.arguments)
+        form = RoleUserCreateForm(self.request.arguments)
 
         if not form.validate():
             return self.render(
@@ -34,7 +34,7 @@ class ServiceAccountCreate(GrouperHandler):
             )
 
         try:
-            create_service_account(self.session, self.current_user, form.data["name"],
+            create_role_user(self.session, self.current_user, form.data["name"],
                 form.data["description"], form.data["canjoin"])
         except IntegrityError:
             self.session.rollback()

--- a/grouper/fe/handlers/role_user_view.py
+++ b/grouper/fe/handlers/role_user_view.py
@@ -1,10 +1,10 @@
-from grouper.fe.handlers.template_variables import get_service_account_view_template_vars
+from grouper.fe.handlers.template_variables import get_role_user_view_template_vars
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
 from grouper.models.user import User
 
 
-class ServiceAccountView(GrouperHandler):
+class RoleUserView(GrouperHandler):
 
     def get(self, user_id=None, name=None):
         self.handle_refresh()
@@ -20,5 +20,5 @@ class ServiceAccountView(GrouperHandler):
         self.render("service.html",
                     user=user,
                     group=group,
-                    **get_service_account_view_template_vars(session, actor, user, group, graph)
+                    **get_role_user_view_template_vars(session, actor, user, group, graph)
                     )

--- a/grouper/fe/handlers/role_users_view.py
+++ b/grouper/fe/handlers/role_users_view.py
@@ -1,6 +1,6 @@
 from grouper.fe.util import GrouperHandler
 
 
-class ServiceAccountsView(GrouperHandler):
+class RoleUsersView(GrouperHandler):
     def get(self):
         self.redirect("/users?service=1")

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -9,7 +9,7 @@ from grouper.permissions import (get_owner_arg_list, get_pending_request_by_grou
     get_requests_by_owner)
 from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
     get_public_keys_of_user)
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user import (get_log_entries_by_user, user_open_audits, user_requests_aggregate,
     user_role, user_role_index)
 from grouper.user_group import get_groups_by_user
@@ -115,10 +115,10 @@ def get_user_view_template_vars(session, actor, user, graph):
     return ret
 
 
-def get_service_account_view_template_vars(session, actor, user, group, graph):
+def get_role_user_view_template_vars(session, actor, user, group, graph):
     ret = get_user_view_template_vars(session, actor, user, graph)
     ret.update(get_group_view_template_vars(session, actor, group, graph))
-    ret["can_control"] = can_manage_service_account(session, user=actor, tuser=user)
+    ret["can_control"] = can_manage_role_user(session, user=actor, tuser=user)
     ret["log_entries"] = sorted(set(get_log_entries_by_user(session, user) +
         group.my_log_entries()), key=lambda x: x.log_time, reverse=True)
     return ret

--- a/grouper/fe/handlers/user_disable.py
+++ b/grouper/fe/handlers/user_disable.py
@@ -2,7 +2,7 @@ from grouper.constants import USER_ADMIN, USER_DISABLE
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
-from grouper.service_account import disable_service_account, is_owner_of_service_account
+from grouper.role_user import disable_role_user, is_owner_of_role_user
 from grouper.user import disable_user
 from grouper.user_permissions import user_has_permission
 
@@ -13,7 +13,7 @@ class UserDisable(GrouperHandler):
         return (
             user_has_permission(session, actor, USER_ADMIN) or
             user_has_permission(session, actor, USER_DISABLE, argument=target.name) or
-            (target.role_user and is_owner_of_service_account(session, actor, tuser=target))
+            (target.role_user and is_owner_of_role_user(session, actor, tuser=target))
         )
 
     def post(self, user_id=None, name=None):
@@ -26,7 +26,7 @@ class UserDisable(GrouperHandler):
             return self.forbidden()
 
         if user.role_user:
-            disable_service_account(self.session, user=user)
+            disable_role_user(self.session, user=user)
         else:
             disable_user(self.session, user)
 

--- a/grouper/fe/handlers/user_enable.py
+++ b/grouper/fe/handlers/user_enable.py
@@ -3,7 +3,7 @@ from grouper.fe.forms import UserEnableForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
-from grouper.service_account import enable_service_account, is_owner_of_service_account
+from grouper.role_user import enable_role_user, is_owner_of_role_user
 from grouper.user import enable_user
 from grouper.user_permissions import user_has_permission
 
@@ -14,7 +14,7 @@ class UserEnable(GrouperHandler):
         return (
             user_has_permission(session, actor, USER_ADMIN) or
             user_has_permission(session, actor, USER_ENABLE, argument=target.name) or
-            (target.role_user and is_owner_of_service_account(session, actor, tuser=target))
+            (target.role_user and is_owner_of_role_user(session, actor, tuser=target))
         )
 
     def post(self, user_id=None, name=None):
@@ -31,7 +31,7 @@ class UserEnable(GrouperHandler):
             return self.redirect("/users/{}?refresh=yes".format(user.name))
 
         if user.role_user:
-            enable_service_account(self.session, actor=self.current_user,
+            enable_role_user(self.session, actor=self.current_user,
                 preserve_membership=form.preserve_membership.data, user=user)
         else:
             enable_user(self.session, user, self.current_user,

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -4,7 +4,7 @@ from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_password import add_new_user_password, PasswordAlreadyExists
 
 
@@ -13,7 +13,7 @@ class UserPasswordAdd(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return actor.name == target.name or (target.role_user and
-            can_manage_service_account(session, actor, tuser=target))
+            can_manage_role_user(session, actor, tuser=target))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_password_delete.py
+++ b/grouper/fe/handlers/user_password_delete.py
@@ -2,7 +2,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_password import UserPassword
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_password import delete_user_password, PasswordDoesNotExist
 from grouper.user_permissions import user_is_user_admin
 
@@ -12,7 +12,7 @@ class UserPasswordDelete(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None, pass_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_shell.py
+++ b/grouper/fe/handlers/user_shell.py
@@ -4,7 +4,7 @@ from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 
 
 class UserShell(GrouperHandler):
@@ -12,7 +12,7 @@ class UserShell(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -7,7 +7,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_token import add_new_user_token
 
 
@@ -16,7 +16,7 @@ class UserTokenAdd(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return actor.name == target.name or (target.role_user and
-            can_manage_service_account(session, actor, tuser=target))
+            can_manage_role_user(session, actor, tuser=target))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_token_disable.py
+++ b/grouper/fe/handlers/user_token_disable.py
@@ -2,7 +2,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
-from grouper.service_account import can_manage_service_account
+from grouper.role_user import can_manage_role_user
 from grouper.user_permissions import user_is_user_admin
 from grouper.user_token import disable_user_token
 
@@ -12,7 +12,7 @@ class UserTokenDisable(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_service_account(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
 
     def get(self, user_id=None, name=None, token_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -40,10 +40,10 @@ from grouper.fe.handlers.public_key_add import PublicKeyAdd
 from grouper.fe.handlers.public_key_add_tag import PublicKeyAddTag
 from grouper.fe.handlers.public_key_delete import PublicKeyDelete
 from grouper.fe.handlers.public_key_remove_tag import PublicKeyRemoveTag
+from grouper.fe.handlers.role_user_create import RoleUserCreate
+from grouper.fe.handlers.role_user_view import RoleUserView
+from grouper.fe.handlers.role_users_view import RoleUsersView
 from grouper.fe.handlers.search import Search
-from grouper.fe.handlers.service_account_create import ServiceAccountCreate
-from grouper.fe.handlers.service_account_view import ServiceAccountView
-from grouper.fe.handlers.service_accounts_view import ServiceAccountsView
 from grouper.fe.handlers.tag_edit import TagEdit
 from grouper.fe.handlers.tag_view import TagView
 from grouper.fe.handlers.tags_view import TagsView
@@ -83,10 +83,10 @@ HANDLERS = [
     ),
     (r"/search", Search),
     (r"/users", UsersView),
-    (r"/service", ServiceAccountsView),
+    (r"/service", RoleUsersView),
     (r"/users/public-keys", UsersPublicKey),
     (r"/users/tokens", UsersUserTokens),
-    (r"/service/create", ServiceAccountCreate),
+    (r"/service/create", RoleUserCreate),
     (r"/user/requests", UserRequests),
 ]
 
@@ -113,7 +113,7 @@ for regex in (r"(?P<user_id>[0-9]+)", USERNAME_VALIDATION):
         (r"/users/{}/tokens/(?P<token_id>[0-9]+)/disable".format(regex), UserTokenDisable),
         (r"/users/{}/passwords/add".format(regex), UserPasswordAdd),
         (r"/users/{}/passwords/(?P<pass_id>[0-9]+)/delete".format(regex), UserPasswordDelete),
-        (r"/service/{}".format(regex), ServiceAccountView),
+        (r"/service/{}".format(regex), RoleUserView),
     ])
 
 for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -18,7 +18,7 @@ from grouper.models.user import User
 from grouper.models.user_metadata import UserMetadata
 from grouper.models.user_password import UserPassword
 from grouper.public_key import get_all_public_key_tags
-from grouper.service_account import is_service_account
+from grouper.role_user import is_role_user
 from grouper.util import singleton
 
 MEMBER_TYPE_MAP = {
@@ -279,7 +279,7 @@ class GroupGraph(object):
                 description=group.description,
                 canjoin=group.canjoin,
                 enabled=group.enabled,
-                service_account=is_service_account(session, group=group),
+                service_account=is_role_user(session, group=group),
                 type="Group"
             )
         return out

--- a/tests/test_fe_handlers.py
+++ b/tests/test_fe_handlers.py
@@ -13,8 +13,8 @@ from grouper.models.group_edge import GroupEdge
 from grouper.models.request import Request
 from grouper.models.user import User
 from grouper.public_key import get_public_keys_of_user
-from grouper.service_account import (disable_service_account, enable_service_account,
-    get_service_account, is_service_account)
+from grouper.role_user import (disable_role_user, enable_role_user,
+    get_role_user, is_role_user)
 from url_util import url
 
 
@@ -134,12 +134,12 @@ def test_sa_pubkeys(session, users, http_client, base_url):
 
     assert u is not None
     assert g is not None
-    assert is_service_account(session, user=u)
-    assert is_service_account(session, group=g)
-    assert get_service_account(session, user=u).group.id == g.id
-    assert get_service_account(session, group=g).user.id == u.id
-    assert not is_service_account(session, user=user)
-    assert not is_service_account(session, group=Group.get(session, name="team-sre"))
+    assert is_role_user(session, user=u)
+    assert is_role_user(session, group=g)
+    assert get_role_user(session, user=u).group.id == g.id
+    assert get_role_user(session, group=g).user.id == u.id
+    assert not is_role_user(session, user=user)
+    assert not is_role_user(session, group=Group.get(session, name="team-sre"))
 
     assert not get_public_keys_of_user(session, user.id)
 
@@ -269,12 +269,12 @@ def test_sa_tokens(session, users, http_client, base_url):
 
     assert u is not None
     assert g is not None
-    assert is_service_account(session, user=u)
-    assert is_service_account(session, group=g)
-    assert get_service_account(session, user=u).group.id == g.id
-    assert get_service_account(session, group=g).user.id == u.id
-    assert not is_service_account(session, user=user)
-    assert not is_service_account(session, group=Group.get(session, name="team-sre"))
+    assert is_role_user(session, user=u)
+    assert is_role_user(session, group=g)
+    assert get_role_user(session, user=u).group.id == g.id
+    assert get_role_user(session, group=g).user.id == u.id
+    assert not is_role_user(session, user=user)
+    assert not is_role_user(session, group=Group.get(session, name="team-sre"))
 
     with pytest.raises(HTTPError):
         # Add token
@@ -554,7 +554,7 @@ def test_request_autoexpiration(graph, groups, permissions, session, standard_gr
 
 
 @pytest.mark.gen_test
-def test_add_service_account(session, users, http_client, base_url):
+def test_add_role_user(session, users, http_client, base_url):
     user = users['zorkian@a.co']
 
     # Add account
@@ -579,16 +579,16 @@ def test_add_service_account(session, users, http_client, base_url):
 
     assert u is not None
     assert g is not None
-    assert is_service_account(session, user=u)
-    assert is_service_account(session, group=g)
-    assert get_service_account(session, user=u).group.id == g.id
-    assert get_service_account(session, group=g).user.id == u.id
-    assert not is_service_account(session, user=user)
-    assert not is_service_account(session, group=Group.get(session, name="team-sre"))
+    assert is_role_user(session, user=u)
+    assert is_role_user(session, group=g)
+    assert get_role_user(session, user=u).group.id == g.id
+    assert get_role_user(session, group=g).user.id == u.id
+    assert not is_role_user(session, user=user)
+    assert not is_role_user(session, group=Group.get(session, name="team-sre"))
 
 
 @pytest.mark.gen_test
-def test_disable_service_account(session, users, http_client, base_url):
+def test_disable_role_user(session, users, http_client, base_url):
     user = users['zorkian@a.co']
 
     # Add account
@@ -613,20 +613,20 @@ def test_disable_service_account(session, users, http_client, base_url):
 
     assert u is not None
     assert g is not None
-    assert is_service_account(session, user=u)
-    assert is_service_account(session, group=g)
-    assert get_service_account(session, user=u).group.id == g.id
-    assert get_service_account(session, group=g).user.id == u.id
-    assert not is_service_account(session, user=user)
-    assert not is_service_account(session, group=Group.get(session, name="team-sre"))
+    assert is_role_user(session, user=u)
+    assert is_role_user(session, group=g)
+    assert get_role_user(session, user=u).group.id == g.id
+    assert get_role_user(session, group=g).user.id == u.id
+    assert not is_role_user(session, user=user)
+    assert not is_role_user(session, group=Group.get(session, name="team-sre"))
 
-    disable_service_account(session, user=u)
+    disable_role_user(session, user=u)
     u = User.get(session, name="bob@svc.localhost")
     assert not u.enabled, "The SA User should be disabled"
     g = Group.get(session, name="bob@svc.localhost")
     assert not g.enabled, "The SA Group should be disabled"
 
-    enable_service_account(session, actor=user, group=g, preserve_membership=True)
+    enable_role_user(session, actor=user, group=g, preserve_membership=True)
     u = User.get(session, name="bob@svc.localhost")
     assert u.enabled, "The SA User should be enabled"
     g = Group.get(session, name="bob@svc.localhost")


### PR DESCRIPTION
Role user was the old name that was still used in places internally.
Rename all internal APIs to use `RoleName` or `role_name`.  This frees
up the `ServiceAccount` and `service_account` namespace for the new
implementation.

Do not change the API endpoints and the flags they use to specify
whether to include service accounts or not, since those will continue
working as they currently do with both old role users and new service
accounts.