### PR TITLE
Email groups directly for permissions requests

### DIFF
--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -483,7 +483,10 @@ def create_request(session, user, group, permission, argument, reason):
         mailto_owner_arg_list = owner_arg_list
 
     for owner, arg in mailto_owner_arg_list:
-        mail_to += [u for t, u in owner.my_members() if t == 'User']
+        if owner.email_address:
+            mail_to.append(owner.email_address)
+        else:
+            mail_to.extend([u for t, u in owner.my_members() if t == 'User'])
 
     subj = get_template_env().get_template('email/pending_permission_request_subj.tmpl').render(
         permission=permission.name, group=group.name

--- a/itests/test_api_groups.py
+++ b/itests/test_api_groups.py
@@ -17,4 +17,4 @@ def test_get_group(api_client):  # noqa: F811
     assert sorted(perms) == [("audited", ""), ("ssh", "*"), ("sudo", "shell"), ("team-sre", "*")]
 
     assert group.audited
-    assert group.contacts == {"email": None}
+    assert group.contacts == {"email": "team-sre@a.co"}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -176,6 +176,9 @@ def groups(session):
                           "security-team", "auditors", "sad-team", "audited-team", "user-admins",
                           "group-admins")
     }
+    groups_with_emails = ("team-sre", "serving-team", "security-team")
+    for group in groups_with_emails:
+        groups[group].email_address = "{}@a.co".format(group)
     session.commit()
     return groups
 


### PR DESCRIPTION
Changes the email notifications for permissions requests to be sent directly to a group's email address if one is specified. Also modifies the unit tests to test the new behavior