### PR TITLE
Expiration date update for group request pages

### DIFF
--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -23,7 +23,9 @@ def _make_date_obj(input_date_obj):
     elif isinstance(input_date_obj, datetime):
         date_obj = input_date_obj
     else:
-        assert False, "input_date_obj {} is of unsupported type {}".format(input_date_obj, type(input_date_obj))
+        assert False, "input_date_obj {} is of unsupported type {}".format(
+            input_date_obj, type(input_date_obj)
+        )
 
     assert isinstance(date_obj, datetime)
 

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -15,7 +15,7 @@ def _make_date_obj(input_date_obj):
     object."""
     if isinstance(input_date_obj, float):
         date_obj = datetime.fromtimestamp(input_date_obj, UTC)
-    elif isinstance(input_date_obj, basestring):
+    elif isinstance(input_date_obj, string_types):
         try:
             date_obj = datetime.strptime(input_date_obj, "%m/%d/%Y")
         except ValueError:

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -23,7 +23,7 @@ def _make_date_obj(input_date_obj):
     elif isinstance(input_date_obj, datetime):
         date_obj = input_date_obj
     else:
-        assert False, "{}>>>{}".format(input_date_obj, type(input_date_obj))
+        assert False, "input_date_obj {} is of unsupported type {}".format(input_date_obj, type(input_date_obj))
 
     assert isinstance(date_obj, datetime)
 

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -51,7 +51,7 @@ def print_date(input_date):
     if input_date is None or input_date == "" or isinstance(input_date, Undefined):
         return ""
 
-    date_obj = _make_date_obj(date_obj)
+    date_obj = _make_date_obj(input_date)
 
     return date_obj.strftime(settings["date_format"])
 

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 from jinja2 import Environment, PackageLoader
+from jinja2.runtime import Undefined
 from pytz import UTC
 from six import string_types
 
@@ -22,7 +23,7 @@ def _make_date_obj(input_date_obj):
     elif isinstance(input_date_obj, datetime):
         date_obj = input_date_obj
     else:
-        assert False, '{}>>>{}'.format(input_date_obj, type(input_date_obj))
+        assert False, "{}>>>{}".format(input_date_obj, type(input_date_obj))
 
     assert isinstance(date_obj, datetime)
 
@@ -47,7 +48,7 @@ def print_date(input_date):
 
     Returns human readable date/time string.
     """
-    if input_date is None or input_date == '' or isinstance(input_date, Undefined):
+    if input_date is None or input_date == "" or isinstance(input_date, Undefined):
         return ""
 
     date_obj = _make_date_obj(date_obj)

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -8,16 +8,21 @@ from six import string_types
 from grouper.fe.settings import settings
 
 
-def _make_date_obj(date_obj):
+def _make_date_obj(input_date_obj):
     """Given either a datetime object, float date/time in UTC unix epoch, or
     string date/time in the form '%Y-%m-%d %H:%M:%S.%f' return a datetime
     object."""
-    if isinstance(date_obj, float):
-        date_obj = datetime.fromtimestamp(date_obj, UTC)
-
-    if isinstance(date_obj, string_types):
-        date_obj = datetime.strptime(date_obj, "%Y-%m-%d %H:%M:%S.%f")
-        date_obj = date_obj.replace(tzinfo=UTC)
+    if isinstance(input_date_obj, float):
+        date_obj = datetime.fromtimestamp(input_date_obj, UTC)
+    elif isinstance(input_date_obj, basestring):
+        try:
+            date_obj = datetime.strptime(input_date_obj, "%m/%d/%Y")
+        except ValueError:
+            date_obj = datetime.strptime(input_date_obj, "%Y-%m-%d %H:%M:%S.%f")
+    elif isinstance(input_date_obj, datetime):
+        date_obj = input_date_obj
+    else:
+        assert False, '{}>>>{}'.format(input_date_obj, type(input_date_obj))
 
     assert isinstance(date_obj, datetime)
 
@@ -32,7 +37,7 @@ def _utcnow():
     return datetime.now(UTC)
 
 
-def print_date(date_obj):
+def print_date(input_date):
     """Print a human readable date/time string that respects system
     configuration for time zone and date/time format.
 
@@ -42,12 +47,11 @@ def print_date(date_obj):
 
     Returns human readable date/time string.
     """
