### PR TITLE
Revert back to v1 XSRF cookies

### DIFF
--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -29,6 +29,7 @@ def get_application(settings, sentry_client, deployment_name):
         "static_path": os.path.join(os.path.dirname(grouper.fe.__file__), "static"),
         "debug": settings.debug,
         "xsrf_cookies": True,
+        "xsrf_cookie_version": 1,
     }
 
     my_settings = {


### PR DESCRIPTION
The bump to tornado 4.x changes the XSRF cookie format, which breaks
existing sessions since the XSRF cookie has a 30-day expiration.
Temporarily switching back to v1 cookies until we have a better
migration plan.

See also: http://www.tornadoweb.org/en/stable/releases/v3.2.2.html