### PR TITLE
Add new service account implementation

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -5,12 +5,16 @@ _NAME_VALIDATION = r"(?P<{}>[@\-\w\.]+)"
 NAME_VALIDATION = _NAME_VALIDATION.format("name")
 
 # This regex needs to exactly match the above, EXCEPT that the name should be "name2".
-# This is kind of gross. :\
-# TODO(lfaraone): Figure out why this is needed, and then stop needing it.
+# This is kind of gross. :\ We have to do this because the name of the capture group becomes the
+# argument to route handler, named arguments have to be unique, and at least one route (edit
+# member) requires occurrences of the name validation regex.
 NAME2_VALIDATION = _NAME_VALIDATION.format("name2")
 
-# This regex is specifically to validate usernames.
+# These regexes are specifically to validate usernames.  SERVICE_ACCOUNT_VALIDATION is the same as
+# USERNAME_VALIDATION but with a distinct capture group name so that it doesn't conflict with a
+# NAME_VALIDATION regex in the same URL.
 USERNAME_VALIDATION = r"(?P<name>[\w-]+@\w+[\.\w]+)"
+SERVICE_ACCOUNT_VALIDATION = r"(?P<accountname>[\w-]+@\w+[\.\w]+)"
 
 # UserToken validators
 TOKEN_SECRET_VALIDATION = r"(?P<token_secret>[a-f0-9]{40})"

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -349,3 +349,37 @@ class RoleUserCreateForm(Form):
     description = TextAreaField("Description")
     canjoin = SelectField("Who Can Join?", choices=GROUP_CANJOIN_CHOICES,
     default="canask")
+
+
+class ServiceAccountCreateForm(Form):
+    name = StringField("Name", [
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
+        validators.DataRequired(),
+        ValidateRegex(constants.NAME_VALIDATION),
+        ValidateRegex(constants.USERNAME_VALIDATION),
+    ])
+    description = TextAreaField("Description")
+    machine_set = TextAreaField("Machine Set")
+
+
+class ServiceAccountEditForm(Form):
+    description = TextAreaField("Description")
+    machine_set = TextAreaField("Machine Set")
+
+
+class ServiceAccountEnableForm(Form):
+    owner = SelectField("Owner", [
+        validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
+        validators.DataRequired(),
+        ValidateRegex(constants.NAME_VALIDATION),
+    ])
+
+
+class ServiceAccountPermissionGrantForm(Form):
+    permission = SelectField("Permission", [
+        validators.DataRequired(),
+    ])
+    argument = StringField("Argument", [
+        validators.Length(min=0, max=constants.MAX_NAME_LENGTH),
+        ValidateRegex(constants.ARGUMENT_VALIDATION),
+    ])

--- a/grouper/fe/handlers/public_key_add.py
+++ b/grouper/fe/handlers/public_key_add.py
@@ -6,6 +6,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 
 
 class PublicKeyAdd(GrouperHandler):
