### PR TITLE
Don't show &nbsp; as the empty description

### DIFF
--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -69,7 +69,7 @@
 <div class="row">
     <div class="col-md-6">
         <blockquote><p>
-            <em>{{group.description|default("&nbsp;", True)|escape}}</em>
+            <em>{{group.description|default("", True)|escape}}</em>
         </p></blockquote>
     </div>
     <div class="col-md-6">

--- a/grouper/fe/templates/service.html
+++ b/grouper/fe/templates/service.html
@@ -70,7 +70,7 @@
 <div class="row">
     <div class="col-md-6">
         <blockquote><p>
-            <em>{{group.description|default("&nbsp;", True)|escape}}</em>
+            <em>{{group.description|default("", True)|escape}}</em>
         </p></blockquote>
     </div>
     <div class="col-md-6">

--- a/grouper/fe/templates/tag.html
+++ b/grouper/fe/templates/tag.html
@@ -20,7 +20,7 @@
 <div class="row">
     <div class="col-md-6">
         <blockquote><p>
-            <em>{{tag.description|default("&nbsp;", True)|escape}}</em>
+            <em>{{tag.description|default("", True)|escape}}</em>
         </p></blockquote>
     </div>
 </div>


### PR DESCRIPTION
In several places, there was an attempt to use a single non-breaking
space as the display default for descriptions if there was no
description set.  However, these attributes were also HTML-escaped,
which meant Grouper showed a description of literally "&nbsp;".

Just use an empty string instead; the non-breaking space wasn't doing
any real layout work.