### PR TITLE
Don't call unknown method on URLError

### DIFF
--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -20,7 +20,7 @@ class ProxyHandler(UserProxyHandler):
             data = err.read()
         except urllib2.URLError as err:
             code = 503
-            headers = str(err.info())
+            headers = str(err)
             data = "503 Service Unavailable: %s\n" % err
 
         self.send_response(code)


### PR DESCRIPTION
urllib2.URLError doesn't have an info() method, which meant that
those failures weren't logged properly by user_proxy.