### PR TITLE
Skip Selenium tests if not available

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,4 @@
 import pytest
-from selenium import webdriver
-import subprocess
-import yaml
 
 from grouper.api.routes import HANDLERS as API_HANDLERS
 from grouper.app import Application
@@ -217,60 +214,3 @@ def fe_app(session, standard_graph):
             "template_env": get_template_env(),
             }
     return Application(FE_HANDLERS, my_settings=my_settings)
-
-
-@pytest.yield_fixture
-def async_server(standard_graph, tmpdir):
-    config_path = _write_test_config(tmpdir)
-
-    cmds = [
-        [
-            src_path("bin", "grouper-ctl"),
-            "-vvc",
-            config_path,
-            "user_proxy",
-            "cbguder@a.co"
-        ],
-        [
-            src_path("bin", "grouper-fe"),
-            "-c",
-            config_path
-        ]
-    ]
-
-    subprocesses = []
-
-    for cmd in cmds:
-        p = subprocess.Popen(cmd)
-        subprocesses.append(p)
-
-    yield "http://localhost:8888"
-
-    for p in subprocesses:
-        p.kill()
-
-
-@pytest.yield_fixture
-def browser():
-    options = webdriver.ChromeOptions()
-    options.add_argument("headless")
-    options.add_argument("window-size=1920,1080")
-
-    driver = webdriver.Chrome(chrome_options=options)
-
-    yield driver
-
-    driver.quit()
-
-
-def _write_test_config(tmpdir):
-    with open(src_path("config", "dev.yaml")) as config_file:
-        config = yaml.safe_load(config_file.read())
-
-    config["common"]["database"] = db_url(tmpdir)
-
-    config_path = str(tmpdir.join("grouper.yaml"))
-    with open(config_path, "w") as config_file:
-        yaml.safe_dump(config, config_file)
-
-    return config_path

--- a/tests/fixtures_selenium.py
+++ b/tests/fixtures_selenium.py
@@ -1,0 +1,70 @@
+import subprocess
+
+import pytest
+import yaml
+
+from fixtures import standard_graph  # noqa: F401
+from path_util import db_url, src_path
+
+
+selenium = pytest.importorskip("selenium")
+
+
+def _write_test_config(tmpdir):
+    with open(src_path("config", "dev.yaml")) as config_file:
+        config = yaml.safe_load(config_file.read())
+
+    config["common"]["database"] = db_url(tmpdir)
+
+    config_path = str(tmpdir.join("grouper.yaml"))
+    with open(config_path, "w") as config_file:
+        yaml.safe_dump(config, config_file)
+
+    return config_path
+
+
+@pytest.yield_fixture
+def async_server(standard_graph, tmpdir):
+    config_path = _write_test_config(tmpdir)
+
+    cmds = [
+        [
+            src_path("bin", "grouper-ctl"),
+            "-vvc",
+            config_path,
+            "user_proxy",
+            "cbguder@a.co"
+        ],
+        [
+            src_path("bin", "grouper-fe"),
+            "-c",
+            config_path
+        ]
+    ]
+
+    subprocesses = []
+
+    for cmd in cmds:
+        p = subprocess.Popen(cmd)
+        subprocesses.append(p)
+
+    yield "http://localhost:8888"
+
+    for p in subprocesses:
+        p.kill()
+
+
+@pytest.yield_fixture
+def browser():
+    options = selenium.webdriver.ChromeOptions()
+    options.add_argument("headless")
+    options.add_argument("window-size=1920,1080")
+
+    try:
+        driver = selenium.webdriver.Chrome(chrome_options=options)
+    except selenium.common.exceptions.WebDriverException:
+        pytest.skip("could not initialize Selenium Chrome webdriver")
+
+    yield driver
+
+    driver.quit()

--- a/tests/test_fe_audits.py
+++ b/tests/test_fe_audits.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 
 from fixtures import graph, groups, permissions, session, standard_graph, users  # noqa: F401
-from fixtures import async_server, browser  # noqa: F401
 from fixtures import fe_app as app  # noqa: F401
+from fixtures_selenium import async_server, browser  # noqa: F401
 from pages import AuditsCreatePage, GroupViewPage
 from plugins import group_ownership_policy
 from url_util import url

--- a/tests/test_fe_groups.py
+++ b/tests/test_fe_groups.py
@@ -1,8 +1,8 @@
 import pytest
 
 from fixtures import graph, groups, permissions, session, standard_graph, users  # noqa: F401
-from fixtures import async_server, browser  # noqa: F401
 from fixtures import fe_app as app  # noqa: F401
+from fixtures_selenium import async_server, browser  # noqa: F401
 from grouper.role_user import create_role_user
 from pages import (GroupEditMemberPage, GroupViewPage, GroupsViewPage, NoSuchElementException,
     RoleUserViewPage)

--- a/tests/test_fe_users.py
+++ b/tests/test_fe_users.py
@@ -1,6 +1,6 @@
 from fixtures import graph, groups, permissions, session, standard_graph, users  # noqa: F401
-from fixtures import async_server, browser  # noqa: F401
 from fixtures import fe_app as app  # noqa: F401
+from fixtures_selenium import async_server, browser  # noqa: F401
 from pages import UserViewPage
 from plugins import group_ownership_policy
 from url_util import url


### PR DESCRIPTION
If either the Python selenium module or the necessary webdriver
is not available, skip the Selenium tests.  This allows running
the test suite in integration test environments where Selenium
is not available.