### PR TITLE
Add Multi Users API Endpoint

### DIFF
--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -1,5 +1,6 @@
 from grouper.api.handlers import (
         Groups,
+        MultiUsers,
         NotFound,
         Permissions,
         ServiceAccounts,
@@ -16,7 +17,6 @@ HANDLERS = [
     (r"/users/{}".format(NAME_VALIDATION), Users),
     (r"/token/validate".format(NAME_VALIDATION), TokenValidate),
 
-
     (r"/public-keys", UsersPublicKeys),
 
     (r"/groups", Groups),
@@ -27,6 +27,8 @@ HANDLERS = [
 
     (r"/service_accounts", ServiceAccounts),
     (r"/service_accounts/{}".format(NAME_VALIDATION), ServiceAccounts),
+
+    (r"/multi/users", MultiUsers),
 
     (DEBUG_ROUTE_PATH, Stats),
 


### PR DESCRIPTION
This adds an endpoint to the API servers that allows clients to request
(and receive) information about multiple users in a single request. This
allows clients that need detailed information about multiple users to
batch their requests into a single request for improved efficiency.

Preliminary testing using 100 Python processes to saturate the server
with requests shows that this endpoint is substantially more efficient,
providing detailed data on 40x as many users per second as the
traditional user endpoint.

This endpoint also supports Service Accounts in the same endpoint. This
decision was made to allow requests for data among Service Accounts and
Users to be batched together, and because Service Accounts return the
exact same data as Users.

Signed-off-by: Tyler O'Meara <tomeara@quora.com>