### PR TITLE
Call user_created plugins for role users

### DIFF
--- a/grouper/models/base/model_base.py
+++ b/grouper/models/base/model_base.py
@@ -25,8 +25,6 @@ class _Model(object):
         instance = cls(**kwargs)
         instance.add(session)
 
-        cls.just_created(instance)
-
         return instance, True
 
     def just_created(self):
@@ -34,6 +32,7 @@ class _Model(object):
 
     def add(self, session):
         session._add(self)
+        self.just_created()
         return self
 
     def delete(self, session):

--- a/grouper/models/user.py
+++ b/grouper/models/user.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
@@ -9,6 +11,10 @@ from grouper.models.base.model_base import Model
 from grouper.models.comment import CommentObjectMixin
 from grouper.models.counter import Counter
 from grouper.plugin import get_plugins
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Tuple  # noqa
+    from grouper.models.session import Session  # noqa
 
 
 class User(Model, CommentObjectMixin):
@@ -23,18 +29,22 @@ class User(Model, CommentObjectMixin):
 
     @hybrid_property
     def name(self):
+        # type: () -> str
         return self.username
 
     @property
     def type(self):
+        # type: () -> str
         return "User"
 
     def __repr__(self):
+        # type: () -> str
         return "<%s: id=%s username=%s>" % (
             type(self).__name__, self.id, self.username)
 
     @staticmethod
     def get(session, pk=None, name=None):
+        # type: (Session, Optional[int], Optional[str]) -> Optional[User]
         if pk is not None:
             return session.query(User).filter_by(id=pk).scalar()
         if name is not None:
@@ -42,15 +52,22 @@ class User(Model, CommentObjectMixin):
         return None
 
     def just_created(self):
+        # type: () -> None
+        """Call the user_created plugin on new User creation."""
+        # This is a little weird because the default value of the column isn't applied in the
+        # object at the time this is called, so role_user may be None instead of False.
+        is_service_account = self.role_user is not None and self.role_user
         for plugin in get_plugins():
-            plugin.user_created(self)
+            plugin.user_created(self, is_service_account)
 
     def add(self, session):
+        # type: (Session) -> User
         super(User, self).add(session)
         Counter.incr(session, "updates")
         return self
 
     def is_member(self, members):
+        # type: (Iterable[Tuple[str, str]]) -> bool
         return ("User", self.name) in members
 
     def set_metadata(self, key, value):

--- a/grouper/plugin.py
+++ b/grouper/plugin.py
@@ -88,8 +88,8 @@ class PluginRejectedDisablingUser(PluginException):
 
 
 class BasePlugin(object):
-    def user_created(self, user):
-        # type: (User) -> None
+    def user_created(self, user, is_service_account=False):
+        # type: (User, bool) -> None
         """Called when a new user is created
 
         When new users enter into Grouper, you might have reason to set metadata on those
@@ -97,6 +97,7 @@ class BasePlugin(object):
 
         Args:
             user: Object of new user.
+            is_service_account: Whether this user is a service account (role user)
 
         Returns:
             The return code of this method is ignored.


### PR DESCRIPTION
user_created() plugin methods were only called for regular user
creation, not role user creation, essentially by accident.  The
just_created() method was only plugged into get_or_create() model
methods but not add().  Move it to add() so that it's always
called.

Provide an additional argument to the user_created() plugin method
flagging whether or not this is a service account (role user).