### PR TITLE
add delay in wait_until_accept to fix flaky itest

### DIFF
--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -126,8 +126,5 @@ def wait_until_accept(port, timeout=3.0):
                 raise
         else:
             s.close()
-            # When running in TravisCI, there seems to be a race condition causing the next
-            # connect to error with ECONNREFUSED.  This pause seems to eliminate that
-            time.sleep(0.25)
             return
-        time.sleep(0.001)
+        time.sleep(0.1)

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -130,3 +130,4 @@ def wait_until_accept(port, timeout=3.0):
             # connect to error with ECONNREFUSED.  This pause seems to eliminate that
             time.sleep(0.25)
             return
+        time.sleep(0.001)


### PR DESCRIPTION
I think this might "fix" the "connection refused" itest flakiness