### PR TITLE
Remove "url" from FE and API settings

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -143,11 +143,6 @@ fe:
     # Type: str
     sentry_dsn:
 
-    # Url is the location of the Grouper homepage, no trailing slash. This should include a
-    # port if one is needed.
-    # Type: str
-    url: "http://127.0.0.1:8888"
-
     # A list of lists of the shells that users are allowed to select. The first argument is
     # the shell location (i.e. /bin/bash), and the second is a user readable format for the
     # shell
@@ -185,8 +180,3 @@ api:
     # Sentry DSN for logging exceptions
     # Type: str
     sentry_dsn:
-
-    # Url is the location of the Grouper homepage, no trailing slash. This should include a
-    # port if one is needed.
-    # Type: str
-    url: "http://127.0.0.1:8888"

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -7,5 +7,4 @@ settings = Settings.from_settings(base_settings, {
     "num_processes": 1,
     "port": 8990,
     "refresh_interval": 60,
-    "url": "http://127.0.0.1:8888",
 })

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -29,6 +29,5 @@ settings = FeSettings.from_settings(base_settings, {
     "shell": [["/bin/false", "Shell support in Grouper has not been setup by the administrator"]],
     "site_docs": None,
     "timezone": FeSettings.default_timezone,
-    "url": "http://127.0.0.1:8888",
     "user_auth_header": "X-Grouper-User",
 })


### PR DESCRIPTION
This should be the same value across the board, so they don't need their own copy.