### PR TITLE
Fix 500 error when updating a processed request.

### DIFF
--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -56,7 +56,7 @@ class GroupRequestUpdate(GrouperHandler):
         updates = request.my_status_updates()
 
         if not form.status.choices:
-            alerts = (Alert("info", "Request has already been processed"),)
+            alerts = [Alert("info", "Request has already been processed")]
             return self.render(
                 "group-request-update.html", group=group, request=request,
                 members=members, form=form, alerts=alerts,

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -198,7 +198,9 @@ class GrouperHandler(RequestHandler):
         context.update(kwargs)
 
         # Merge alerts
-        context["alerts"] = defaults.get("alerts", []) + kwargs.get("alerts", [])
+        context["alerts"] = []
+        context["alerts"].extend(defaults.get("alerts", []))
+        context["alerts"].extend(kwargs.get("alerts", []))
 
         self.write(self.render_template(template_name, **context))
 


### PR DESCRIPTION
Also make alert merging a little more defensive to avoid this in the
future.