### PR TITLE
add sorting to /permissions

### DIFF
--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -1,5 +1,13 @@
+from datetime import timedelta
+
 from grouper.fe.util import GrouperHandler
 from grouper.user_permissions import user_creatable_permissions
+
+
+def _round_timestamp(timestamp):
+    return timestamp - timedelta(
+        seconds=timestamp.second, microseconds=timestamp.microsecond
+    )
 
 
 class PermissionsView(GrouperHandler):
@@ -11,10 +19,30 @@ class PermissionsView(GrouperHandler):
         offset = int(self.get_argument("offset", 0))
         limit = int(self.get_argument("limit", 100))
         audited_only = bool(int(self.get_argument("audited", 0)))
+        sort_key = self.get_argument("sort_by", "")
+        sort_dir = self.get_argument("order", "")
         if limit > 9000:
             limit = 9000
 
-        permissions = self.graph.get_permissions(audited=audited_only)
+        sort_keys = {
+            "name": lambda p: p.name,
+            # round timestamps to the nearest minute so permissions created together will
+            # show up alphabetically
+            "date": lambda p: _round_timestamp(p.created_on),
+        }
+
+        if sort_key not in sort_keys:
+            sort_key = "name"
+
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "asc"
+
+        permissions = sorted(
+            self.graph.get_permissions(audited=audited_only),
+            key=sort_keys[sort_key],
+            reverse=(sort_dir == "desc")
+        )
+
         total = len(permissions)
         permissions = permissions[offset:offset + limit]
 
@@ -22,5 +50,6 @@ class PermissionsView(GrouperHandler):
 
         self.render(
             "permissions.html", permissions=permissions, offset=offset, limit=limit, total=total,
-            can_create=can_create, audited_permissions=audited_only
+            can_create=can_create, audited_permissions=audited_only,
+            sort_key=sort_key, sort_dir=sort_dir
         )

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -16,7 +16,7 @@
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
     {% if audited_permissions %}
-    <a class="btn btn-warning" href="/permissions?limit={{limit}}&audited=0">
+    <a class="btn btn-warning" href="{{update_qs(audited='0', offset='0')}}">
         <i class="fa"></i> Show all permissions
     </a>
     {% else %}
@@ -25,7 +25,7 @@
         <i class="fa fa-plus"></i> Create
     </a>
     {% endif %}
-    <a class="btn btn-warning" href="/permissions?limit={{limit}}&audited=1">
+    <a class="btn btn-warning" href="{{update_qs(audited='1', offset='0')}}">
         <i class="fa"></i> Show audited permissions only
     </a>
     {% endif %}
@@ -36,8 +36,9 @@
         <table class="table table-elist">
             <thead>
                 <tr>
-                    <th class="col-sm-2">Name</th>
+                    <th class="col-sm-2"><a href="{{update_qs(sort_by='name', order='desc' if sort_key == 'name' and sort_dir == 'asc' else 'asc', offset='0')}}" class="white">Name</a></th>
                     <th class="col-sm-5">Description</th>
+                    <th class="col-sm-2"><a href="{{update_qs(sort_by='date', order='asc' if sort_key == 'date' and sort_dir == 'desc' else 'desc', offset='0')}}" class="white">Created On</a></th>
                 </tr>
             </thead>
             <tbody>
@@ -45,6 +46,7 @@
                 <tr>
                     <td>{{ permission(perm) }}</td>
                     <td>{{ perm.description|default("", True) | escape }}</td>
+                    <td>{{ perm.created_on | print_date}}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -173,7 +173,7 @@ class GrouperHandler(RequestHandler):
     def update_qs(self, **kwargs):
         qs = self.request.arguments.copy()
         qs.update(kwargs)
-        return "?" + urllib.urlencode(qs, True)
+        return "?" + urllib.urlencode(sorted(qs.items()), True)
 
     def is_active(self, test_path):
         path = self.request.path


### PR DESCRIPTION
- useful for looking at recently created permissions
- adds a new date column to `/permissions`
- allow sorting by name or creation date
- toggleable sort direction

![image](https://user-images.githubusercontent.com/7821859/46320448-4bf4d100-c593-11e8-864f-452e70b2e26d.png)

![image](https://user-images.githubusercontent.com/7821859/46320441-41d2d280-c593-11e8-8f05-71a7fdc26f65.png)