-    if date_obj is None:
+    if input_date is None or input_date == '' or isinstance(input_date, Undefined):
         return ""
 
     date_obj = _make_date_obj(date_obj)
 
-    date_obj = date_obj.astimezone(settings["timezone"])
     return date_obj.strftime(settings["date_format"])
 
 

--- a/grouper/fe/templates/group-request-update.html
+++ b/grouper/fe/templates/group-request-update.html
@@ -19,6 +19,7 @@
                 <th class="col-sm-2">From Status</th>
                 <th class="col-sm-2">To Status</th>
                 <th class="col-sm-2">Date</th>
+                <th class="col-sm-2">Expiration Date</th>
             </tr>
         </thead>
         <tbody>
@@ -28,6 +29,7 @@
                     <td>{{ update.from_status|default("", True) }}</td>
                     <td>{{ update.to_status }}</td>
                     <td>{{ update.change_at|print_date }}</td>
+                    <td>{{ request.changes.expiration|print_date }}</td>
                 </tr>
                 <tr>
                     <td colspan="5">

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -48,7 +48,9 @@
                         <td class="request-requester">{{ request.requester }}</td>
                         <td class="request-status">{{ request.status }}</td>
                         <td class="request-requested-at">{{ request.requested_at|print_date }}</td>
-                        <td class="request-expiration">{{ request.changes['expiration'] }}</td>
+                        {% if request.changes.get('expiration')%}
+                        <td class="request-expiration">{{ request.changes.expiration|print_date }}</td>
+                        {% endif %}
                     </tr>
                     <tr>
                         {% if current_user_role['is_approver'] %}

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -49,7 +49,7 @@
                         <td class="request-status">{{ request.status }}</td>
                         <td class="request-requested-at">{{ request.requested_at|print_date }}</td>
                         {% if request.changes.get('expiration')%}
-                        <td class="request-expiration">{{ request.changes.expiration|print_date }}</td>
+                            <td class="request-expiration">{{ request.changes.expiration|print_date }}</td>
                         {% endif %}
                     </tr>
                     <tr>

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -1,9 +1,9 @@
+from datetime import datetime
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
 from sqlalchemy.orm import relationship
 
 
 from grouper.expiration import add_expiration, cancel_expiration
-from grouper.fe.template_util import _make_date_obj, _utcnow
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.base.model_base import Model
 from grouper.models.user import User
@@ -115,10 +115,10 @@ class GroupEdge(Model):
                     # Check for and remove pending expiration notification.
                     cancel_expiration(self.session, group_name, member_name)
                 if value:
