### PR TITLE
Add plugin support for verifying machine_set

### DIFF
--- a/grouper/fe/handlers/service_account_create.py
+++ b/grouper/fe/handlers/service_account_create.py
@@ -4,7 +4,7 @@ from grouper.fe.forms import ServiceAccountCreateForm
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
-from grouper.service_account import create_service_account, DuplicateServiceAccount
+from grouper.service_account import BadMachineSet, create_service_account, DuplicateServiceAccount
 
 
 class ServiceAccountCreate(GrouperHandler):
@@ -24,7 +24,6 @@ class ServiceAccountCreate(GrouperHandler):
             self.request.arguments["name"][0] += "@" + settings.service_account_email_domain
 
         form = ServiceAccountCreateForm(self.request.arguments)
-
         if not form.validate():
             return self.render(
                 "service-account-create.html", form=form, group=group,
@@ -35,7 +34,7 @@ class ServiceAccountCreate(GrouperHandler):
             form.name.errors.append("All service accounts must have a username ending in {}"
                 .format(settings.service_account_email_domain))
             return self.render(
-                "service-account-create.html", form=form,
+                "service-account-create.html", form=form, group=group,
                 alerts=self.get_form_alerts(form.errors)
             )
 
@@ -44,8 +43,13 @@ class ServiceAccountCreate(GrouperHandler):
                 form.data["description"], form.data["machine_set"], group)
         except DuplicateServiceAccount:
             form.name.errors.append("A user with name {} already exists".format(form.data["name"]))
+        except BadMachineSet as e:
+            form.machine_set.errors.append(str(e))
+
+        if form.name.errors or form.machine_set.errors:
             return self.render(
-                "service-account-create.html", form=form, alerts=self.get_form_alerts(form.errors)
+                "service-account-create.html", form=form, group=group,
+                alerts=self.get_form_alerts(form.errors)
             )
 
         url = "/groups/{}/service/{}?refresh=yes".format(group.name, form.data["name"])

--- a/grouper/models/service_account.py
+++ b/grouper/models/service_account.py
@@ -7,6 +7,11 @@ from grouper.models.counter import Counter
 from grouper.models.user import User
 
 
+class MachineSetInvalid(Exception):
+    """A plugin rejected the machine set for this service acccount."""
+    pass
+
+
 class ServiceAccount(Model):
     """Represents a group-owned service account.
 

--- a/grouper/plugin.py
+++ b/grouper/plugin.py
@@ -87,6 +87,11 @@ class PluginRejectedDisablingUser(PluginException):
     pass
 
 
+class PluginRejectedMachineSet(PluginException):
+    """A plugin rejected a machine set for a service account."""
+    pass
+
+
 class BasePlugin(object):
     def user_created(self, user, is_service_account=False):
         # type: (User, bool) -> None
@@ -187,5 +192,19 @@ class BasePlugin(object):
 
         Raises:
             PluginRejectedDisablingUser: if the plugin rejects the change
+        """
+        pass
+
+    def check_machine_set(self, name, machine_set):
+        # type: (str, str) -> None
+        """Check whether a service account machine set is valid.
+
+        Args:
+            name: Name of the service account being changed
+            machine_set: New machine set for a service account
+
+        Raises:
+            PluginRejectedMachineSet to reject the change.  The exception message will be shown to
+            the user.
         """
         pass


### PR DESCRIPTION
New service accounts and edited service accounts will now run their
machine set through a plugin function, if defined, and give it the
opportunity to reject that machine set with an exception.