### PR TITLE
Increase permission argument length in request

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -214,7 +214,7 @@ class GroupPermissionRequestDropdownForm(Form):
         "Argument",
         [
             validators.DataRequired(),
-            validators.Length(min=0, max=64),
+            validators.Length(min=0, max=constants.MAX_NAME_LENGTH),
             ValidateRegex(constants.ARGUMENT_VALIDATION),
         ],
     )
@@ -231,7 +231,7 @@ class GroupPermissionRequestTextForm(Form):
         "Argument",
         [
             validators.DataRequired(),
-            validators.Length(min=0, max=64),
+            validators.Length(min=0, max=constants.MAX_NAME_LENGTH),
             ValidateRegex(constants.ARGUMENT_VALIDATION),
         ],
     )
@@ -247,7 +247,7 @@ class PermissionRequestForm(Form):
         "Argument",
         [
             validators.DataRequired(),
-            validators.Length(min=0, max=64),
+            validators.Length(min=0, max=constants.MAX_NAME_LENGTH),
             ValidateRegex(constants.ARGUMENT_VALIDATION),
         ],
     )

--- a/grouper/models/permission_request.py
+++ b/grouper/models/permission_request.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
+from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.base.model_base import Model
 from grouper.settings import settings
@@ -22,7 +23,7 @@ class PermissionRequest(Model):
 
     permission_id = Column(Integer, ForeignKey("permissions.id"), nullable=False)
     permission = relationship("Permission", foreign_keys=[permission_id])
-    argument = Column(String(length=64), nullable=True)
+    argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
 
     group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
     group = relationship("Group", foreign_keys=[group_id])


### PR DESCRIPTION
Permission arguments were allowed to be MAX_NAME_LENGTH (128
characters) in the permission_map table, but the request was still
capped at 64 characters.  Make these consistent.

Add a test, although since SQLite doesn't check any column
constraints the test will never fail unless you run the test against
a MySQL database.