-                    expiration = _make_date_obj(value)
+                    expiration = datetime.strptime(value, "%m/%d/%Y")
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
-                    if expiration > _utcnow():
+                    if expiration > datetime.utcnow():
                         add_expiration(
                             self.session,
                             expiration,

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -4,7 +4,7 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, Sm
 from sqlalchemy.orm import relationship
 
 from grouper.expiration import add_expiration, cancel_expiration
-from grouper.fe.template_util import _make_date_obj, _utcnow
+from grouper.fe.template_util import _make_date_obj
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.base.model_base import Model
 from grouper.models.user import User
@@ -119,7 +119,7 @@ class GroupEdge(Model):
                     expiration = _make_date_obj(value)
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
-                    if expiration > _utcnow():
+                    if expiration > datetime.now(UTC):
                         add_expiration(
                             self.session,
                             expiration,

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, Sm
 from sqlalchemy.orm import relationship
 
 from grouper.expiration import add_expiration, cancel_expiration
+from grouper.fe.template_util import _make_date_obj, _utcnow
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.base.model_base import Model
 from grouper.models.user import User
@@ -115,10 +116,12 @@ class GroupEdge(Model):
                     # Check for and remove pending expiration notification.
                     cancel_expiration(self.session, group_name, member_name)
                 if value:
-                    expiration = datetime.strptime(value, "%m/%d/%Y")
+                    expiration = _make_date_obj(value)
+                    assert isinstance(expiration, datetime)
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
-                    if expiration > datetime.utcnow():
+                    if expiration > _utcnow():
+                        assert expiration > _utcnow()
                         add_expiration(
                             self.session,
                             expiration,

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -117,7 +117,6 @@ class GroupEdge(Model):
                     cancel_expiration(self.session, group_name, member_name)
                 if value:
                     expiration = _make_date_obj(value)
-                    assert isinstance(expiration, datetime)
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
                     if expiration > _utcnow():

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -120,7 +120,6 @@ class GroupEdge(Model):
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
                     if expiration > _utcnow():
-                        assert expiration > _utcnow()
                         add_expiration(
                             self.session,
                             expiration,

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
-from sqlalchemy.orm import relationship
 
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
+from sqlalchemy.orm import relationship 
 
 from grouper.expiration import add_expiration, cancel_expiration
 from grouper.models.base.constants import OBJ_TYPES_IDX

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
 from sqlalchemy.orm import relationship
 

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -3,8 +3,9 @@ from datetime import datetime
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
 from sqlalchemy.orm import relationship
 
+
 from grouper.expiration import add_expiration, cancel_expiration
-from grouper.fe.template_util import _make_date_obj
+from grouper.fe.template_util import _make_date_obj, _utcnow
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.base.model_base import Model
 from grouper.models.user import User
@@ -119,7 +120,7 @@ class GroupEdge(Model):
                     expiration = _make_date_obj(value)
                     setattr(self, key, expiration)
                     # Avoid sending notifications for expired edges.
-                    if expiration > datetime.now(UTC):
+                    if expiration > _utcnow():
                         add_expiration(
                             self.session,
                             expiration,

--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -131,7 +131,7 @@ def test_request_to_join_group(async_server, browser):  # noqa: F811
     request_row = page.find_request_row("User: cbguder@a.co")
     assert request_row.requester == "cbguder@a.co"
     assert request_row.status == "pending"
-    assert request_row.expiration == "2999-12-30 04:00 PM"
+    assert request_row.expiration == "2999-12-31 12:00 AM"
     assert request_row.role == "member"
     assert request_row.reason == "Testing"
 

--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -131,7 +131,7 @@ def test_request_to_join_group(async_server, browser):  # noqa: F811
     request_row = page.find_request_row("User: cbguder@a.co")
     assert request_row.requester == "cbguder@a.co"
     assert request_row.status == "pending"
-    assert request_row.expiration == "12/31/2999"
+    assert request_row.expiration == "2999-12-30 04:00 PM"
     assert request_row.role == "member"
     assert request_row.reason == "Testing"
 

--- a/tests/fe/util_test.py
+++ b/tests/fe/util_test.py
@@ -57,9 +57,9 @@ def test_print_date(mock_settings):
     mock_settings.__getitem__.side_effect = fake_settings_getitem
 
     for date_, expected, msg in [
-        (datetime(2015, 8, 11, 18, tzinfo=UTC), "2015-08-11 11:00 AM", "from datetime object"),
-        (datetime(2015, 8, 11, 18, 0, 10, 10, tzinfo=UTC), "2015-08-11 11:00 AM", "ignore sec/ms"),
-        ("2015-08-11 18:00:00.000", "2015-08-11 11:00 AM", "from string"),
-        (1439316000.0, "2015-08-11 11:00 AM", "from float / unix timestamp"),
+        (datetime(2015, 8, 11, 18, tzinfo=UTC), "2015-08-11 06:00 PM", "from datetime object"),
+        (datetime(2015, 8, 11, 18, 0, 10, 10, tzinfo=UTC), "2015-08-11 06:00 PM", "ignore sec/ms"),
+        ("2015-08-11 18:00:00.000", "2015-08-11 06:00 PM", "from string"),
+        (1439316000.0, "2015-08-11 06:00 PM", "from float / unix timestamp"),
     ]:
         assert print_date(date_) == expected, msg


### PR DESCRIPTION
Updating display of expiration date to be more aligned with way we represent other date fields.
- Updated template_util for date format handler
- Update the FE for displaying on group requests and individual group request action page

Tested:
- created user, request to join group
- logged in as admin, view group, view request pages, view individual request page, action
- Auto-expiry shows up when date is passed (log at the bottom of page)