### PR TITLE
Skip test_bin tests if bin/* was not found

### DIFF
--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,16 +1,21 @@
 import subprocess
 
+from path_util import src_path
+
 
 def test_api():
-    out = subprocess.check_output(["bin/grouper-api", "--help"])
+    bin_path = src_path("bin", "grouper-api")
+    out = subprocess.check_output([bin_path, "--help"])
     assert out.startswith("usage: grouper-api")
 
 
 def test_ctl():
-    out = subprocess.check_output(["bin/grouper-ctl", "--help"])
+    bin_path = src_path("bin", "grouper-ctl")
+    out = subprocess.check_output([bin_path, "--help"])
     assert out.startswith("usage: grouper-ctl")
 
 
 def test_fe():
-    out = subprocess.check_output(["bin/grouper-fe", "--help"])
+    bin_path = src_path("bin", "grouper-fe")
+    out = subprocess.check_output([bin_path, "--help"])
     assert out.startswith("usage: grouper-fe")


### PR DESCRIPTION
test_bin.py assumes the tests are being run from the root of a
Marou source distribution, but when run under Bazel, the current
working directory can be somewhere else entirely.  Skip these
tests if the files can't be found in `bin/` relative to the current
working directory.  (These tests essentially just check the imports
in the `bin/*` scripts, so it's no great loss if they're skipped.)