### PR TITLE
Also dump table indices with dump_sql

### DIFF
--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from sqlalchemy.schema import CreateTable
+from sqlalchemy.schema import CreateIndex, CreateTable
 
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
@@ -16,6 +16,8 @@ def dump_sql_command(args):
     db_engine = get_db_engine(get_database_url(settings))
     for table in Model.metadata.sorted_tables:
         print CreateTable(table).compile(db_engine)
+        for index in table.indexes:
+            print CreateIndex(index).compile(db_engine)
 
 
 def add_parser(subparsers):


### PR DESCRIPTION
These aren't included in the table definition by default and have
to be printed out separately.