### PR TITLE
Don't use US/Pacific-New in tests

### DIFF
--- a/tests/test_fe_util.py
+++ b/tests/test_fe_util.py
@@ -9,7 +9,7 @@ from grouper.fe.template_util import expires_when_str, long_ago_str, print_date
 
 def fake_settings_getitem(key):
     if key == "timezone":
-        return pytz.timezone('US/Pacific-New')
+        return pytz.timezone('US/Pacific')
     elif key == "date_format":
         return "%Y-%m-%d %I:%M %p"
 


### PR DESCRIPTION
This is not what it sounds like.  From the tzdata source comments:

> On 1989-04-05, the U. S. House of Representatives passed (238-154) a bill
> establishing "Pacific Presidential Election Time"; it was not acted on
> by the Senate or signed into law by the President.

It's an obsolete time zone rule that was never enacted into law, so
it's not included in some environments.  Specifically, it's not available
in the Dropbox Bazel environment, so using it for the test suite is
causing test failures.