### PR TITLE
Do not expose whether a permission is an alias in API responses

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -55,7 +55,7 @@ def get_individual_user_info(handler, name, cutoff, service_account):
             if service_account != is_service_account:
                 raise NoSuchUser
 
-        details = handler.graph.get_user_details(name, cutoff)
+        details = handler.graph.get_user_details(name, cutoff, expose_aliases=False)
         out = {"user": {"name": name}}
         # Updates the output with the user's metadata
         try_update(out["user"], md)
@@ -232,7 +232,7 @@ class Groups(GraphHandler):
             if name not in self.graph.groups:
                 return self.notfound("Group (%s) not found." % name)
 
-            details = self.graph.get_group_details(name, cutoff)
+            details = self.graph.get_group_details(name, cutoff, expose_aliases=False)
 
             out = {"group": {"name": name}}
             try_update(out["group"], self.graph.group_metadata.get(name, {}))
@@ -254,7 +254,7 @@ class Permissions(GraphHandler):
             if name not in self.graph.permissions:
                 return self.notfound("Permission (%s) not found." % name)
 
-            details = self.graph.get_permission_details(name)
+            details = self.graph.get_permission_details(name, expose_aliases=False)
 
             out = {"permission": {"name": name}}
             try_update(out, details)

--- a/tests/test_permission_aliases.py
+++ b/tests/test_permission_aliases.py
@@ -24,13 +24,13 @@ def test_groups_aliased_permissions(mocker, session, standard_graph, http_client
     body = json.loads(resp.body)
 
     permissions = [
-        (p['permission'], p['argument'], p['alias'])
+        (p['permission'], p['argument'])
         for p in body['data']['permissions']
     ]
 
-    assert ('owner', 'sad-team', False) in permissions
-    assert ('ssh', 'owner=sad-team', True) in permissions
-    assert ('sudo', 'sad-team', True) in permissions
+    assert ('owner', 'sad-team') in permissions
+    assert ('ssh', 'owner=sad-team') in permissions
+    assert ('sudo', 'sad-team') in permissions
 
 
 @pytest.mark.gen_test
@@ -47,13 +47,13 @@ def test_users_aliased_permissions(mocker, session, standard_graph, http_client,
     body = json.loads(resp.body)
 
     permissions = [
-        (p['permission'], p['argument'], p['alias'])
+        (p['permission'], p['argument'])
         for p in body['data']['permissions']
     ]
 
-    assert ('owner', 'sad-team', False) in permissions
-    assert ('ssh', 'owner=sad-team', True) in permissions
-    assert ('sudo', 'sad-team', True) in permissions
+    assert ('owner', 'sad-team') in permissions
+    assert ('ssh', 'owner=sad-team') in permissions
+    assert ('sudo', 'sad-team') in permissions
 
 
 @pytest.mark.gen_test
@@ -70,9 +70,9 @@ def test_permissions_aliased_permissions(mocker, session, standard_graph, http_c
     body = json.loads(resp.body)
 
     permissions = [
-        (group, p['argument'], p['alias'])
+        (group, p['argument'])
         for group, g in body['data']['groups'].iteritems()
         for p in g['permissions']
     ]
 
-    assert ('sad-team', 'owner=sad-team', True) in permissions
+    assert ('sad-team', 'owner=sad-team') in permissions


### PR DESCRIPTION
This is a bad, but hopefully temporary solution to a problem that should
not exist in the first place. Old versions of Groupy break when mapped
permissions include unexpected fields, and declaring exactly what's
included in API responses is a larger (and riskier) change. This commit
can be reverted when we no longer need to support old Groupy versions.