### PR TITLE
Avoid parens in test assertions

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -200,8 +200,8 @@ def test_permission_grant_to_owners(session, standard_graph, groups, grantable_p
     # make sure get_owner() respect substrings
     res = [o for o, a in get_owner_arg_list(session, perm1, "somesubstring",
             owners_by_arg_by_perm=owners_by_arg_by_perm)]
-    assert (sorted(res) == sorted([groups["all-teams"], groups["team-sre"]]),
-            "should include substring wildcard matches")
+    assert sorted(res) == sorted([groups["all-teams"], groups["team-sre"]]), \
+            "should include substring wildcard matches"
 
     res = [o for o, a in get_owner_arg_list(session, perm1, "othersubstring",
             owners_by_arg_by_perm=owners_by_arg_by_perm)]

--- a/tests/test_shells.py
+++ b/tests/test_shells.py
@@ -29,8 +29,8 @@ def test_shell(session, users, http_client, base_url):
 
         user = User.get(session, name=user.username)
 
-        assert (get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None,
-            "The user should have shell metadata")
+        assert get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None, \
+            "The user should have shell metadata"
         assert (get_user_metadata_by_key(session, user.id, 
                    USER_METADATA_SHELL_KEY).data_value == "/bin/bash")
 
@@ -42,10 +42,10 @@ def test_shell(session, users, http_client, base_url):
 
         user = User.get(session, name=user.username)
 
-        assert (get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None,
-            "The user should have shell metadata")
-        assert (get_user_metadata_by_key(session, user.id, 
-                   USER_METADATA_SHELL_KEY).data_value == "/bin/bash")
+        assert get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None, \
+            "The user should have shell metadata"
+        assert get_user_metadata_by_key(session, user.id,
+                                        USER_METADATA_SHELL_KEY).data_value == "/bin/bash"
 
         fe_url = url(base_url, '/users/{}/shell'.format(user.username))
         resp = yield http_client.fetch(fe_url, method="POST",
@@ -55,7 +55,7 @@ def test_shell(session, users, http_client, base_url):
 
         user = User.get(session, name=user.username)
 
-        assert (get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None,
-            "The user should have shell metadata")
+        assert get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None, \
+            "The user should have shell metadata"
         assert (get_user_metadata_by_key(session, user.id, 
                    USER_METADATA_SHELL_KEY).data_value == "/bin/zsh")


### PR DESCRIPTION
It's not safe to use parentheses to continue assertions on multiple
lines.  `assert` is a built-in, not a method call, so this passes
a tuple to `assert`, which is always true.  Remove the parentheses
and use backslash for line continuation.

Caught by py.test warnings in the Travis CI run.