### PR TITLE
Remove height from log_entry_panel on permission page

### DIFF
--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -60,7 +60,7 @@
 
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
-        {{ log_entry_panel(400, log_entries) }}
+        {{ log_entry_panel(log_entries) }}
     </div>
 </div>
 


### PR DESCRIPTION
6a863cf20647fbd1a1b9f034e223938c5a372225 removed the height parameter
but one of the callers was not updated.  Remove the height argument.