@@ -13,7 +14,8 @@ class PublicKeyAdd(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_add_tag.py
+++ b/grouper/fe/handlers/public_key_add_tag.py
@@ -5,6 +5,7 @@ from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.user import User
 from grouper.public_key import add_tag_to_public_key, DuplicateTag, get_public_key, KeyNotFound
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -13,7 +14,8 @@ class PublicKeyAddTag(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None, key_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_delete.py
+++ b/grouper/fe/handlers/public_key_delete.py
@@ -5,6 +5,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.public_key import delete_public_key, get_public_key, KeyNotFound
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -13,7 +14,8 @@ class PublicKeyDelete(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None, key_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/public_key_remove_tag.py
+++ b/grouper/fe/handlers/public_key_remove_tag.py
@@ -4,6 +4,7 @@ from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.user import User
 from grouper.public_key import get_public_key, KeyNotFound, remove_tag_from_public_key, TagNotOnKey
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_is_user_admin
 
 
@@ -12,7 +13,8 @@ class PublicKeyRemoveTag(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def post(self, user_id=None, name=None, key_id=None, tag_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/service_account_create.py
+++ b/grouper/fe/handlers/service_account_create.py
@@ -1,0 +1,56 @@
+from typing import Optional  # noqa
+
+from sqlalchemy.exc import IntegrityError
+
+from grouper.fe.forms import ServiceAccountCreateForm
+from grouper.fe.settings import settings
+from grouper.fe.util import GrouperHandler
+from grouper.models.group import Group
+from grouper.service_account import create_service_account
+
+
+class ServiceAccountCreate(GrouperHandler):
+    def get(self, group_id=None, name=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        form = ServiceAccountCreateForm()
+        return self.render("service-account-create.html", form=form, group=group)
+
+    def post(self, group_id=None, name=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+
+        if "@" not in self.request.arguments["name"][0]:
+            self.request.arguments["name"][0] += "@" + settings.service_account_email_domain
+
+        form = ServiceAccountCreateForm(self.request.arguments)
+
+        if not form.validate():
+            return self.render(
+                "service-account-create.html", form=form, group=group,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        if form.data["name"].split("@")[-1] != settings.service_account_email_domain:
+            form.name.errors.append("All service accounts must have a username ending in {}"
+                .format(settings.service_account_email_domain))
+            return self.render(
+                "service-account-create.html", form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        try:
+            create_service_account(self.session, self.current_user, form.data["name"],
+                form.data["description"], form.data["machine_set"], group)
+        except IntegrityError:
+            self.session.rollback()
+            form.name.errors.append("A user with name {} already exists".format(form.data["name"]))
+            return self.render(
+                "service-account-create.html", form=form,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        url = "/groups/{}/service/{}?refresh=yes".format(group.name, form.data["name"])
+        return self.redirect(url)

--- a/grouper/fe/handlers/service_account_disable.py
+++ b/grouper/fe/handlers/service_account_disable.py
@@ -1,0 +1,29 @@
+from grouper.constants import USER_ADMIN
+from grouper.fe.util import GrouperHandler
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.service_account import can_manage_service_account, disable_service_account
+from grouper.user_permissions import user_has_permission
+
+
+class ServiceAccountDisable(GrouperHandler):
+    @staticmethod
+    def check_access(session, actor, target):
+        if user_has_permission(session, actor, USER_ADMIN):
+            return True
+        return can_manage_service_account(session, target, actor)
+
+    def post(self, group_id=None, name=None, account_id=None, accountname=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        disable_service_account(self.session, self.current_user, service_account)
+
+        return self.redirect("/groups/{}?refresh=yes".format(group.name))

--- a/grouper/fe/handlers/service_account_edit.py
+++ b/grouper/fe/handlers/service_account_edit.py
@@ -1,10 +1,8 @@
 from grouper.fe.forms import ServiceAccountEditForm
 from grouper.fe.util import GrouperHandler
-from grouper.models.audit_log import AuditLog
-from grouper.models.counter import Counter
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
-from grouper.service_account import can_manage_service_account
+from grouper.service_account import can_manage_service_account, edit_service_account
 
 
 class ServiceAccountEdit(GrouperHandler):
@@ -43,14 +41,8 @@ class ServiceAccountEdit(GrouperHandler):
                 form=form, alerts=self.get_form_alerts(form.errors)
             )
 
-        service_account.description = form.data["description"]
-        service_account.machine_set = form.data["machine_set"]
-        Counter.incr(self.session, "updates")
-
-        self.session.commit()
-
-        AuditLog.log(self.session, self.current_user.id, "edit_service_account",
-                     "Edited service account.", on_user_id=service_account.user.id)
+        edit_service_account(self.session, self.current_user, service_account,
+                             form.data["description"], form.data["machine_set"])
 
         return self.redirect("/groups/{}/service/{}".format(
             group.name, service_account.user.username))

--- a/grouper/fe/handlers/service_account_edit.py
+++ b/grouper/fe/handlers/service_account_edit.py
@@ -1,0 +1,56 @@
+from grouper.fe.forms import ServiceAccountEditForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.service_account import can_manage_service_account
+
+
+class ServiceAccountEdit(GrouperHandler):
+    def get(self, group_id=None, name=None, account_id=None, accountname=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+
+        if not can_manage_service_account(self.session, service_account, self.current_user):
+            return self.forbidden()
+
+        form = ServiceAccountEditForm(obj=service_account)
+
+        self.render(
+            "service-account-edit.html", service_account=service_account, group=group, form=form,
+        )
+
+    def post(self, group_id=None, name=None, account_id=None, accountname=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+
+        if not can_manage_service_account(self.session, service_account, self.current_user):
+            return self.forbidden()
+
+        form = ServiceAccountEditForm(self.request.arguments, obj=service_account)
+        if not form.validate():
+            return self.render(
+                "service-account-edit.html", service_account=service_account, group=group,
+                form=form, alerts=self.get_form_alerts(form.errors)
+            )
+
+        service_account.description = form.data["description"]
+        service_account.machine_set = form.data["machine_set"]
+        Counter.incr(self.session, "updates")
+
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, "edit_service_account",
+                     "Edited service account.", on_user_id=service_account.user.id)
+
+        return self.redirect("/groups/{}/service/{}".format(
+            group.name, service_account.user.username))

--- a/grouper/fe/handlers/service_account_enable.py
+++ b/grouper/fe/handlers/service_account_enable.py
@@ -1,0 +1,74 @@
+import operator
+
+from grouper.constants import USER_ADMIN
+from grouper.fe.forms import ServiceAccountEnableForm
+from grouper.fe.util import GrouperHandler
+from grouper.group import get_all_groups
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.service_account import enable_service_account
+from grouper.user_permissions import user_has_permission
+
+
+class ServiceAccountEnable(GrouperHandler):
+    @staticmethod
+    def check_access(session, actor, target):
+        return user_has_permission(session, actor, USER_ADMIN)
+
+    def get_form(self):
+        """Helper to create a ServiceAccountEnableForm populated with all groups.
+
+        Note that the first choice is blank so the first user alphabetically
+        isn't always selected.
+
+        Returns:
+            ServiceAccountEnableForm object.
+        """
+        form = ServiceAccountEnableForm(self.request.arguments)
+
+        group_choices = [
+            (group.groupname, "Group: " + group.groupname)  # (value, label)
+            for group in get_all_groups(self.session)
+        ]
+
+        form.owner.choices = [("", "")] + sorted(group_choices, key=operator.itemgetter(1))
+
+        return form
+
+    def get(self, user_id=None, name=None):
+        service_account = ServiceAccount.get(self.session, user_id, name)
+        if not service_account:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        form = self.get_form()
+        return self.render("service-account-enable.html", form=form, user=service_account.user)
+
+    def post(self, user_id=None, name=None):
+        service_account = ServiceAccount.get(self.session, user_id, name)
+        if not service_account:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        form = self.get_form()
+        if not form.validate():
+            return self.render(
+                "service-account-enable.html", form=form, user=service_account.user,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        owner = Group.get(self.session, name=form.data["owner"])
+        if owner is None:
+            form.owner.errors.append("Group not found.")
+            return self.render(
+                "service-account-enable.html", form=form, user=service_account.user,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        enable_service_account(self.session, self.current_user, service_account, owner)
+        return self.redirect("/groups/{}/service/{}?refresh=yes".format(
+            owner.name, service_account.user.username))

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -1,0 +1,110 @@
+from sqlalchemy.exc import IntegrityError
+
+from grouper.constants import USER_ADMIN
+from grouper.fe.forms import ServiceAccountPermissionGrantForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.group import Group
+from grouper.models.permission import Permission
+from grouper.models.service_account import ServiceAccount
+from grouper.permissions import grant_permission_to_service_account
+from grouper.service_account import can_manage_service_account
+from grouper.user_permissions import user_has_permission
+from grouper.util import matches_glob
+
+
+class ServiceAccountPermissionGrant(GrouperHandler):
+    @staticmethod
+    def check_access(session, actor, target):
+        if user_has_permission(session, actor, USER_ADMIN):
+            return True
+        return can_manage_service_account(session, target, actor)
+
+    def get_form(self, grantable):
+        """Helper to create a ServiceAccountPermissionGrantForm.
+
+        Populate it with all the permissions held by the group.  Note that the first choice is
+        blank so the first user alphabetically isn't always selected.
+
+        Returns:
+            ServiceAccountPermissionGrantForm object.
+        """
+        form = ServiceAccountPermissionGrantForm(self.request.arguments)
+        form.permission.choices = [["", "(select one)"]]
+        for perm in grantable:
+            entry = "{} ({})".format(perm[1], perm[3])
+            form.permission.choices.append([perm[1], entry])
+        return form
+
+    def get(self, group_id=None, name=None, account_id=None, accountname=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+        user = service_account.user
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        form = self.get_form(group.my_permissions())
+        return self.render(
+            "service-account-permission-grant.html", form=form, user=user, group=group
+        )
+
+    def post(self, group_id=None, name=None, account_id=None, accountname=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+        user = service_account.user
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        grantable = group.my_permissions()
+        form = self.get_form(grantable)
+        if not form.validate():
+            return self.render(
+                "service-account-permission-grant.html", form=form, user=user, group=group,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        permission = Permission.get(self.session, form.data["permission"])
+        if not permission:
+            return self.notfound()
+
+        allowed = False
+        for perm in grantable:
+            if perm[1] == permission.name:
+                if matches_glob(perm[3], form.data["argument"]):
+                    allowed = True
+                    break
+        if not allowed:
+            form.argument.errors.append(
+                "The group {} does not have that permission".format(group.name))
+            return self.render(
+                "service-account-permission-grant.html", form=form, user=user, group=group,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        try:
+            grant_permission_to_service_account(
+                self.session, service_account, permission, form.data["argument"])
+        except IntegrityError:
+            self.session.rollback()
+            return self.render(
+                "service-account-permission-grant.html", form=form, user=user,
+                alerts=self.get_form_alerts(form.errors)
+            )
+
+        AuditLog.log(self.session, self.current_user.id, "grant_permission",
+                     "Granted permission with argument: {}".format(form.data["argument"]),
+                     on_permission_id=permission.id, on_group_id=group.id,
+                     on_user_id=service_account.user.id)
+
+        return self.redirect("/groups/{}/service/{}?refresh=yes".format(
+            group.name, service_account.user.username))

--- a/grouper/fe/handlers/service_account_permission_revoke.py
+++ b/grouper/fe/handlers/service_account_permission_revoke.py
@@ -1,0 +1,47 @@
+from grouper.constants import USER_ADMIN
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.counter import Counter
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
+from grouper.service_account import can_manage_service_account
+from grouper.user_permissions import user_has_permission
+
+
+class ServiceAccountPermissionRevoke(GrouperHandler):
+    @staticmethod
+    def check_access(session, actor, target):
+        if user_has_permission(session, actor, USER_ADMIN):
+            return True
+        return can_manage_service_account(session, target, actor)
+
+    def post(self, group_id=None, name=None, account_id=None, accountname=None, mapping_id=None):
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, service_account):
+            return self.forbidden()
+
+        mapping = ServiceAccountPermissionMap.get(self.session, mapping_id)
+        if not mapping:
+            return self.notfound()
+
+        permission = mapping.permission
+        argument = mapping.argument
+
+        mapping.delete(self.session)
+        Counter.incr(self.session, "updates")
+        self.session.commit()
+
+        AuditLog.log(self.session, self.current_user.id, "revoke_permission",
+                     "Revoked permission with argument: {}".format(argument),
+                     on_permission_id=permission.id, on_group_id=group.id,
+                     on_user_id=service_account.user.id)
+
+        return self.redirect("/groups/{}/service/{}?refresh=yes".format(
+            group.name, service_account.user.username))

--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -1,0 +1,22 @@
+from grouper.fe.handlers.template_variables import get_user_view_template_vars
+from grouper.fe.util import GrouperHandler
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+
+
+class ServiceAccountView(GrouperHandler):
+
+    def get(self, group_id=None, name=None, account_id=None, accountname=None):
+        self.handle_refresh()
+        group = Group.get(self.session, group_id, name)
+        if not group:
+            return self.notfound()
+        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        if not service_account:
+            return self.notfound()
+
+        user = service_account.user
+        self.render(
+            "service-account.html", service_account=service_account, group=group, user=user,
+            **get_user_view_template_vars(self.session, self.current_user, user, self.graph)
+        )

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -1,15 +1,15 @@
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.fe.util import Alert
 from grouper.graph import NoSuchGroup, NoSuchUser
+from grouper.group_service_account import get_service_accounts
 from grouper.models.audit_member import AUDIT_STATUS_CHOICES
 from grouper.models.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
-from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.permissions import (get_owner_arg_list, get_pending_request_by_group,
     get_requests_by_owner)
 from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
     get_public_keys_of_user)
 from grouper.role_user import can_manage_role_user
-from grouper.service_account import can_manage_service_account
+from grouper.service_account import can_manage_service_account, service_account_permissions
 from grouper.user import (get_log_entries_by_user, user_open_audits, user_requests_aggregate,
     user_role, user_role_index)
 from grouper.user_group import get_groups_by_user
@@ -31,7 +31,7 @@ def get_group_view_template_vars(session, actor, group, graph):
 
     ret["members"] = group.my_members()
     ret["groups"] = group.my_groups()
-    ret["service_accounts"] = group.my_service_accounts()
+    ret["service_accounts"] = get_service_accounts(session, group)
     ret["permissions"] = group_md.get('permissions', [])
 
     ret["permission_requests_pending"] = []
@@ -127,7 +127,7 @@ def get_user_view_template_vars(session, actor, user, graph):
 
     if user.is_service_account:
         service_account = user.service_account
-        ret["permissions"] = ServiceAccountPermissionMap.permissions_for(session, service_account)
+        ret["permissions"] = service_account_permissions(session, service_account)
     else:
         ret["permissions"] = user_md.get('permissions', [])
 

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -5,6 +5,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_password import add_new_user_password, PasswordAlreadyExists
 
 
@@ -12,8 +13,9 @@ class UserPasswordAdd(GrouperHandler):
 
     @staticmethod
     def check_access(session, actor, target):
-        return actor.name == target.name or (target.role_user and
-            can_manage_role_user(session, actor, tuser=target))
+        return (actor.name == target.name or
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_password_delete.py
+++ b/grouper/fe/handlers/user_password_delete.py
@@ -3,6 +3,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_password import UserPassword
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_password import delete_user_password, PasswordDoesNotExist
 from grouper.user_permissions import user_is_user_admin
 
@@ -12,7 +13,8 @@ class UserPasswordDelete(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None, pass_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_shell.py
+++ b/grouper/fe/handlers/user_shell.py
@@ -5,6 +5,7 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 
 
 class UserShell(GrouperHandler):
@@ -12,7 +13,8 @@ class UserShell(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -8,6 +8,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_token import add_new_user_token
 
 
@@ -15,8 +16,9 @@ class UserTokenAdd(GrouperHandler):
 
     @staticmethod
     def check_access(session, actor, target):
-        return actor.name == target.name or (target.role_user and
-            can_manage_role_user(session, actor, tuser=target))
+        return (actor.name == target.name or
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_token_disable.py
+++ b/grouper/fe/handlers/user_token_disable.py
@@ -3,6 +3,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
 from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_is_user_admin
 from grouper.user_token import disable_user_token
 
@@ -12,7 +13,8 @@ class UserTokenDisable(GrouperHandler):
     @staticmethod
     def check_access(session, actor, target):
         return (actor.name == target.name or user_is_user_admin(session, actor) or
-            (target.role_user and can_manage_role_user(session, actor, tuser=target)))
+            (target.role_user and can_manage_role_user(session, actor, tuser=target)) or
+            (target.is_service_account and can_manage_service_account(session, target, actor)))
 
     def get(self, user_id=None, name=None, token_id=None):
         user = User.get(self.session, user_id, name)

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -19,6 +19,18 @@ class UserView(GrouperHandler):
         if user.role_user:
             return self.redirect("/service/{}".format(user_id or name))
 
+        if user.is_service_account:
+            service_account = user.service_account
+            if service_account.owner:
+                return self.redirect("/groups/{}/service/{}".format(
+                    service_account.owner.group.name, user.username))
+            else:
+                self.render(
+                    "service-account.html", service_account=service_account, group=None, user=user,
+                    **get_user_view_template_vars(self.session, self.current_user, user, self.graph)
+                )
+                return
+
         self.render("user.html",
                     user=user,
                     **get_user_view_template_vars(self.session, self.current_user, user, self.graph)

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -1,10 +1,11 @@
 from grouper.constants import (
-        DEBUG_ROUTE_PATH,
-        NAME2_VALIDATION,
-        NAME_VALIDATION,
-        PERMISSION_VALIDATION,
-        USERNAME_VALIDATION,
-        )
+    DEBUG_ROUTE_PATH,
+    NAME2_VALIDATION,
+    NAME_VALIDATION,
+    PERMISSION_VALIDATION,
+    SERVICE_ACCOUNT_VALIDATION,
+    USERNAME_VALIDATION,
+)
 from grouper.fe.handlers.audits_complete import AuditsComplete
 from grouper.fe.handlers.audits_create import AuditsCreate
 from grouper.fe.handlers.audits_view import AuditsView
@@ -44,6 +45,13 @@ from grouper.fe.handlers.role_user_create import RoleUserCreate
 from grouper.fe.handlers.role_user_view import RoleUserView
 from grouper.fe.handlers.role_users_view import RoleUsersView
 from grouper.fe.handlers.search import Search
+from grouper.fe.handlers.service_account_create import ServiceAccountCreate
+from grouper.fe.handlers.service_account_disable import ServiceAccountDisable
+from grouper.fe.handlers.service_account_edit import ServiceAccountEdit
+from grouper.fe.handlers.service_account_enable import ServiceAccountEnable
+from grouper.fe.handlers.service_account_permission_grant import ServiceAccountPermissionGrant
+from grouper.fe.handlers.service_account_permission_revoke import ServiceAccountPermissionRevoke
+from grouper.fe.handlers.service_account_view import ServiceAccountView
 from grouper.fe.handlers.tag_edit import TagEdit
 from grouper.fe.handlers.tag_view import TagView
 from grouper.fe.handlers.tags_view import TagsView
@@ -114,12 +122,17 @@ for regex in (r"(?P<user_id>[0-9]+)", USERNAME_VALIDATION):
         (r"/users/{}/passwords/add".format(regex), UserPasswordAdd),
         (r"/users/{}/passwords/(?P<pass_id>[0-9]+)/delete".format(regex), UserPasswordDelete),
         (r"/service/{}".format(regex), RoleUserView),
+        (r"/service/{}/enable".format(regex), ServiceAccountEnable),
     ])
 
 for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
     HANDLERS.extend([
         (r"/groups/{}".format(regex), GroupView),
         (r"/groups/{}/edit".format(regex), GroupEdit),
+        (
+            r"/groups/{}/edit/(?P<member_type>user|group)/{}".format(regex, NAME2_VALIDATION),
+            GroupEditMember
+        ),
         (r"/groups/{}/disable".format(regex), GroupDisable),
         (r"/groups/{}/enable".format(regex), GroupEnable),
         (r"/groups/{}/join".format(regex), GroupJoin),
@@ -129,11 +142,24 @@ for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
         (r"/groups/{}/requests".format(regex), GroupRequests),
         (r"/groups/{}/requests/(?P<request_id>[0-9]+)".format(regex), GroupRequestUpdate),
         (r"/groups/{}/permission/request".format(regex), GroupPermissionRequest),
-        (
-            r"/groups/{}/edit/(?P<member_type>user|group)/{}".format(regex, NAME2_VALIDATION),
-            GroupEditMember
-        ),
+        (r"/groups/{}/service/create".format(regex), ServiceAccountCreate),
     ])
+
+for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
+    for service_regex in (r"(?P<account_id>[0-9]+)", SERVICE_ACCOUNT_VALIDATION):
+        HANDLERS.extend([
+            (r"/groups/{}/service/{}".format(regex, service_regex), ServiceAccountView),
+            (r"/groups/{}/service/{}/disable".format(regex, service_regex), ServiceAccountDisable),
+            (r"/groups/{}/service/{}/edit".format(regex, service_regex), ServiceAccountEdit),
+            (
+                r"/groups/{}/service/{}/grant".format(regex, service_regex),
+                ServiceAccountPermissionGrant
+            ),
+            (
+                r"/groups/{}/service/{}/revoke/(?P<mapping_id>[0-9]+)".format(regex, service_regex),
+                ServiceAccountPermissionRevoke
+            ),
+        ])
 
 for regex in (r"(?P<tag_id>[0-9]+)", NAME_VALIDATION):
     HANDLERS.extend([

--- a/grouper/fe/templates/forms/service-account-create.html
+++ b/grouper/fe/templates/forms/service-account-create.html
@@ -1,0 +1,7 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.name, 3, 8, class_="form-control") }}
+{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+{{ form_field(form.machine_set, 3, 8, class_="form-control", rows=1) }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/service-account-edit.html
+++ b/grouper/fe/templates/forms/service-account-edit.html
@@ -1,0 +1,6 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+{{ form_field(form.machine_set, 3, 8, class_="form-control", rows=1) }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/service-account-enable.html
+++ b/grouper/fe/templates/forms/service-account-enable.html
@@ -1,0 +1,5 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.owner, 3, 8, class_="form-control") }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/forms/service-account-permission-grant.html
+++ b/grouper/fe/templates/forms/service-account-permission-grant.html
@@ -1,0 +1,6 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.permission, 3, 8, class_="form-control") }}
+{{ form_field(form.argument, 3, 8, class_="form-control") }}
+
+{{ xsrf_form() }}

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
-                                help_for, account %}
+                                help_for, account, service_account_panel %}
 
 {% block heading %}
     <a href="/groups">Groups</a>
@@ -100,6 +100,7 @@
     </div>
     <div class="col-md-5">
         {{ group_panel(390, groups, current_user_role['role']) }}
+        {{ service_account_panel(390, group.name, service_accounts, current_user_role["is_member"]) }}
     </div>
 </div>
 <div class="row">

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -170,6 +170,45 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
+{% macro one_service_account_row(groupname, accountname) -%}
+    <td><a href="/groups/{{ groupname }}/service/{{ accountname }}">{{ accountname }}</a></td>
+{%- endmacro %}
+{% macro service_account_panel(max_height, groupname, service_accounts, can_control) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Service Accounts</h3>
+        </div>
+        <div style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Name</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for service_account in service_accounts %}
+                    <tr>
+                        {{ one_service_account_row(groupname, service_account.user.username) }}
+                    </tr>
+                {% endfor %}
+                {% if not service_accounts %}
+                    <tr>
+                        <td colspan="2" class="text-center"><em>No Service Accounts</em></td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+        {% if can_control %}
+        <div class="panel-footer">
+            <a class="btn btn-default btn-sm" href="/groups/{{ groupname }}/service/create">
+                <span class="glyphicon glyphicon-plus"></span> Add Service Account
+            </a>
+        </div>
+        {% endif %}
+    </div>
+{%- endmacro %}
+
 {% macro account(user, type=None) -%}
 {% if type == None %}
 <a class="account-link" href="/{{ user.type | lower }}s/{{ user.name }}">

--- a/grouper/fe/templates/service-account-create.html
+++ b/grouper/fe/templates/service-account-create.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Create Service Account for <a href="/groups/{{ group.name }}">{{ group.name }}</a>
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Create Service Account for Group</h3>
+           </div>
+
+            <div class="panel-body" id="dropdown_form">
+                <form class="form-horizontal" role="form"
+                    method="post" action="/groups/{{ group.name }}/service/create">
+                    {% include "forms/service-account-create.html" %}
+                    <div class="form-shell">
+                        <div class="col-sm-offset-3 col-sm-4">
+                            <button type="submit" class="btn btn-primary">Submit</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+
+        </div>
+    </div>
+{% endblock %}

--- a/grouper/fe/templates/service-account-edit.html
+++ b/grouper/fe/templates/service-account-edit.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Edit {{service_account.user.username}}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Edit Service Account {{service_account.user.username}}</h3>
+        </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form"
+                  method="post" action="/groups/{{group.name}}/service/{{service_account.id}}/edit">
+                {% include "forms/service-account-edit.html" %}
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/service-account-enable.html
+++ b/grouper/fe/templates/service-account-enable.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Enable Service Account {{ user.username }}</a>
+{% endblock %}
+
+{% block content %}
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Enable Service Account {{ user.username }}</h3>
+           </div>
+
+            <div class="panel-body" id="dropdown_form">
+                <form class="form-horizontal" role="form"
+                    method="post" action="/service/{{ user.username }}/enable">
+                    {% include "forms/service-account-create.html" %}
+                    <div class="form-shell">
+                        <div class="col-sm-offset-3 col-sm-4">
+                            <button type="submit" class="btn btn-primary">Submit</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+
+        </div>
+    </div>
+{% endblock %}

--- a/grouper/fe/templates/service-account-permission-grant.html
+++ b/grouper/fe/templates/service-account-permission-grant.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Grant Permission to {{user.username}}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Grant Permission to {{user.username}}</h3>
+        </div>
+        <div class="panel-body">
+            <form class="form-horizontal" role="form" method="post"
+                  action="/groups/{{group.name}}/service/{{user.username}}/grant">
+                {% include "forms/service-account-permission-grant.html" %}
+                <div class="form-group">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -1,0 +1,305 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import group_panel, log_entry_panel, tokens_panel, public_key_modal,
+                                shell_panel, passwords_panel, permission, %}
+
+{% macro permission_panel(max_height, mappings, group, user, can_manage) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Permissions</h3>
+        </div>
+        <div style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="{% if mappings %}datatable {% endif %}table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Permission</th>
+                        <th class="col-sm-2">Argument</th>
+                        <th class="col-sm-2">Granted</th>
+                        {% if can_manage %}
+                            <th class="col-sm-2"></th>
+                        {% endif %}
+                    </tr>
+                </thead>
+                <tbody>
+                {% for map in mappings %}
+                    <tr>
+                        <td>{{ permission(map) }}</td>
+                        <td class="col-sm-2">{{ map.argument|default("(unargumented)", True)|escape }}</td>
+                        <td class="col-sm-2" title="{{ map.granted_on|print_date }}">
+                            {{ map.granted_on|long_ago_str }}
+                        </td>
+                        {% if can_manage %}
+                            <td class="col-sm-2">
+                                <button class="btn btn-danger btn-xs"
+                                        data-toggle="modal"
+                                        data-target="#revokeModal"
+                                        data-mapping-id="{{map.mapping_id}}">
+                                    <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span> Revoke
+                                </button>
+                            </td>
+                        {% endif %}
+                    </tr>
+                {% endfor %}
+                {% if not mappings %}
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <em>No permissions found.</em>
+                        </td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+        {% if can_manage %}
+        <div class='panel-footer'>
+            <a class="btn btn-default btn-sm" href="/groups/{{group.name}}/service/{{user.username}}/grant">
+                <span class="glyphicon glyphicon-plus"></span> Add Permission
+            </a>
+        </div>
+        {% endif %}
+    </div>
+{%- endmacro %}
+
+{% macro one_public_key_row(key, username, can_control) -%}
+    <td><span class="has-help" data-toggle="popover" data-content="{{ key.created_on|print_date }}">
+        {{ key.created_on|long_ago_str }}</span></td>
+    <td>{% if key.key_type %}{{ key.key_type }}{% endif %}</td>
+    <td>{% if key.key_size %}{{ key.key_size }}{% endif %}</td>
+    <td class="hidden-xs">
+        <code>{{ key.fingerprint }}</code>
+    </td>
+    <td>
+        {% for tag in key.tags %}
+            {% if can_control %}
+            <form action="/users/{{ username }}/public-key/{{ key.id }}/delete_tag/{{ tag.id }}" method="post" style="display: inline">
+            {% endif %}
+                <button type="submit" class="btn btn-danger">
+                    {{ tag.name }}
+                </button>
+            {% if can_control %}
+                {{ xsrf_form() }}
+            </form>
+            {% endif %}
+        {% endfor %}
+    </td>
+    <td>
+        <span class="pull-right">
+        <button class="btn btn-default btn-xs public-key" key-body="{{ key.public_key|escape }}">
+            <i class="fa fa-search"></i>
+        </button>
+        <button class="btn btn-default btn-xs public-key" key-body="{{ ",".join(key.pretty_permissions)|escape }}">
+            <i class="fa fa-key"></i>
+        </button>
+    {% if can_control %}
+        <a class="btn btn-default btn-xs" href="/users/{{ username }}/public-key/{{ key.id }}/tag">
+            <span class="glyphicon glyphicon-tag" style="vertical-align: -1px"></span>
+        </a>
+        <a class="btn btn-default btn-xs" href="/users/{{ username }}/public-key/{{ key.id }}/delete">
+            <span class="glyphicon glyphicon-remove" style="vertical-align: -1px"></span>
+        </a>
+        </span>
+    {% endif %}
+    </td>
+{%- endmacro %}
+
+{% macro public_key_panel(max_height, user, public_keys, can_control=False) -%}
+    {{ public_key_modal() }}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Public Keys</h3>
+        </div>
+        <div class="table-responsive" style="max-height: {{max_height}}px; overflow-y: auto">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-1">Age</th>
+                        <th class="col-sm-1">Type</th>
+                        <th class="col-sm-1">Size</th>
+                        <th class="col-sm-3 hidden-xs">Fingerprint</th>
+                        <th class="col-sm-1">Tags</th>
+                        <th class="col-sm-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for key in public_keys %}
+                    <tr>
+                        {{ one_public_key_row(key, user.name, can_control) }}
+                    </tr>
+                {% endfor %}
+                {% if not public_keys %}
+                    <tr>
+                        <td colspan="9" class="text-center"><em>No Public Keys</em></td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.username }}/public-key/add">
+                <span class="glyphicon glyphicon-plus"></span> Add Public Key
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endmacro %}
+
+{% block heading %}
+    <a href="/groups">Groups</a>
+{% endblock %}
+
+{% block subheading %}
+    Service Account: {{user.username}}
+    {% if not user.enabled %}<small>(disabled)</small>{% endif %}
+{% endblock %}
+
+{% block headingbuttons %}
+    {% if user.enabled and can_disable %}
+        <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
+            <i class="fa fa-minus"></i> Disable
+        </button>
+    {% elif not user.enabled and can_enable %}
+        <a class="btn btn-warning" href="/service/{{ user.username }}/enable">
+            <i class="fa fa-plus"></i> Enable
+        </a>
+    {% endif %}
+    {% if can_control %}
+        <a href="/groups/{{ group.name }}/service/{{ user.username }}/edit"
+           class="btn btn-primary"><i class="fa fa-edit"></i> Edit
+        </a>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-6">
+        <blockquote><p>
+            <em>{{account.description|default("", True)|escape}}</em>
+        </p></blockquote>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Metadata</h3>
+            </div>
+            <table class="table">
+                <tr>
+                    <td><strong>Owner</strong></td>
+                    <td><a href="/groups/{{ group.name }}">{{ group.name }}</a></td>
+                </tr>
+                <tr>
+                    <td><strong>Machine Set</strong></td>
+                    <td>{{ account.machine_set }}</td>
+                </tr>
+            </table>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ permission_panel(390, permissions, group, user, can_control) }}
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        {{ public_key_panel(390, user, public_keys, can_control) }}
+    </div>
+</div>
+{% if can_control %}
+    <div class="row">
+        <div class="col-md-4">
+            {{ tokens_panel(390, user, user_tokens, can_control) }}
+        </div>
+        <div class="col-md-4">
+            {{ shell_panel(390, user, shell, can_control) }}
+        </div>
+        <div class="col-md-4">
+            {{ passwords_panel(390, user, passwords, can_control) }}
+        </div>
+    </div>
+{% endif %}
+
+<div class="row">
+    <div class="col-md-12">
+        {{ log_entry_panel(390, log_entries) }}
+    </div>
+</div>
+
+<div class="modal fade" id="disableModal" tabindex="-1" role="dialog"
+      aria-labelledby="disableModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Disable Service Account</h4>
+           </div>
+            <div class="modal-body">
+                <p>Are you sure you want to disable this service account?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form action="/groups/{{ group.name }}/service/{{user.username}}/disable"
+                      method="post" style="display: inline;">
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Disable</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="revokeModal" tabindex="-1" role="dialog"
+      aria-labelledby="revokeModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Revoke Permission</h4>
+           </div>
+            <div class="modal-body">
+                <p>Are you sure you want to revoke this service account permission?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form class="revoke-permission-form"
+                      {# action is set dynamically in on("show.bs.modal") #}
+                      action="#" method="post"
+                      style="display: inline;">
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Revoke</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block script %}
+{# The revokeModal is generated once per page but could be used for any member being removed. So,
+when the modal shows up, make sure to populate its text and set its form actions to correspond to
+the selected user. #}
+<script type="text/javascript">
+    $(function () {
+        $("#revokeModal").on("show.bs.modal", function(e) {
+            var button = $(e.relatedTarget);
+            var mappingId = button.data("mapping-id");
+
+            var modal = $(e.currentTarget);
+
+            var form = modal.find(".revoke-permission-form")
+            form.attr("action", "/groups/{{group.name}}/service/{{user.username}}/revoke/" + mappingId);
+        });
+    });
+</script>
+{% endblock %}

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -16,12 +16,12 @@ from grouper.models.permission import MappedPermission, Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.public_key import PublicKey
 from grouper.models.service_account import ServiceAccount
-from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.user import User
 from grouper.models.user_metadata import UserMetadata
 from grouper.models.user_password import UserPassword
 from grouper.public_key import get_all_public_key_tags
 from grouper.role_user import is_role_user
+from grouper.service_account import all_service_account_permissions
 from grouper.util import singleton
 
 MEMBER_TYPE_MAP = {
@@ -116,7 +116,7 @@ class GroupGraph(object):
 
             user_metadata = self._get_user_metadata(session)
             permission_metadata = self._get_permission_metadata(session)
-            service_account_permissions = ServiceAccountPermissionMap.all_permissions(session)
+            service_account_permissions = all_service_account_permissions(session)
             group_metadata = self._get_group_metadata(session, permission_metadata)
             group_service_accounts = self._get_group_service_accounts(session)
             permission_tuples = self._get_permission_tuples(session)
@@ -284,7 +284,7 @@ class GroupGraph(object):
         out = defaultdict(list)
         tuples = session.query(Group, ServiceAccount).filter(
             GroupServiceAccount.group_id == Group.id,
-            GroupServiceAccount.service_account_pk == ServiceAccount.id,
+            GroupServiceAccount.service_account_id == ServiceAccount.id,
         )
         for group, account in tuples:
             out[group.groupname].append(account.user.username)

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -281,13 +281,13 @@ class GroupGraph(object):
         '''
         Returns a dict of groupname: { list of service account names }.
         '''
-        out = defaultdict(set)
+        out = defaultdict(list)
         tuples = session.query(Group, ServiceAccount).filter(
             GroupServiceAccount.group_id == Group.id,
             GroupServiceAccount.service_account_pk == ServiceAccount.id,
         )
         for group, account in tuples:
-            out[group.groupname].add(account.user.username)
+            out[group.groupname].append(account.user.username)
         return out
 
     @staticmethod

--- a/grouper/group.py
+++ b/grouper/group.py
@@ -1,11 +1,25 @@
+import logging
 from typing import TYPE_CHECKING
 
 from grouper.graph import Graph, NoSuchGroup
+from grouper.models.counter import Counter
 from grouper.models.group import Group
+from grouper.models.group_service_accounts import GroupServiceAccount
 
 if TYPE_CHECKING:
     from typing import List  # noqa
     from grouper.models.base.session import Session  # noqa
+    from grouper.models.service_account import ServiceAccount  # noqa
+
+
+def add_service_account(session, group, service_account):
+    # type: (Session, Group, ServiceAccount) -> None
+    """Add a service account to a group."""
+    logging.debug("Adding service account %s to %s", service_account.user.username,
+        group.groupname)
+    GroupServiceAccount(group_id=group.id, service_account=service_account).add(session)
+    Counter.incr(session, "updates")
+    session.commit()
 
 
 def get_all_groups(session):

--- a/grouper/group.py
+++ b/grouper/group.py
@@ -1,25 +1,11 @@
-import logging
 from typing import TYPE_CHECKING
 
 from grouper.graph import Graph, NoSuchGroup
-from grouper.models.counter import Counter
 from grouper.models.group import Group
-from grouper.models.group_service_accounts import GroupServiceAccount
 
 if TYPE_CHECKING:
     from typing import List  # noqa
     from grouper.models.base.session import Session  # noqa
-    from grouper.models.service_account import ServiceAccount  # noqa
-
-
-def add_service_account(session, group, service_account):
-    # type: (Session, Group, ServiceAccount) -> None
-    """Add a service account to a group."""
-    logging.debug("Adding service account %s to %s", service_account.user.username,
-        group.groupname)
-    GroupServiceAccount(group_id=group.id, service_account=service_account).add(session)
-    Counter.incr(session, "updates")
-    session.commit()
 
 
 def get_all_groups(session):

--- a/grouper/group_service_account.py
+++ b/grouper/group_service_account.py
@@ -1,0 +1,34 @@
+import logging
+
+from grouper.models.counter import Counter
+from grouper.models.group_service_accounts import GroupServiceAccount
+from grouper.models.service_account import ServiceAccount
+from grouper.models.user import User
+
+
+def add_service_account(session, group, service_account):
+    # type: (Session, Group, ServiceAccount) -> None
+    """Add a service account to a group."""
+    logging.debug("Adding service account %s to %s", service_account.user.username,
+        group.groupname)
+    GroupServiceAccount(group_id=group.id, service_account=service_account).add(session)
+    Counter.incr(session, "updates")
+    session.commit()
+
+
+def get_service_accounts(session, group):
+    # type: (Session, Group) -> List[ServiceAccount]
+    """Return all service accounts owned by a group."""
+
+    service_accounts = session.query(
+        ServiceAccount
+    ).join(
+        ServiceAccount.owner,
+    ).filter(
+        GroupServiceAccount.group_id == group.id,
+        GroupServiceAccount.service_account_id == ServiceAccount.id,
+        group.enabled == True,
+        User.enabled == True,
+    ).all()
+
+    return service_accounts

--- a/grouper/group_service_account.py
+++ b/grouper/group_service_account.py
@@ -1,9 +1,16 @@
 import logging
 
+from typing import TYPE_CHECKING
+
 from grouper.models.counter import Counter
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
+
+if TYPE_CHECKING:
+    from typing import List  # noqa
+    from grouper.models.group import Group  # noqa
+    from grouper.models.session import Session  # noqa
 
 
 def add_service_account(session, group, service_account):

--- a/grouper/models/base/constants.py
+++ b/grouper/models/base/constants.py
@@ -5,5 +5,12 @@ REQUEST_STATUS_CHOICES = {
     "cancelled": set([]),
 }
 
-OBJ_TYPES_IDX = ("User", "Group", "Request", "RequestStatusChange", "PermissionRequestStatusChange")
+OBJ_TYPES_IDX = (
+    "User",
+    "Group",
+    "Request",
+    "RequestStatusChange",
+    "PermissionRequestStatusChange",
+    "ServiceAccount",
+)
 OBJ_TYPES = {obj_type: idx for idx, obj_type in enumerate(OBJ_TYPES_IDX)}

--- a/grouper/models/group.py
+++ b/grouper/models/group.py
@@ -19,12 +19,10 @@ from grouper.models.base.session import flush_transaction
 from grouper.models.comment import Comment, CommentObjectMixin
 from grouper.models.counter import Counter
 from grouper.models.group_edge import APPROVER_ROLE_INDICES, GroupEdge, OWNER_ROLE_INDICES
-from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.request import Request
 from grouper.models.request_status_change import RequestStatusChange
-from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
 
 GROUP_JOIN_CHOICES = {
@@ -192,23 +190,6 @@ class Group(Model, CommentObjectMixin):
         ).all()
 
         return users
-
-    def my_service_accounts(self):
-        # type: () -> List[ServiceAccount]
-        """Return all service accounts owned by a group."""
-
-        service_accounts = self.session.query(
-            ServiceAccount
-        ).join(
-            ServiceAccount.owner,
-        ).filter(
-            GroupServiceAccount.group_id == self.id,
-            GroupServiceAccount.service_account_pk == ServiceAccount.id,
-            self.enabled == True,
-            User.enabled == True,
-        ).all()
-
-        return service_accounts
 
     def my_approver_users(self):
         # type: () -> List[User]

--- a/grouper/models/group_service_accounts.py
+++ b/grouper/models/group_service_accounts.py
@@ -15,7 +15,7 @@ class GroupServiceAccount(Model):
     __table_args__ = (
         Index(
             "group_service_account_idx",
-            "group_id", "service_account_pk",
+            "group_id", "service_account_id",
             unique=True
         ),
     )
@@ -25,11 +25,11 @@ class GroupServiceAccount(Model):
     group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
     group = relationship("Group", backref="service_accounts", foreign_keys=[group_id])
 
-    service_account_pk = Column(Integer, ForeignKey("service_accounts.id"), nullable=False)
+    service_account_id = Column(Integer, ForeignKey("service_accounts.id"), nullable=False)
     service_account = relationship("ServiceAccount", backref=backref("owner", uselist=False),
-        foreign_keys=[service_account_pk])
+        foreign_keys=[service_account_id])
 
     def __repr__(self):
         # type: () -> str
-        return "%s(group_id=%s, service_account_pk=%s)" % (
-            type(self).__name__, self.group_id, self.service_account_pk)
+        return "%s(group_id=%s, service_account_id=%s)" % (
+            type(self).__name__, self.group_id, self.service_account_id)

--- a/grouper/models/group_service_accounts.py
+++ b/grouper/models/group_service_accounts.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, ForeignKey, Index, Integer
+from sqlalchemy.orm import backref, relationship
+
+from grouper.models.base.model_base import Model
+
+
+class GroupServiceAccount(Model):
+    """Service accounts owned by a group.
+
+    A group may own zero or more service accounts. This table holds the mapping between a Group and
+    the ServiceAccount objects it owns.
+    """
+
+    __tablename__ = "group_service_accounts"
+    __table_args__ = (
+        Index(
+            "group_service_account_idx",
+            "group_id", "service_account_pk",
+            unique=True
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
+    group = relationship("Group", backref="service_accounts", foreign_keys=[group_id])
+
+    service_account_pk = Column(Integer, ForeignKey("service_accounts.id"), nullable=False)
+    service_account = relationship("ServiceAccount", backref=backref("owner", uselist=False),
+        foreign_keys=[service_account_pk])
+
+    def __repr__(self):
+        # type: () -> str
+        return "%s(group_id=%s, service_account_pk=%s)" % (
+            type(self).__name__, self.group_id, self.service_account_pk)

--- a/grouper/models/service_account.py
+++ b/grouper/models/service_account.py
@@ -1,0 +1,59 @@
+from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy.orm import backref, relationship
+
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import Session  # noqa
+from grouper.models.counter import Counter
+from grouper.models.user import User
+
+
+class ServiceAccount(Model):
+    """Represents a group-owned service account.
+
+    A service account is like a Grouper user, but with some key differences:
+
+    1. Service accounts cannot take actions in Grouper and cannot be members of groups.
+    2. Every service account is owned by one group.
+    3. Service accounts do not inherit group permissions by default.
+    4. Group members can manage the service account and delegate permissions to it.
+    5. Service accounts have some additional metadata.
+
+    Internally, a service account is represented by a ServiceAccount object pointing to a User
+    object that has the service_account flag set to True.
+
+    This data model is a compromise to avoid a large data migration.  In an ideal world, there would
+    be an underlying Account object that holds the data in common between User and ServiceAccount,
+    and User and ServiceAccount would both have one-to-one mappings to an Account.  The Grouper API
+    is set up to behave as if this world existed.
+    """
+
+    __tablename__ = "service_accounts"
+
+    id = Column(Integer, primary_key=True)
+    description = Column(Text)
+    machine_set = Column(Text)
+    user_pk = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user = relationship("User", uselist=False, backref=backref("service_account", uselist=False))
+
+    def __repr__(self):
+        # type: () -> str
+        return "<%s: id=%s user_pk=%s>" % (
+            type(self).__name__, self.id, self.user_pk)
+
+    @staticmethod
+    def get(session, pk=None, name=None):
+        # type: (Session, int, str) -> ServiceAccount
+        if pk is not None:
+            return session.query(ServiceAccount).filter_by(id=pk).scalar()
+        if name is not None:
+            return session.query(ServiceAccount).filter(
+                ServiceAccount.user_pk == User.id,
+                User.username == name,
+            ).scalar()
+        return None
+
+    def add(self, session):
+        # type: (Session) -> ServiceAccount
+        super(ServiceAccount, self).add(session)
+        Counter.incr(session, "updates")
+        return self

--- a/grouper/models/service_account.py
+++ b/grouper/models/service_account.py
@@ -32,13 +32,13 @@ class ServiceAccount(Model):
     id = Column(Integer, primary_key=True)
     description = Column(Text)
     machine_set = Column(Text)
-    user_pk = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     user = relationship("User", uselist=False, backref=backref("service_account", uselist=False))
 
     def __repr__(self):
         # type: () -> str
-        return "<%s: id=%s user_pk=%s>" % (
-            type(self).__name__, self.id, self.user_pk)
+        return "<%s: id=%s user_id=%s>" % (
+            type(self).__name__, self.id, self.user_id)
 
     @staticmethod
     def get(session, pk=None, name=None):
@@ -47,7 +47,7 @@ class ServiceAccount(Model):
             return session.query(ServiceAccount).filter_by(id=pk).scalar()
         if name is not None:
             return session.query(ServiceAccount).filter(
-                ServiceAccount.user_pk == User.id,
+                ServiceAccount.user_id == User.id,
                 User.username == name,
             ).scalar()
         return None

--- a/grouper/models/service_account_permission_map.py
+++ b/grouper/models/service_account_permission_map.py
@@ -1,0 +1,93 @@
+from collections import defaultdict, namedtuple
+from datetime import datetime
+from typing import Dict, List  # noqa
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from grouper.constants import MAX_NAME_LENGTH
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import Session  # noqa
+from grouper.models.permission import Permission
+from grouper.models.service_account import ServiceAccount
+from grouper.models.user import User
+
+# A single permission.  "distance" is always 0 but simplifies some UI logic if present.
+ServiceAccountPermission = namedtuple("ServiceAccountPermission",
+    ["permission", "argument", "granted_on", "mapping_id"])
+
+
+class ServiceAccountPermissionMap(Model):
+    """Relationship between Permission and ServiceAccount.
+
+    Maps a relationship between a Permission and a ServiceAccount (compare PermissionMap for
+    Group). Note that a single permission can be mapped into a given group multiple times, as long
+    as the argument is unique.
+
+    These include the optional arguments, which can either be a string, an asterisks ("*"), or
+    Null to indicate no argument.
+    """
+
+    __tablename__ = "service_account_permissions_map"
+    __table_args__ = (
+        UniqueConstraint("permission_id", "service_account_id", "argument", name="uidx1"),
+    )
+
+    id = Column(Integer, primary_key=True)
+
+    permission_id = Column(Integer, ForeignKey("permissions.id"), nullable=False)
+    permission = relationship("Permission", foreign_keys=[permission_id])
+
+    service_account_id = Column(Integer, ForeignKey("service_accounts.id"), nullable=False)
+    service_account = relationship("ServiceAccount", foreign_keys=[service_account_id])
+
+    argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
+    granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    @staticmethod
+    def all_permissions(session):
+        # type: (Session) -> Dict[str, List[ServiceAccountPermission]]
+        """Return a dict of service account names to their permissions."""
+        out = defaultdict(list)  # type: Dict[str, List[ServiceAccountPermission]]
+        permissions = session.query(Permission, ServiceAccountPermissionMap).filter(
+            Permission.id == ServiceAccountPermissionMap.permission_id,
+            ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
+            ServiceAccount.user_pk == User.id,
+            User.enabled == True,
+        )
+        for permission in permissions:
+            out[permission[1].service_account.user.username].append(ServiceAccountPermission(
+                permission=permission[0].name,
+                argument=permission[1].argument,
+                granted_on=permission[1].granted_on,
+                mapping_id=permission[1].id,
+            ))
+        return out
+
+    @staticmethod
+    def get(session, id=None):
+        # type: (Session, int) -> ServiceAccountPermissionMap
+        if id is not None:
+            return session.query(ServiceAccountPermissionMap).filter_by(id=id).scalar()
+        return None
+
+    @staticmethod
+    def permissions_for(session, service_account):
+        # type: (Session, ServiceAccount) -> List[ServiceAccountPermission]
+        """Return the permissions of a service account."""
+        permissions = session.query(Permission, ServiceAccountPermissionMap).filter(
+            Permission.id == ServiceAccountPermissionMap.permission_id,
+            ServiceAccountPermissionMap.service_account_id == service_account.id,
+            ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
+            ServiceAccount.user_pk == User.id,
+            User.enabled == True,
+        )
+        out = []
+        for permission in permissions:
+            out.append(ServiceAccountPermission(
+                permission=permission[0].name,
+                argument=permission[1].argument,
+                granted_on=permission[1].granted_on,
+                mapping_id=permission[1].id
+            ))
+        return out

--- a/grouper/models/user.py
+++ b/grouper/models/user.py
@@ -19,6 +19,7 @@ class User(Model, CommentObjectMixin):
     username = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     enabled = Column(Boolean, default=True, nullable=False)
     role_user = Column(Boolean, default=False, nullable=False)
+    is_service_account = Column(Boolean, default=False, nullable=False)
     tokens = relationship("UserToken", back_populates="user")
 
     @hybrid_property

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -19,6 +19,7 @@ from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.permission_request import PermissionRequest
 from grouper.models.permission_request_status_change import PermissionRequestStatusChange
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.tag_permission_map import TagPermissionMap
 from grouper.plugin import get_plugins
 from grouper.user_group import get_groups_by_user
@@ -62,6 +63,31 @@ def grant_permission(session, group_id, permission_id, argument=''):
     assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
 
     mapping = PermissionMap(permission_id=permission_id, group_id=group_id, argument=argument)
+    mapping.add(session)
+
+    Counter.incr(session, "updates")
+
+    session.commit()
+
+
+def grant_permission_to_service_account(session, account, permission, argument=''):
+    """
+    Grant a permission to this service account. This will fail if the (permission, argument) has
+    already been granted to this group.
+
+    Args:
+        session(models.base.session.Session): database session
+        account(ServiceAccount): a ServiceAccount object being granted a permission
+        permission(Permission): a Permission object being granted
+        argument(str): must match constants.ARGUMENT_VALIDATION
+
+    Throws:
+        AssertError if argument does not match ARGUMENT_VALIDATION regex
+    """
+    assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
+
+    mapping = ServiceAccountPermissionMap(
+        permission_id=permission.id, service_account_id=account.id, argument=argument)
     mapping.add(session)
 
     Counter.incr(session, "updates")

--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -1,0 +1,101 @@
+"""Service account handling.
+
+A service account is an account that is not a Grouper user and cannot be a member of groups, but
+can have permissions delegated to it.  Every service account is owned by one and only one Group.
+
+In an ideal world, we would have an Account abstraction, and both a User and a ServiceAccount would
+contain an Account.  The Account would hold the data in common betweeen User and ServiceAccount.
+In practice, that would mean a huge database migration, so User does double duty as the underlying
+Account abstraction.  A User that's just the account of a ServiceAccount is flagged with the
+service_account boolean field.
+"""
+
+from typing import Union  # noqa
+
+from grouper.group import add_service_account
+from grouper.models.audit_log import AuditLog
+from grouper.models.base.session import Session  # noqa
+from grouper.models.counter import Counter
+from grouper.models.group import Group  # noqa
+from grouper.models.service_account import ServiceAccount
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
+from grouper.models.user import User
+from grouper.user import disable_user, enable_user
+
+
+def create_service_account(session, actor, name, description, machine_set, owner):
+    # type: (Session, User, str, str, str, Group) -> ServiceAccount
+    """Creates a service account and its underlying user.
+
+    Also adds the service account to the list of accounts managed by the owning group.
+
+    Throws:
+        IntegrityError: if a user with the given name already exists
+    """
+    user = User(username=name, is_service_account=True)
+    service_account = ServiceAccount(user=user, description=description, machine_set=machine_set)
+
+    user.add(session)
+    service_account.add(session)
+    session.flush()
+
+    add_service_account(session, owner, service_account)
+
+    AuditLog.log(session, actor.id, "create_service_account", "Created new service account.",
+                 on_group_id=owner.id, on_user_id=service_account.user_pk)
+
+    return service_account
+
+
+def is_service_account(session, user):
+    # type: (Session, User) -> bool
+    """Returns whether a User is a service account.
+
+    Also returns True for role users until they have been retired.
+    """
+    return user.is_service_account or user.role_user
+
+
+def can_manage_service_account(session, target, user):
+    # type: (Session, Union[ServiceAccount, User], User) -> bool
+    """Returns whether a User has permission to manage a ServiceAccount."""
+    if type(target) == User:
+        if not target.is_service_account:
+            return False
+        account = target.service_account
+    else:
+        account = target
+    if account.owner is None:
+        return False
+    return user.is_member(account.owner.group.my_members())
+
+
+def disable_service_account(session, actor, service_account):
+    # type: (Session, User, ServiceAccount) -> None
+    """Disables a service account and deletes the association with a Group."""
+    disable_user(session, service_account.user)
+    owner_id = service_account.owner.group.id
+    service_account.owner.delete(session)
+    permissions = session.query(ServiceAccountPermissionMap).filter_by(
+        service_account_id=service_account.id)
+    for permission in permissions:
+        permission.delete(session)
+
+    AuditLog.log(session, actor.id, "disable_service_account", "Disabled service account.",
+                 on_group_id=owner_id, on_user_id=service_account.user_pk)
+
+    Counter.incr(session, "updates")
+    session.commit()
+
+
+def enable_service_account(session, actor, service_account, owner):
+    # type: (Session, User, ServiceAccount, Group) -> None
+    """Enables a service account and sets a new owner."""
+    enable_user(session, service_account.user, actor, preserve_membership=False)
+    add_service_account(session, owner, service_account)
+
+    AuditLog.log(session, actor.id, "enable_service_account", "Enabled service account.",
+                 on_group_id=owner.id, on_user_id=service_account.user_pk)
+
+    Counter.incr(session, "updates")
+    session.commit()

--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -61,7 +61,7 @@ def create_service_account(session, actor, name, description, machine_set, owner
     add_service_account(session, owner, service_account)
 
     AuditLog.log(session, actor.id, "create_service_account", "Created new service account.",
-                 on_group_id=owner.id, on_user_id=service_account.user_pk)
+                 on_group_id=owner.id, on_user_id=service_account.user_id)
 
     return service_account
 
@@ -114,7 +114,7 @@ def disable_service_account(session, actor, service_account):
         permission.delete(session)
 
     AuditLog.log(session, actor.id, "disable_service_account", "Disabled service account.",
-                 on_group_id=owner_id, on_user_id=service_account.user_pk)
+                 on_group_id=owner_id, on_user_id=service_account.user_id)
 
     Counter.incr(session, "updates")
     session.commit()
@@ -127,7 +127,7 @@ def enable_service_account(session, actor, service_account, owner):
     add_service_account(session, owner, service_account)
 
     AuditLog.log(session, actor.id, "enable_service_account", "Enabled service account.",
-                 on_group_id=owner.id, on_user_id=service_account.user_pk)
+                 on_group_id=owner.id, on_user_id=service_account.user_id)
 
     Counter.incr(session, "updates")
     session.commit()
@@ -140,7 +140,7 @@ def service_account_permissions(session, service_account):
         Permission.id == ServiceAccountPermissionMap.permission_id,
         ServiceAccountPermissionMap.service_account_id == service_account.id,
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
-        ServiceAccount.user_pk == User.id,
+        ServiceAccount.user_id == User.id,
         User.enabled == True,
     )
     out = []
@@ -161,7 +161,7 @@ def all_service_account_permissions(session):
     permissions = session.query(Permission, ServiceAccountPermissionMap).filter(
         Permission.id == ServiceAccountPermissionMap.permission_id,
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
-        ServiceAccount.user_pk == User.id,
+        ServiceAccount.user_id == User.id,
         User.enabled == True,
     )
     for permission in permissions:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -15,6 +15,7 @@ from grouper.models.group import Group
 from grouper.models.permission import Permission
 from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing
+from grouper.service_account import create_service_account
 from path_util import src_path, db_url
 from util import add_member, grant_permission
 
@@ -28,7 +29,8 @@ def standard_graph(session, graph, users, groups, permissions):
     |  team-sre             |
     |    * gary (o)         +---------------------------------+
     |    * zay              |                                 |
-    |    * zorkian          |                     +-----------v-----------+
+    |    * zorkian          |                                 |
+    |    * service (s)      |                     +-----------v-----------+
     |                       |                     |                       |
     +-----------------------+                     |  serving-team         |
     +-----------------------+           +--------->    * zorkian (o)      |
@@ -80,7 +82,7 @@ def standard_graph(session, graph, users, groups, permissions):
     +-----------------------+
 
     Arrows denote member of the source in the destination group. (o) for
-    owners, (np) for non-permissioned owners.
+    owners, (np) for non-permissioned owners, (s) for service accounts.
     """
     add_member(groups["team-sre"], users["gary@a.co"], role="owner")
     add_member(groups["team-sre"], users["zay@a.co"])
@@ -125,6 +127,11 @@ def standard_graph(session, graph, users, groups, permissions):
 
     add_member(groups["group-admins"], users["cbguder@a.co"], role="owner")
     grant_permission(groups["group-admins"], permissions[GROUP_ADMIN])
+
+    create_service_account(
+        session, users["zay@a.co"], "service@a.co", "some service account", "some machines",
+        groups["team-sre"]
+    )
 
     session.commit()
     graph.update_from_db(session)

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -24,7 +24,7 @@ def test_users(users, http_client, base_url):
     api_url = url(base_url, '/users')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    users_wo_role = sorted((u for u in users if u != u"role@a.co"))
+    users_wo_role = sorted([u for u in users if u != u"role@a.co"] + [u"service@a.co"])
 
     print 'user_wo_role={}'.format(users_wo_role)
     print 'res={}'.format(sorted(body["data"]["users"]))

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -24,7 +24,7 @@ def test_users(users, http_client, base_url):
     api_url = url(base_url, '/users')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    users_wo_role = sorted([u for u in users if u != u"role@a.co"] + [u"service@a.co"])
+    users_wo_role = sorted([u for u in users if u not in (u"role@a.co", u"service@a.co")])
 
     print 'user_wo_role={}'.format(users_wo_role)
     print 'res={}'.format(sorted(body["data"]["users"]))
@@ -92,7 +92,7 @@ def test_service_accounts(users, http_client, base_url):
     api_url = url(base_url, '/service_accounts')
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    service_accounts = sorted([user.name for user in users.values() if user.role_user])
+    service_accounts = sorted([u.name for u in users.values() if u.role_user] + ["service@a.co"])
 
     assert resp.code == 200
     assert body["status"] == "ok"

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -11,7 +11,9 @@ from fixtures import standard_graph, graph, users, groups, session, permissions 
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.models.counter import Counter
 from grouper.models.permission import Permission
+from grouper.models.service_account import ServiceAccount
 from grouper.models.user_token import UserToken
+from grouper.permissions import grant_permission_to_service_account
 from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
 from grouper.user_password import add_new_user_password, delete_user_password, user_passwords
 from grouper.user_token import add_new_user_token, disable_user_token
@@ -21,16 +23,22 @@ from util import grant_permission
 
 @pytest.mark.gen_test
 def test_users(users, http_client, base_url):
-    api_url = url(base_url, '/users')
+    all_users = sorted(users.keys() + ["service@a.co"])
+    users_wo_role = sorted([u for u in users if u != u"role@a.co"])
+
+    api_url = url(base_url, "/users")
     resp = yield http_client.fetch(api_url)
     body = json.loads(resp.body)
-    users_wo_role = sorted([u for u in users if u not in (u"role@a.co", u"service@a.co")])
-
-    print 'user_wo_role={}'.format(users_wo_role)
-    print 'res={}'.format(sorted(body["data"]["users"]))
     assert resp.code == 200
     assert body["status"] == "ok"
     assert sorted(body["data"]["users"]) == users_wo_role
+
+    api_url = url(base_url, "/users?include_role_users=yes")
+    resp = yield http_client.fetch(api_url)
+    body = json.loads(resp.body)
+    assert resp.code == 200
+    assert body["status"] == "ok"
+    assert sorted(body["data"]["users"]) == all_users
 
     # TODO: test cutoff
 
@@ -51,7 +59,7 @@ def test_multi_users(users, http_client, base_url):
     assert resp.code == 200
     assert body["status"] == "ok"
     # Service Accounts should be included
-    assert sorted(body["data"].iterkeys()) == sorted(users)
+    assert sorted(body["data"].iterkeys()) == sorted(users.keys() + ['service@a.co'])
 
     # Test case when only valid usernames are provided
     api_url = make_url('tyleromeara@a.co', 'gary@a.co', 'role@a.co')
@@ -88,15 +96,44 @@ def test_multi_users(users, http_client, base_url):
 
 
 @pytest.mark.gen_test
-def test_service_accounts(users, http_client, base_url):
-    api_url = url(base_url, '/service_accounts')
-    resp = yield http_client.fetch(api_url)
-    body = json.loads(resp.body)
+def test_service_accounts(session, standard_graph, users, http_client, base_url):
+    graph = standard_graph
     service_accounts = sorted([u.name for u in users.values() if u.role_user] + ["service@a.co"])
 
+    api_url = url(base_url, "/service_accounts")
+    resp = yield http_client.fetch(api_url)
+    body = json.loads(resp.body)
     assert resp.code == 200
     assert body["status"] == "ok"
     assert sorted(body["data"]["service_accounts"]) == service_accounts
+
+    # TODO: test cutoff
+
+    # Retrieve a single service account and check its metadata.
+    api_url = url(base_url, "/service_accounts/service@a.co")
+    resp = yield http_client.fetch(api_url)
+    body = json.loads(resp.body)
+    assert resp.code == 200
+    assert body["status"] == "ok"
+    data = body["data"]["user"]
+    assert "service_account" in data
+    assert data["service_account"]["description"] == "some service account"
+    assert data["service_account"]["machine_set"] == "some machines"
+    assert data["service_account"]["owner"] == "team-sre"
+    assert body["data"]["permissions"] == []
+
+    # Delegate a permission to the service account and check for it.
+    service_account = ServiceAccount.get(session, name="service@a.co")
+    permission = Permission.get(session, name="team-sre")
+    grant_permission_to_service_account(session, service_account, permission, "*")
+    graph.update_from_db(session)
+    resp = yield http_client.fetch(api_url)
+    body = json.loads(resp.body)
+    assert resp.code == 200
+    assert body["status"] == "ok"
+    permissions = body["data"]["permissions"]
+    assert permissions[0]["permission"] == "team-sre"
+    assert permissions[0]["argument"] == "*"
 
 
 @pytest.mark.gen_test

--- a/tests/test_service_accounts.py
+++ b/tests/test_service_accounts.py
@@ -1,0 +1,275 @@
+from urllib import urlencode
+
+import pytest
+
+from sqlalchemy.exc import IntegrityError
+from tornado.httpclient import HTTPError
+
+from fixtures import fe_app as app
+from fixtures import graph, groups, permissions, session, standard_graph, users  # noqa
+from grouper.constants import USER_ADMIN
+from grouper.models.base.session import Session
+from grouper.models.permission import Permission
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
+from grouper.permissions import grant_permission_to_service_account
+from grouper.service_account import (
+    can_manage_service_account,
+    create_service_account,
+    disable_service_account,
+    enable_service_account,
+    is_service_account,
+)
+from url_util import url
+from util import grant_permission
+
+
+def test_service_accounts(standard_graph, session, users, groups, permissions):
+    graph = standard_graph
+    user = users["zorkian@a.co"]
+    group = groups["team-sre"]
+
+    # Create a service account.
+    service_account = create_service_account(session, user, "service@a.co", "some service account",
+        "some machines", group)
+    assert service_account.description == "some service account"
+    assert service_account.machine_set == "some machines"
+    assert service_account.user.name == "service@a.co"
+    assert service_account.user.enabled == True
+    assert service_account.user.is_service_account == True
+    service_accounts = group.my_service_accounts()
+    assert len(service_accounts) == 1
+    assert service_accounts[0].user.name == "service@a.co"
+    assert is_service_account(session, service_account.user)
+    session.commit()
+
+    # Duplicates should raise an exception.
+    with pytest.raises(IntegrityError):
+        create_service_account(session, user, "service@a.co", "dup", "dup", group)
+    session.rollback()
+
+    # zorkian should be able to manage the account, as should gary, but oliver (not a member of the
+    # group) should not.
+    assert can_manage_service_account(session, service_account, user)
+    assert can_manage_service_account(session, service_account, users["gary@a.co"])
+    assert not can_manage_service_account(session, service_account, users["oliver@a.co"])
+
+    # Check that the user appears in the graph.
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert metadata["enabled"]
+    assert metadata["service_account"]["description"] == "some service account"
+    assert metadata["service_account"]["machine_set"] == "some machines"
+    assert metadata["service_account"]["owner"] == "team-sre"
+    group_details = graph.get_group_details("team-sre")
+    assert group_details["service_accounts"] == set(["service@a.co"])
+
+    # Grant a permission to the service account and check it in the graph.
+    grant_permission_to_service_account(session, service_account, permissions["team-sre"], "*")
+    graph.update_from_db(session)
+    user_details = graph.get_user_details("service@a.co")
+    assert user_details["permissions"][0]["permission"] == "team-sre"
+    assert user_details["permissions"][0]["argument"] == "*"
+
+    # Diabling the service account should remove the link to the group.
+    disable_service_account(session, user, service_account)
+    assert service_account.user.enabled == False
+    assert group.my_service_accounts() == []
+
+    # The user should also be gone from the graph and have its permissions removed.
+    graph.update_from_db(session)
+    group_details = graph.get_group_details("team-sre")
+    assert "service_accounts" not in group_details
+    metadata = graph.user_metadata["service@a.co"]
+    assert not metadata["enabled"]
+    assert "owner" not in metadata["service_account"]
+    user_details = graph.get_user_details("service@a.co")
+    assert user_details["permissions"] == []
+
+    # We can re-enable and attach to a different group.
+    new_group = groups["security-team"]
+    enable_service_account(session, user, service_account, new_group)
+    assert service_account.user.enabled == True
+    assert group.my_service_accounts() == []
+    service_accounts = new_group.my_service_accounts()
+    assert len(service_accounts) == 1
+    assert service_accounts[0].user.name == "service@a.co"
+
+    # Check that this is reflected in the graph and the user has no permissions.
+    graph.update_from_db(session)
+    group_details = graph.get_group_details("security-team")
+    assert group_details["service_accounts"] == set(["service@a.co"])
+    metadata = graph.user_metadata["service@a.co"]
+    assert metadata["service_account"]["owner"] == "security-team"
+    user_details = graph.get_user_details("service@a.co")
+    assert user_details["permissions"] == []
+
+
+@pytest.mark.gen_test
+def test_service_account_fe_disable(session, graph, users, groups, http_client, base_url):
+    admin = "tyleromeara@a.co"
+    owner = "oliver@a.co"
+    plebe = "gary@a.co"
+    user = users["oliver@a.co"]
+
+    # Add a service account to the security-team group.
+    group = groups["security-team"]
+    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
+
+    # Unrelated people cannot disable the service account.
+    fe_url = url(base_url, "/groups/security-team/service/service@a.co/disable")
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST",
+                headers={"X-Grouper-User": plebe}, body=urlencode({}))
+
+    # Group members can disable the service account.
+    resp = yield http_client.fetch(fe_url, method="POST",
+            headers={"X-Grouper-User": owner}, body=urlencode({}))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert not metadata["enabled"]
+    group_details = graph.get_group_details("security-team")
+    assert "service_accounts" not in group_details
+
+    # The group owner cannot enable the account, since the group ownership has been lost
+    fe_url = url(base_url, "/service/service@a.co/enable")
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST",
+                headers={"X-Grouper-User": owner}, body=urlencode({"owner": "security-team"}))
+
+    # A global admin can enable the account.
+    resp = yield http_client.fetch(fe_url, method="POST",
+            headers={"X-Grouper-User": admin}, body=urlencode({"owner": "security-team"}))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert metadata["enabled"]
+    assert metadata["service_account"]["owner"] == "security-team"
+    group_details = graph.get_group_details("security-team")
+    assert group_details["service_accounts"] == set(["service@a.co"])
+
+    # And can also disable the account even though they're not a member of the group.
+    fe_url = url(base_url, "/groups/security-team/service/service@a.co/disable")
+    resp = yield http_client.fetch(fe_url, method="POST",
+            headers={"X-Grouper-User": admin}, body=urlencode({}))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert not metadata["enabled"]
+
+
+@pytest.mark.gen_test
+def test_service_account_fe_edit(session, graph, users, groups, http_client, base_url):
+    admin = "tyleromeara@a.co"
+    owner = "oliver@a.co"
+    plebe = "gary@a.co"
+    user = users["oliver@a.co"]
+
+    # Create a service account.
+    group = groups["security-team"]
+    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
+
+    # Unrelated people cannot edit the service account.
+    fe_url = url(base_url, "/groups/security-team/service/service@a.co/edit")
+    update = {
+        "description": "desc",
+        "machine_set": "machines",
+    }
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST",
+                headers={"X-Grouper-User": plebe}, body=urlencode(update))
+
+    # A group member can.
+    resp = yield http_client.fetch(fe_url, method="POST",
+                headers={"X-Grouper-User": owner}, body=urlencode(update))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert metadata["service_account"]["description"] == "desc"
+    assert metadata["service_account"]["machine_set"] == "machines"
+
+    # A user admin also can.
+    update["description"] = "done by admin"
+    resp = yield http_client.fetch(fe_url, method="POST",
+                headers={"X-Grouper-User": owner}, body=urlencode(update))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.user_metadata["service@a.co"]
+    assert metadata["service_account"]["description"] == "done by admin"
+
+
+@pytest.mark.gen_test
+def test_service_account_fe_perms(session, graph, users, groups, http_client, base_url):
+    admin = "tyleromeara@a.co"
+    owner = "zay@a.co"
+    plebe = "oliver@a.co"
+    user = users["zay@a.co"]
+
+    # Create a service account.
+    group = groups["team-sre"]
+    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
+
+    # Unrelated people cannot grant a permission.
+    fe_url = url(base_url, "/groups/team-sre/service/service@a.co/grant")
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": plebe},
+                body=urlencode({"permission": "team-sre", "argument": "*"}))
+
+    # Even group owners cannot grant an unrelated permission.
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": owner},
+            body=urlencode({"permission": "other-perm", "argument": "*"}))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.get_user_details("service@a.co")
+    assert metadata["permissions"] == []
+
+    # Group owners can delegate a team permission.
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": owner},
+            body=urlencode({"permission": "team-sre", "argument": "*"}))
+    assert resp.code == 200
+
+    # Global user admins still cannot grant an unrelated permission.
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": admin},
+            body=urlencode({"permission": "other-perm", "argument": "*"}))
+    assert resp.code == 200
+    graph.update_from_db(session)
+    metadata = graph.get_user_details("service@a.co")
+    assert len(metadata["permissions"]) == 1
+
+    # But can delegate a team permission.
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": admin},
+            body=urlencode({"permission": "ssh", "argument": "*"}))
+    assert resp.code == 200
+
+    # Check that the permissions are reflected in the graph.
+    graph.update_from_db(session)
+    metadata = graph.get_user_details("service@a.co")
+    assert metadata["permissions"][0]["permission"] == "team-sre"
+    assert metadata["permissions"][0]["argument"] == "*"
+    assert metadata["permissions"][1]["permission"] == "ssh"
+    assert metadata["permissions"][1]["argument"] == "*"
+
+    # Find the mapping IDs of the two permissions.
+    permissions = ServiceAccountPermissionMap.permissions_for(session, service_account)
+
+    # Unrelated people cannot revoke a permission.
+    fe_url = url(base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(
+        permissions[0].mapping_id))
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": plebe},
+                body=urlencode({}))
+
+    # But the group owner and a global admin can.
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": admin},
+            body=urlencode({}))
+    assert resp.code == 200
+    fe_url = url(base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(
+        permissions[1].mapping_id))
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": owner},
+            body=urlencode({}))
+    assert resp.code == 200
+
+    # This should have removed all the permissions.
+    graph.update_from_db(session)
+    metadata = graph.get_user_details("service@a.co")
+    assert metadata["permissions"] == []

--- a/tests/test_service_accounts.py
+++ b/tests/test_service_accounts.py
@@ -10,6 +10,7 @@ from fixtures import graph, groups, permissions, session, standard_graph, users 
 from grouper.constants import USER_ADMIN
 from grouper.models.base.session import Session
 from grouper.models.permission import Permission
+from grouper.models.service_account import ServiceAccount
 from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.permissions import grant_permission_to_service_account
 from grouper.service_account import (
@@ -23,33 +24,30 @@ from url_util import url
 from util import grant_permission
 
 
-def test_service_accounts(standard_graph, session, users, groups, permissions):
+def test_service_accounts(session, standard_graph, users, groups, permissions):
     graph = standard_graph
-    user = users["zorkian@a.co"]
-    group = groups["team-sre"]
 
     # Create a service account.
-    service_account = create_service_account(session, user, "service@a.co", "some service account",
-        "some machines", group)
+    service_account = ServiceAccount.get(session, name="service@a.co")
     assert service_account.description == "some service account"
     assert service_account.machine_set == "some machines"
     assert service_account.user.name == "service@a.co"
     assert service_account.user.enabled == True
     assert service_account.user.is_service_account == True
-    service_accounts = group.my_service_accounts()
+    service_accounts = groups["team-sre"].my_service_accounts()
     assert len(service_accounts) == 1
     assert service_accounts[0].user.name == "service@a.co"
     assert is_service_account(session, service_account.user)
-    session.commit()
 
     # Duplicates should raise an exception.
     with pytest.raises(IntegrityError):
-        create_service_account(session, user, "service@a.co", "dup", "dup", group)
+        create_service_account(
+            session, users["zay@a.co"], "service@a.co", "dup", "dup", groups["team-sre"])
     session.rollback()
 
     # zorkian should be able to manage the account, as should gary, but oliver (not a member of the
     # group) should not.
-    assert can_manage_service_account(session, service_account, user)
+    assert can_manage_service_account(session, service_account, users["zorkian@a.co"])
     assert can_manage_service_account(session, service_account, users["gary@a.co"])
     assert not can_manage_service_account(session, service_account, users["oliver@a.co"])
 
@@ -61,7 +59,7 @@ def test_service_accounts(standard_graph, session, users, groups, permissions):
     assert metadata["service_account"]["machine_set"] == "some machines"
     assert metadata["service_account"]["owner"] == "team-sre"
     group_details = graph.get_group_details("team-sre")
-    assert group_details["service_accounts"] == set(["service@a.co"])
+    assert group_details["service_accounts"] == ["service@a.co"]
 
     # Grant a permission to the service account and check it in the graph.
     grant_permission_to_service_account(session, service_account, permissions["team-sre"], "*")
@@ -71,9 +69,9 @@ def test_service_accounts(standard_graph, session, users, groups, permissions):
     assert user_details["permissions"][0]["argument"] == "*"
 
     # Diabling the service account should remove the link to the group.
-    disable_service_account(session, user, service_account)
+    disable_service_account(session, users["zorkian@a.co"], service_account)
     assert service_account.user.enabled == False
-    assert group.my_service_accounts() == []
+    assert groups["team-sre"].my_service_accounts() == []
 
     # The user should also be gone from the graph and have its permissions removed.
     graph.update_from_db(session)
@@ -87,9 +85,9 @@ def test_service_accounts(standard_graph, session, users, groups, permissions):
 
     # We can re-enable and attach to a different group.
     new_group = groups["security-team"]
-    enable_service_account(session, user, service_account, new_group)
+    enable_service_account(session, users["zorkian@a.co"], service_account, new_group)
     assert service_account.user.enabled == True
-    assert group.my_service_accounts() == []
+    assert groups["team-sre"].my_service_accounts() == []
     service_accounts = new_group.my_service_accounts()
     assert len(service_accounts) == 1
     assert service_accounts[0].user.name == "service@a.co"
@@ -97,7 +95,7 @@ def test_service_accounts(standard_graph, session, users, groups, permissions):
     # Check that this is reflected in the graph and the user has no permissions.
     graph.update_from_db(session)
     group_details = graph.get_group_details("security-team")
-    assert group_details["service_accounts"] == set(["service@a.co"])
+    assert group_details["service_accounts"] == ["service@a.co"]
     metadata = graph.user_metadata["service@a.co"]
     assert metadata["service_account"]["owner"] == "security-team"
     user_details = graph.get_user_details("service@a.co")
@@ -105,15 +103,11 @@ def test_service_accounts(standard_graph, session, users, groups, permissions):
 
 
 @pytest.mark.gen_test
-def test_service_account_fe_disable(session, graph, users, groups, http_client, base_url):
+def test_service_account_fe_disable(session, standard_graph, http_client, base_url):
+    graph = standard_graph
     admin = "tyleromeara@a.co"
-    owner = "oliver@a.co"
-    plebe = "gary@a.co"
-    user = users["oliver@a.co"]
-
-    # Add a service account to the security-team group.
-    group = groups["security-team"]
-    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
+    owner = "gary@a.co"
+    plebe = "oliver@a.co"
 
     # Unrelated people cannot disable the service account.
     fe_url = url(base_url, "/groups/security-team/service/service@a.co/disable")
@@ -128,25 +122,25 @@ def test_service_account_fe_disable(session, graph, users, groups, http_client, 
     graph.update_from_db(session)
     metadata = graph.user_metadata["service@a.co"]
     assert not metadata["enabled"]
-    group_details = graph.get_group_details("security-team")
+    group_details = graph.get_group_details("team-sre")
     assert "service_accounts" not in group_details
 
     # The group owner cannot enable the account, since the group ownership has been lost
     fe_url = url(base_url, "/service/service@a.co/enable")
     with pytest.raises(HTTPError):
         yield http_client.fetch(fe_url, method="POST",
-                headers={"X-Grouper-User": owner}, body=urlencode({"owner": "security-team"}))
+                headers={"X-Grouper-User": owner}, body=urlencode({"owner": "team-sre"}))
 
     # A global admin can enable the account.
     resp = yield http_client.fetch(fe_url, method="POST",
-            headers={"X-Grouper-User": admin}, body=urlencode({"owner": "security-team"}))
+            headers={"X-Grouper-User": admin}, body=urlencode({"owner": "team-sre"}))
     assert resp.code == 200
     graph.update_from_db(session)
     metadata = graph.user_metadata["service@a.co"]
     assert metadata["enabled"]
-    assert metadata["service_account"]["owner"] == "security-team"
-    group_details = graph.get_group_details("security-team")
-    assert group_details["service_accounts"] == set(["service@a.co"])
+    assert metadata["service_account"]["owner"] == "team-sre"
+    group_details = graph.get_group_details("team-sre")
+    assert group_details["service_accounts"] == ["service@a.co"]
 
     # And can also disable the account even though they're not a member of the group.
     fe_url = url(base_url, "/groups/security-team/service/service@a.co/disable")
@@ -159,15 +153,11 @@ def test_service_account_fe_disable(session, graph, users, groups, http_client, 
 
 
 @pytest.mark.gen_test
-def test_service_account_fe_edit(session, graph, users, groups, http_client, base_url):
+def test_service_account_fe_edit(session, standard_graph, http_client, base_url):
+    graph = standard_graph
     admin = "tyleromeara@a.co"
-    owner = "oliver@a.co"
-    plebe = "gary@a.co"
-    user = users["oliver@a.co"]
-
-    # Create a service account.
-    group = groups["security-team"]
-    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
+    owner = "gary@a.co"
+    plebe = "oliver@a.co"
 
     # Unrelated people cannot edit the service account.
     fe_url = url(base_url, "/groups/security-team/service/service@a.co/edit")
@@ -199,15 +189,11 @@ def test_service_account_fe_edit(session, graph, users, groups, http_client, bas
 
 
 @pytest.mark.gen_test
-def test_service_account_fe_perms(session, graph, users, groups, http_client, base_url):
+def test_service_account_fe_perms(session, standard_graph, http_client, base_url):
+    graph = standard_graph
     admin = "tyleromeara@a.co"
     owner = "zay@a.co"
     plebe = "oliver@a.co"
-    user = users["zay@a.co"]
-
-    # Create a service account.
-    group = groups["team-sre"]
-    service_account = create_service_account(session, user, "service@a.co", "foo", "bar", group)
 
     # Unrelated people cannot grant a permission.
     fe_url = url(base_url, "/groups/team-sre/service/service@a.co/grant")
@@ -250,6 +236,7 @@ def test_service_account_fe_perms(session, graph, users, groups, http_client, ba
     assert metadata["permissions"][1]["argument"] == "*"
 
     # Find the mapping IDs of the two permissions.
+    service_account = ServiceAccount.get(session, name="service@a.co")
     permissions = ServiceAccountPermissionMap.permissions_for(session, service_account)
 
     # Unrelated people cannot revoke a permission.

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -106,7 +106,7 @@ def test_graph_disable(session, graph, users, groups, user_admin_perm_to_auditor
         http_client, base_url):
     graph.update_from_db(session)
     old_users = graph.users
-    assert sorted(old_users) == sorted(users.keys())
+    assert sorted(old_users) == sorted(users.keys() + ["service@a.co"])
 
     # disable a user
     username = u"oliver@a.co"

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -67,6 +67,16 @@ def test_usertokens(standard_graph, session, users, groups, permissions):  # noq
     assert tok.check_secret(secret) == False
 
 
+@pytest.fixture
+def user_admin_perm_to_auditors(session, groups):
+    """Adds a USER_ADMIN permission to the "auditors" group"""
+    user_admin_perm, is_new = Permission.get_or_create(session, name=USER_ADMIN,
+        description="grouper.admin.users permission")
+    session.commit()
+
+    grant_permission(groups["auditors"], user_admin_perm)
+
+
 @pytest.mark.gen_test
 def test_user_tok_acls(session, graph, users, user_admin_perm_to_auditors, http_client, base_url):
     role_user = "role@a.co"
@@ -89,17 +99,6 @@ def test_user_tok_acls(session, graph, users, user_admin_perm_to_auditors, http_
         # admin creating token for normal (non-role) user
         resp = yield http_client.fetch(fe_url, method="POST",
                 headers={"X-Grouper-User": admin}, body=urlencode({"name": "foo3"}))
-
-
-
-@pytest.fixture
-def user_admin_perm_to_auditors(session, groups):
-    """Adds a USER_ADMIN permission to the "auditors" group"""
-    user_admin_perm, is_new = Permission.get_or_create(session, name=USER_ADMIN,
-        description="grouper.admin.users permission")
-    session.commit()
-
-    grant_permission(groups["auditors"], user_admin_perm)
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
This adds a new type of service account, distinct from the role user
implementation, represented by a ServiceAccount object owned by a
Group.  These accounts use a different permission and management model:
all members of the owning group can manage the service account, and
the service account only has permissions directly granted to it.  Those
permissions must be held by the group that owns the service account.

Users now have a new service_account key in their metadata in the graph
that contains the service account metadata (description, machine set,
and owner).

Removal of permissions from the service account when they're removed
from the owning group is not yet implemented.

Deployment will require a database migration to add several new tables
and the new is_service_account column on the users table.