### PR TITLE
Add support for SMTP servers that require logins

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -39,6 +39,21 @@ common:
     # Type: str
     smtp_server: "localhost"
 
+    # Whether to connect to the SMTP server using TLS
+    # Type: bool
+    smtp_use_ssl: false
+
+    # Username to use for logging in to the SMTP server
+    # You should probably not use this unless smtp_use_ssl is true
+    # Leave blank if you want to not authenticate to the SMTP server
+    # Type: str
+    smtp_username: ""
+
+    # Password to use for logging in to the SMTP server
+    # You should probably not use this unless smtp_use_ssl is true
+    # Type: str
+    smtp_password: ""
+
     # Address to send email from
     # Type: str
     from_addr: "no-reply@grouper.local"

--- a/grouper/email_util.py
+++ b/grouper/email_util.py
@@ -182,7 +182,16 @@ def send_email_raw(settings, recipient_list, msg_raw):
         return
 
     sender = settings["from_addr"]
-    smtp = smtplib.SMTP(settings["smtp_server"])
+    username = settings["smtp_username"]
+    password = settings["smtp_password"]
+    use_ssl = settings["smtp_use_ssl"]
+
+    smtp_cls = smtplib.SMTP_SSL if use_ssl else smtplib.SMTP
+    smtp = smtp_cls(settings["smtp_server"])
+
+    if username:
+        smtp.login(username, password)
+
     smtp.sendmail(sender, recipient_list, msg_raw)
     smtp.quit()
 

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -101,6 +101,9 @@ settings = Settings({
     "restricted_ownership_permissions": None,
     "send_emails": True,
     "sentry_dsn": None,
+    "smtp_password": "",
     "smtp_server": "localhost",
+    "smtp_use_ssl": False,
+    "smtp_username": "root",
     "url": "http://127.0.0.1:8888",
 })

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -104,6 +104,6 @@ settings = Settings({
     "smtp_password": "",
     "smtp_server": "localhost",
     "smtp_use_ssl": False,
-    "smtp_username": "root",
+    "smtp_username": "",
     "url": "http://127.0.0.1:8888",
 })


### PR DESCRIPTION
Adds 3 new configuration options:
* smtp_use_ssl to force SSL on the SMTP connection
* smtp_username for the username to use when logging in
* smtp_password for the password to use when logging in

Support for servers that do not require authentication is supported by
leaving the smtp_username field blank.