### PR TITLE
Uncaught exceptions in the background thread exit the process

### DIFF
--- a/grouper/background.py
+++ b/grouper/background.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 from datetime import datetime, timedelta
 import logging
+import thread
 from threading import Thread
 from time import sleep
 
@@ -147,6 +148,8 @@ class BackgroundThread(Thread):
                 stats.set_gauge("successful-background-update", 0)
                 stats.set_gauge("failed-background-update", 1)
                 self.capture_exception()
+                self.logger.exception("Unexpected exception occurred in background thread.")
+                thread.interrupt_main()
                 raise
 
             sleep(60)


### PR DESCRIPTION
Currently, non-database related exceptions in the background thread are
reraised, terminating the background thread. This is nonideal as
temporal errors can result in the background thread ceasing to run,
requiring a server restart. This change adds logging for all unexpected
exceptions in the background thread and then raises a KeyboardInterrupt
on the main thread, causing the process to exit. This prevents the main
thread from serving requests that could be based on outdated or corrupt
information, as well as automating part of the oncall response.

Signed-off-by: Tyler O'Meara <tomeara@quora.com>