### PR TITLE
Fix permission argument checking

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -28,7 +28,7 @@ TOKEN_FORMAT = r"^{}/{}:{}$".format(
 # Regexes for validating permission/argument names
 PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+)"
 PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+(?:\.\*)?)"
-ARGUMENT_VALIDATION = r"(?P<argument>|[\^\*\w\[\]\$=+/.:-]+)"
+ARGUMENT_VALIDATION = r"(?P<argument>|[\^\*\w\[\]\$=+/.: -]+)"
 
 # Global permission names to prevent stringly typed things
 PERMISSION_GRANT = "grouper.permission.grant"

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -206,6 +206,7 @@ class GroupPermissionRequestDropdownForm(Form):
     ])
     argument = SelectField("Argument", [
         validators.DataRequired(),
+        ValidateRegex(constants.ARGUMENT_VALIDATION),
     ])
     reason = TextAreaField("Reason", [
         validators.DataRequired(),
@@ -220,6 +221,7 @@ class GroupPermissionRequestTextForm(Form):
     ])
     argument = StringField("Argument", [
         validators.DataRequired(),
+        ValidateRegex(constants.ARGUMENT_VALIDATION),
     ])
     reason = TextAreaField("Reason", [
         validators.DataRequired(),

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -63,7 +63,8 @@ def grant_permission(session, group_id, permission_id, argument=''):
     Throws:
         AssertError if argument does not match ARGUMENT_VALIDATION regex
     """
-    assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
+    assert re.match(ARGUMENT_VALIDATION + r"$", argument), \
+        'Permission argument does not match regex.'
 
     mapping = PermissionMap(permission_id=permission_id, group_id=group_id, argument=argument)
     mapping.add(session)
@@ -87,7 +88,8 @@ def grant_permission_to_service_account(session, account, permission, argument='
     Throws:
         AssertError if argument does not match ARGUMENT_VALIDATION regex
     """
-    assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
+    assert re.match(ARGUMENT_VALIDATION + r"$", argument), \
+        'Permission argument does not match regex.'
 
     mapping = ServiceAccountPermissionMap(
         permission_id=permission.id, service_account_id=account.id, argument=argument)
@@ -116,7 +118,8 @@ def grant_permission_to_tag(session, tag_id, permission_id, argument=''):
     Returns:
         bool indicating whether the function succeeded or not
     """
-    assert re.match(ARGUMENT_VALIDATION, argument), 'Permission argument does not match regex.'
+    assert re.match(ARGUMENT_VALIDATION + r"$", argument), \
+        'Permission argument does not match regex.'
 
     try:
         mapping = TagPermissionMap(permission_id=permission_id, tag_id=tag_id, argument=argument)

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -38,6 +38,8 @@ def test_tags(session, http_client, base_url, graph):
     tag = PublicKeyTag.get(session, name="tyler_was_here")
 
     grant_permission_to_tag(session, tag.id, perm.id, "prod")
+    with pytest.raises(AssertionError):
+        grant_permission_to_tag(session, tag.id, perm.id, "question?")
 
     user = session.query(User).filter_by(username="testuser@a.co").scalar()
 


### PR DESCRIPTION
Permission argument checking was a bit of a mess.  We validated
arguments when granting permissions directly, but not when creating
a request for a permission.  The backup regex checking the argument
inside the API only checked that the argument started with a valid
string, not consisted solely of a valid string.

Add validators when requesting a permission, anchor the regex in
the assertions in the API, and add tests to ensure we're properly
validating permission arguments.

Allow spaces in permission arguments, since we were already using
them (via requested permissions).