### PR TITLE
Support for multiple plugin/oneoff directories

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -50,7 +50,7 @@ def main(args, sentry_client):
     logging.info("begin. log_level={}".format(log_level))
 
     try:
-        load_plugins(settings.plugin_dir, settings.plugin_module_paths, service_name="grouper_api")
+        load_plugins(settings.plugin_dirs, settings.plugin_module_paths, service_name="grouper_api")
     except PluginsDirectoryDoesNotExist as e:
         logging.fatal("Plugin directory does not exist: {}".format(e))
         sys.exit(1)

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -56,7 +56,7 @@ def main(args, sentry_client):
             "debug mode does not support multiple processes"
 
     try:
-        load_plugins(settings.plugin_dir, settings.plugin_module_paths, service_name="grouper_fe")
+        load_plugins(settings.plugin_dirs, settings.plugin_module_paths, service_name="grouper_fe")
     except PluginsDirectoryDoesNotExist as e:
         logging.fatal("Plugin directory does not exist: {}".format(e))
         sys.exit(1)

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -17,19 +17,20 @@ common:
     # Type: str
     log_format: "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
 
-    # Directory for plugins. If set, load plugins from this directory. Plugins can affect the
+    # Directories for plugins. If set, load plugins from these directories. Plugins can affect the
     # behavior of Grouper.
-    # Type: str
-    plugin_dir: ""
+    # Type: list of str
+    plugin_dirs: []
 
     # Module paths for plugins to load from.
     # Type: list of str
     plugin_module_paths:
     - plugins.group_ownership_policy
 
-    # Directory for one-offs. If set, load oneoffs from this directory which
+    # Directories for one-offs. If set, load oneoffs from these directories which
     # are run via grouper-ctl.
-    oneoff_dir: ""
+    # Type: list of str
+    oneoff_dirs: []
 
     # Name of permissions for which we restrict ownership calculations to
     # exclude wildcard ownership if any non-wildcard owners are avaiable.

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -54,8 +54,7 @@ def main(sys_argv=sys.argv, start_config_thread=True):
     log_level = get_loglevel(args)
     logging.basicConfig(level=log_level, format=settings.log_format)
 
-    if settings.plugin_dir:
-        load_plugins(settings.plugin_dir, settings.plugin_module_paths, service_name="grouper-ctl")
+    load_plugins(settings.plugin_dirs, settings.plugin_module_paths, service_name="grouper-ctl")
 
     if log_level < 0:
         sa_log.setLevel(logging.INFO)

--- a/grouper/ctl/oneoff.py
+++ b/grouper/ctl/oneoff.py
@@ -56,7 +56,7 @@ def key_value_arg_type(arg):
 def oneoff_command(args):
     session = make_session()
 
-    oneoffs = Annex(BaseOneOff, [settings["oneoff_dir"]], raise_exceptions=True)
+    oneoffs = Annex(BaseOneOff, settings.oneoff_dirs, raise_exceptions=True)
     for oneoff in oneoffs:
         oneoff.configure(service_name="grouper-ctl")
 

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -35,6 +35,13 @@ class Settings(object):
         for key, value in settings.iteritems():
             key = key.lower()
 
+            # TODO(cbguder): Remove backwards compatibility for old keys
+            if key in ["plugin_dir", "oneoff_dir"]:
+                new_key = "%ss".format(key)
+                self.logger.warning("%s is deprecated, please use %s instead", key, new_key)
+                key = new_key
+                value = [value]
+
             # Limit the parts of the config file that can have an effect.
             if key not in self.settings:
                 continue
@@ -96,9 +103,9 @@ settings = Settings({
     "nonauditor_expiration_days": 5,
     "from_addr": "no-reply@grouper.local",
     "log_format": "%(asctime)-15s\t%(levelname)s\t%(message)s",
-    "oneoff_dir": None,
-    "plugin_dir": None,
-    "plugin_module_paths": None,
+    "oneoff_dirs": [],
+    "plugin_dirs": [],
+    "plugin_module_paths": [],
     "restricted_ownership_permissions": None,
     "send_emails": True,
     "sentry_dsn": None,


### PR DESCRIPTION
This deprecates `plugin_dir` and `oneoff_dir` in favor of `plugin_dirs`
and `oneoff_dirs` respectively, and prints a warning when they're used.