### PR TITLE
Display service accounts like role users

### DIFF
--- a/grouper/fe/handlers/users_view.py
+++ b/grouper/fe/handlers/users_view.py
@@ -1,3 +1,5 @@
+from sqlalchemy import or_
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.user import User
 
@@ -12,12 +14,20 @@ class UsersView(GrouperHandler):
         if limit > 9000:
             limit = 9000
 
-        users = (
-            self.session.query(User)
-            .filter(User.enabled == enabled)
-            .filter(User.role_user == service)
-            .order_by(User.username)
-        )
+        if service:
+            users = self.session.query(User).filter(
+                User.enabled == enabled,
+                or_(
+                    User.role_user == True,
+                    User.is_service_account == True,
+                ),
+            ).order_by(User.username)
+        else:
+            users = self.session.query(User).filter(
+                User.enabled == enabled,
+                User.role_user == False,
+                User.is_service_account == False,
+            ).order_by(User.username)
         total = users.count()
         users = users.offset(offset).limit(limit).all()
 

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -297,11 +297,11 @@ enabled. Membership in this group is regularly reviewed.
 {% if type == None %}
 <a class="account-link" href="/{{ user.type | lower }}s/{{ user.name }}">
     <i class="fa fa-user{% if user.type.lower() == 'group' %}s{% endif %}"></i> 
-    {% if user.role_user %}
+    {% if user.role_user or user.is_service_account %}
     <i>
     {% endif %}
     {{ user.name }}
-    {% if user.role_user %}
+    {% if user.role_user or user.is_service_account %}
     (service)</i>
     {% endif %}
 </a>


### PR DESCRIPTION
Exclude service accounts from the user list by default and show
them when service accounts are selected.  Show them in italics
with the (service) marker, as with role accounts.