### PR TITLE
Deduplicate form_field macros

### DIFF
--- a/grouper/fe/templates/forms/group-permission-request-dropdown.html
+++ b/grouper/fe/templates/forms/group-permission-request-dropdown.html
@@ -1,21 +1,4 @@
-{% macro form_field(field, label_width, field_width, help=None) -%}
-    <div class="form-group form-group-{{field.label.field_id}} {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-               {{ field.label.text }}
-               {% if help %}
-               <a data-toggle="popover" title="restricted argument set"
-                       data-content="{{ help|escape }}">
-                   <sup>?</sup>
-               </a>
-               {% endif %}
-               {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(dropdown_form.permission_name, 3, 8, class_="form-control input-permission_name") }}
 {{ form_field(dropdown_form.argument, 3, 8, class_="form-control", help=dropdown_help) }}

--- a/grouper/fe/templates/forms/role-user-create.html
+++ b/grouper/fe/templates/forms/role-user-create.html
@@ -1,19 +1,7 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
-
+{% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(form.name, 3, 8, class_="form-control") }}
 {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
 {{ form_field(form.canjoin, 3, 4, class_="form-control") }}
 
 {{ xsrf_form() }}
-

--- a/grouper/fe/templates/forms/user-password.html
+++ b/grouper/fe/templates/forms/user-password.html
@@ -1,17 +1,6 @@
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
-        <label for="{{field.label.field_id}}"
-               class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
-        </label>
-        <div class="col-sm-{{field_width}}">
-            {{ field(**kwargs) }}
-        </div>
-    </div>
-{%- endmacro %}
+{% from 'macros/ui.html' import form_field -%}
 
-
-{{ form_field(form.name, 3, 8, class_="form-control", rows=5) }}
+{{ form_field(form.name, 3, 8, class_="form-control") }}
 {{ form_field(form.password, 3, 8, class_="form-control") }}
 
 {{ xsrf_form() }}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -571,11 +571,18 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
-{% macro form_field(field, label_width, field_width) -%}
-    <div class="form-group {% if field.errors %}has-error{% endif %}">
+{% macro form_field(field, label_width, field_width, help=None) -%}
+    <div class="form-group form-group-{{field.label.field_id}} {% if field.errors %}has-error{% endif %}">
         <label for="{{field.label.field_id}}"
                class="col-sm-{{label_width}} control-label">
-            {{ field.label.text }} {% if field.flags.required %}*{% endif %}
+            {{ field.label.text }}
+            {% if help %}
+            <a data-toggle="popover" title="restricted argument set"
+                    data-content="{{ help|escape }}">
+                <sup>?</sup>
+            </a>
+            {% endif %}
+            {% if field.flags.required %}*{% endif %}
         </label>
         <div class="col-sm-{{field_width}}">
             {{ field(**kwargs) }}


### PR DESCRIPTION
There were two copies of the `form_field` macro outside of
`macros/ui.html`, and a third that had an additional parameter.
Merge all of these and get rid of duplicate code.

Remove a rows parameter for the name of a user password, which
both made no sense and wasn't being honored.