### PR TITLE
Provide group-id to removeUserModal for role users

### DIFF
--- a/grouper/fe/templates/service.html
+++ b/grouper/fe/templates/service.html
@@ -190,7 +190,7 @@
 </div>
 
 <div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog"
-      aria-labelledby="removeUserModal" aria-hidden="true">
+      data-group-id="{{group.id}}" aria-labelledby="removeUserModal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Broken in 44ff55e5989e4fd766dcb0c981a660b1957d39e3, which refactored
removeUserModal but didn't add the necessary data item in the role
user page (only in the group page).