### PR TITLE
Add grouper-ctl dump_sql command

### DIFF
--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING
+
+from sqlalchemy.schema import CreateTable
+
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import get_db_engine
+from grouper.settings import settings
+from grouper.util import get_database_url
+
+if TYPE_CHECKING:
+    import argparse  # noqa
+
+
+def dump_sql_command(args):
+    # type: (argparse.Namespace) -> None
+    db_engine = get_db_engine(get_database_url(settings))
+    for table in Model.metadata.sorted_tables:
+        print CreateTable(table).compile(db_engine)
+
+
+def add_parser(subparsers):
+    # type: (argparse._SubParsersAction) -> None
+    dump_sql_parser = subparsers.add_parser("dump_sql", help="Dump database schema.")
+    dump_sql_parser.set_defaults(func=dump_sql_command)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -3,14 +3,7 @@ import logging
 import sys
 
 from grouper import __version__
-from grouper.ctl import (
-        group,
-        oneoff,
-        shell,
-        sync_db,
-        user,
-        user_proxy,
-        )
+from grouper.ctl import dump_sql, group, oneoff, shell, sync_db, user, user_proxy
 from grouper.plugin import load_plugins
 from grouper.settings import default_settings_path, settings
 from grouper.util import get_loglevel
@@ -36,6 +29,7 @@ def main(sys_argv=sys.argv, start_config_thread=True):
     subparsers = parser.add_subparsers(dest="command")
 
     for subcommand_module in [
+            dump_sql,
             group,
             oneoff,
             shell,


### PR DESCRIPTION
Just walks the model and dumps the SQL to create the tables in
the configured engine.  This is enough to manually generate a
database migration with some confidence that the table SQL will be
correct, without the overhead of setting up a proper migration
management system.