### PR TITLE
Suppress exceptions in the background thread

### DIFF
--- a/grouper/background.py
+++ b/grouper/background.py
@@ -147,6 +147,8 @@ class BackgroundThread(Thread):
                 stats.set_gauge("successful-background-update", 0)
                 stats.set_gauge("failed-background-update", 1)
                 self.capture_exception()
-                raise
+                self.logger.exception(
+                    "Unexpected exception occurred while performing background tasks."
+                )
 
             sleep(60)


### PR DESCRIPTION
Currently, non-database related exceptions in the background thread are
reraised, terminating the background thread. This is nonideal as
temporal errors can result in the background thread ceasing to run,
requiring a server restart. This change adds logging for all unexpected
exceptions in the background thread and then suppresses the exception,
continuing to attempt to perform the background tasks.