### PR TITLE
add authorization check for service account creation

### DIFF
--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -59,6 +59,10 @@ def _check_machine_set(service_account, machine_set):
         raise BadMachineSet(str(e))
 
 
+def can_create_service_account(session, actor, group):
+    return actor.is_member(group.my_members())
+
+
 def create_service_account(session, actor, name, description, machine_set, owner):
     # type: (Session, User, str, str, str, Group) -> ServiceAccount
     """Creates a service account and its underlying user.

--- a/itests/test_fe_service_accounts.py
+++ b/itests/test_fe_service_accounts.py
@@ -12,7 +12,7 @@ from tests.url_util import url
 
 
 def test_service_account_lifecycle(async_server, browser):  # noqa: F811
-    browser.get(url(async_server, "/groups/team-sre"))
+    browser.get(url(async_server, "/groups/user-admins"))
 
     page = GroupViewPage(browser)
     page.click_add_service_account_button()
@@ -40,5 +40,5 @@ def test_service_account_lifecycle(async_server, browser):  # noqa: F811
     page.click_enable_button()
 
     page = ServiceAccountEnablePage(browser)
-    page.select_owner("Group: team-sre")
+    page.select_owner("Group: user-admins")
     page.submit()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -27,7 +27,6 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     |    * gary (o)         +---------------------------------+
     |    * zay              |                                 |
     |    * zorkian          |                                 |
-    |    * cbguder          |                                 |
     |    * service (s)      |                     +-----------v-----------+
     |                       |                     |                       |
     +-----------------------+                     |  serving-team         |
@@ -82,7 +81,6 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     Arrows denote member of the source in the destination group. (o) for
     owners, (np) for non-permissioned owners, (s) for service accounts.
     """
-    add_member(groups["team-sre"], users["cbguder@a.co"], role="owner")
     add_member(groups["team-sre"], users["gary@a.co"], role="owner")
     add_member(groups["team-sre"], users["zay@a.co"])
     add_member(groups["team-sre"], users["zorkian@a.co"])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -27,6 +27,7 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     |    * gary (o)         +---------------------------------+
     |    * zay              |                                 |
     |    * zorkian          |                                 |
+    |    * cbguder          |                                 |
     |    * service (s)      |                     +-----------v-----------+
     |                       |                     |                       |
     +-----------------------+                     |  serving-team         |
@@ -81,6 +82,7 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     Arrows denote member of the source in the destination group. (o) for
     owners, (np) for non-permissioned owners, (s) for service accounts.
     """
+    add_member(groups["team-sre"], users["cbguder@a.co"], role="owner")
     add_member(groups["team-sre"], users["gary@a.co"], role="owner")
     add_member(groups["team-sre"], users["zay@a.co"])
     add_member(groups["team-sre"], users["zorkian@a.co"])

--- a/tests/test_service_accounts.py
+++ b/tests/test_service_accounts.py
@@ -192,6 +192,17 @@ def test_service_account_fe_perms(session, standard_graph, http_client, base_url
     owner = "zay@a.co"
     plebe = "oliver@a.co"
 
+    # Unrelated people cannot create a service account
+    fe_url = url(base_url, "/groups/team-sre/service/create")
+    with pytest.raises(HTTPError):
+        yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": plebe},
+                body=urlencode({
+                    "name": "service_account", "description": "*", "machine_set": "*"}))
+    # But group members can create service accounts
+    resp = yield http_client.fetch(fe_url, method="POST", headers={"X-Grouper-User": owner},
+            body=urlencode({"name": "service_account", "description": "*", "machine_set": "*"})) 
+    assert resp.code == 200
+
     # Unrelated people cannot grant a permission.
     fe_url = url(base_url, "/groups/team-sre/service/service@a.co/grant")
     with pytest.raises(HTTPError):


### PR DESCRIPTION
Checks that the actor attempting to create a service account under a group is also a member of said group. DOES NOT allow admins to create service accounts for groups they are not a part of (is this the behavior we want?).