### PR TITLE
Add index on Comment obj_type and obj_pk

### DIFF
--- a/grouper/models/comment.py
+++ b/grouper/models/comment.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -21,6 +21,13 @@ class CommentObjectMixin(object):
 class Comment(Model):
 
     __tablename__ = "comments"
+    __table_args__ = (
+        Index(
+            "obj_idx",
+            "obj_type", "obj_pk",
+            unique=False
+        ),
+    )
 
     id = Column(Integer, primary_key=True)
 


### PR DESCRIPTION
All of our queries on this table are by the combination of obj_type
and obj_pk, so add an index.  This is currently causing 6s queries
in our production environment.