### PR TITLE
Add one-off to check all public keys

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -37,6 +37,7 @@ common:
     # Type: list of str
     oneoff_module_paths:
     - oneoffs.refresh_public_keys
+    - oneoffs.check_public_keys
 
     # Name of permissions for which we restrict ownership calculations to
     # exclude wildcard ownership if any non-wildcard owners are avaiable.

--- a/oneoffs/check_public_keys.py
+++ b/oneoffs/check_public_keys.py
@@ -1,0 +1,28 @@
+import logging
+
+import sshpubkeys
+
+from grouper.models.public_key import PublicKey
+from grouper.oneoff import BaseOneOff
+from grouper.plugin import PluginRejectedPublicKey, get_plugins
+
+
+class CheckPublicKeys(BaseOneOff):
+    def run(self, session, dry_run=True):
+        for key in session.query(PublicKey):
+            pubkey = sshpubkeys.SSHKey(key.public_key, strict=True)
+
+            logging.info("Processing Key (id={})".format(key.id))
+
+            try:
+                pubkey.parse()
+            except sshpubkeys.InvalidKeyException as e:
+                logging.error("Invalid Key (id={}): {}".format(key.id, e.message))
+                continue
+
+            try:
+                for plugin in get_plugins():
+                    plugin.will_add_public_key(pubkey)
+            except PluginRejectedPublicKey as e:
+                logging.error("Bad Key (id={}): {}".format(key.id, e.message))
+                continue


### PR DESCRIPTION
CheckPublicKeys parses and evaluates all public keys, generating a list
of keys that no longer conform to the existing ruleset enforced by
plugins.