### PR TITLE
Increase default grouper-ctl log level to INFO

### DIFF
--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -45,7 +45,7 @@ def main(sys_argv=sys.argv, start_config_thread=True):
         settings.update_from_config(args.config)
         settings.start_config_thread(args.config)
 
-    log_level = get_loglevel(args)
+    log_level = get_loglevel(args, base=logging.INFO)
     logging.basicConfig(level=log_level, format=settings.log_format)
 
     load_plugins(settings.plugin_dirs, settings.plugin_module_paths, service_name="grouper-ctl")

--- a/grouper/util.py
+++ b/grouper/util.py
@@ -24,10 +24,12 @@ def qp_to_bool(arg):
     return arg.lower() in _TRUTHY
 
 
-def get_loglevel(args):
+def get_loglevel(args, base=None):
+    if base is None:
+        base = logging.getLogger().level
     verbose = args.verbose * 10
     quiet = args.quiet * 10
-    return logging.getLogger().level - verbose + quiet
+    return base - verbose + quiet
 
 
 def try_update(dct, update):


### PR DESCRIPTION
`grouper-ctl oneoff list` logs the list of modules at INFO level, so
if the log level isn't at least INFO, that command silently does
nothing.  Change the default log level for grouper-ctl to INFO
since it's interactive without changing the default for other
programs, by allowing `get_log_level` to take an optional base log
level.