### PR TITLE
Improve tools/run-dev, clean up intentional exit

### DIFF
--- a/bin/grouper-api
+++ b/bin/grouper-api
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     try:
         main(args, sentry_client)
-    except:
+    except Exception:
         sentry_client.captureException()
     finally:
         logging.info("end")

--- a/bin/grouper-fe
+++ b/bin/grouper-fe
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
     try:
         main(args, sentry_client)
-    except:
+    except Exception:
         sentry_client.captureException()
     finally:
         logging.info("end")

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -30,26 +30,31 @@ parser.add_option(
 
 os.chdir(os.path.join(os.path.dirname(__file__), '..'))
 
+# Add the grouper directory to the Python environment.
+if "PYTHONPATH" in os.environ:
+    os.environ["PYTHONPATH"] = os.getcwd() + ":" + os.environ["PYTHONPATH"]
+else:
+    os.environ["PYTHONPATH"] = os.getcwd()
+
 # Set up a new process group, so that we can later kill the servers
 # and all of the processes they spawn.
 os.setpgrp()
 
+# Start the services.
 settings = os.environ.get("GROUPER_SETTINGS", "config/dev.yaml")
-
 cmds = [
-    "bin/grouper-ctl -vvc {} user_proxy {}".format(
-        settings,
-        options.user,
-    ),
-    "bin/grouper-fe --config={}".format(settings),
-    "bin/grouper-api --config={}".format(settings),
+    ["bin/grouper-ctl", "-vvc", settings, "user_proxy", options.user],
+    ["bin/grouper-fe", "--config={}".format(settings)],
+    ["bin/grouper-api", "--config={}".format(settings)],
 ]
-
 for cmd in cmds:
-    subprocess.Popen(cmd, shell=True)
+    subprocess.Popen(cmd)
 
+# Wait for a signal and then shut everything down.
 try:
     signal.pause()
+except KeyboardInterrupt:
+    print "Terminating development environment"
 finally:
     # Kill everything in our process group.
     os.killpg(0, signal.SIGTERM)


### PR DESCRIPTION
Pass lists into `subprocess.Popen` to avoid needing `shell=True`.
This probably doesn't matter, but there could be pathological cases
like spaces in the configuration path.

Only catch `Exception` in grouper-api and grouper-fe to avoid
printing stack traces on `sys.exit()` and other normal process exit
cases.

Print a message when shutting down the development environment.

Set PYTHONPATH automatically to reduce the number of things the
caller has to set to get the development environment to run.