### PR TITLE
permissions: Reject requests that are not grantable because of audit constraints

### DIFF
--- a/grouper/fe/handlers/group_permission_request.py
+++ b/grouper/fe/handlers/group_permission_request.py
@@ -1,6 +1,7 @@
 import json
 
 from grouper import permissions
+from grouper.audit import UserNotAuditor
 from grouper.fe.forms import GroupPermissionRequestDropdownForm, GroupPermissionRequestTextForm
 from grouper.fe.settings import settings
 from grouper.fe.util import Alert, GrouperHandler
@@ -94,6 +95,8 @@ class GroupPermissionRequest(GrouperHandler):
                     permission_name=permission.name, argument=form.argument.data)
             alerts = [Alert("danger", "No owners available for requested permission and argument."
                     " If this error persists please contact an adminstrator.")]
+        except UserNotAuditor as e:
+            alerts = [Alert("danger", str(e))]
         else:
             alerts = None
 

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -396,6 +396,7 @@ def create_request(session, user, group, permission, argument, reason):
     Raises:
         RequestAlreadyExists if trying to create a request that is already pending
         NoOwnersAvailable if no owner is available for the requested perm + arg.
+        grouper.audit.UserNotAuditor if the group has owners that are not auditors
     """
     # check if group already has perm + arg pair
     for _, existing_perm_name, _, existing_perm_argument, _ in group.my_permissions():
@@ -424,6 +425,10 @@ def create_request(session, user, group, permission, argument, reason):
 
     if not owner_arg_list:
         raise NoOwnersAvailable()
+
+    if permission.audited:
+        # will raise UserNotAuditor if any owner of the group is not an auditor
+        assert_controllers_are_auditors(group)
 
     pending_status = "pending"
     now = datetime.utcnow()


### PR DESCRIPTION
Requests for audited permissions may not be grantable if the target group has controllers that are not auditors. Surface this at request creation time by rejecting such requests upfront.