### PR TITLE
Allow adding the last permanent owner to a group twice

### DIFF
--- a/plugins/group_ownership_policy.py
+++ b/plugins/group_ownership_policy.py
@@ -53,7 +53,7 @@ class GroupOwnershipPolicyPlugin(BasePlugin):
             if role_idx not in OWNER_ROLE_INDICES:
                 check_permanent_owners = True
 
-        if "expiration" in updates:
+        if updates.get("expiration"):
             check_permanent_owners = True
 
         if "active" in updates and not updates["active"]:

--- a/tests/test_group_ownership_policy.py
+++ b/tests/test_group_ownership_policy.py
@@ -116,6 +116,17 @@ def test_can_always_revoke_members(get_plugins, groups, users):
     revoke_member(group, member)
 
 
+@patch("grouper.group_member.get_plugins")
+def test_can_add_owner_twice(get_plugins, session, groups, users):
+    get_plugins.return_value = [GroupOwnershipPolicyPlugin()]
+
+    group = groups["team-infra"]
+    owner = users["gary@a.co"]
+
+    add_member(group, owner, role="owner")
+    add_member(group, owner, role="owner")
+
+
 @patch("grouper.user.get_plugins")
 def test_cant_disable_last_owner(get_plugins, session, groups, users):
     get_plugins.return_value = [GroupOwnershipPolicyPlugin()]


### PR DESCRIPTION
Previously, the group ownership policy prevented re-adding (i.e. no-op)
the last permanent owner of a group.