### PR TITLE
Allow those with `grouper.audit.manage` to enable/disable auditing of a permissions

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -53,7 +53,7 @@ SYSTEM_PERMISSIONS = [
     (USER_ADMIN, "Ability to to disable/enable any User account and modify its attributes."),
     (GROUP_ADMIN, "Ability to approve/deny/revoke membership to any group."),
     (AUDIT_SECURITY, "Ability to audit security related activity on the system."),
-    (AUDIT_MANAGER, "Ability to start global audits and view audit status."),
+    (AUDIT_MANAGER, "Ability to start and view global audits, and toggle if a perm is audited."),
     (AUDIT_VIEWER, "Ability to view audit results and status."),
     (USER_ENABLE, "Ability to enable a disabled user."),
     (USER_DISABLE, "Ability to disable an enabled user."),

--- a/grouper/fe/handlers/permission_disable_auditing.py
+++ b/grouper/fe/handlers/permission_disable_auditing.py
@@ -1,11 +1,13 @@
+from grouper.constants import AUDIT_MANAGER
 from grouper.fe.util import GrouperHandler
 from grouper.permissions import disable_permission_auditing, NoSuchPermission
-from grouper.user_permissions import user_is_permission_admin
+from grouper.user_permissions import user_has_permission, user_is_permission_admin
 
 
 class PermissionDisableAuditing(GrouperHandler):
     def post(self, user_id=None, name=None):
-        if not user_is_permission_admin(self.session, self.current_user):
+        if not (user_is_permission_admin(self.session, self.current_user) or
+                user_has_permission(self.session, self.current_user, AUDIT_MANAGER)):
             return self.forbidden()
 
         try:

--- a/grouper/fe/handlers/permission_enable_auditing.py
+++ b/grouper/fe/handlers/permission_enable_auditing.py
@@ -1,11 +1,13 @@
+from grouper.constants import AUDIT_MANAGER
 from grouper.fe.util import GrouperHandler
 from grouper.permissions import enable_permission_auditing, NoSuchPermission
-from grouper.user_permissions import user_is_permission_admin
+from grouper.user_permissions import user_has_permission, user_is_permission_admin
 
 
 class PermissionEnableAuditing(GrouperHandler):
     def post(self, name=None):
-        if not user_is_permission_admin(self.session, self.current_user):
+        if not (user_is_permission_admin(self.session, self.current_user) or
+                user_has_permission(self.session, self.current_user, AUDIT_MANAGER)):
             return self.forbidden()
 
         try:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,7 +2,7 @@ import pytest
 
 from grouper.api.routes import HANDLERS as API_HANDLERS
 from grouper.app import Application
-from grouper.constants import AUDIT_MANAGER, GROUP_ADMIN, PERMISSION_AUDITOR, USER_ADMIN
+from grouper.constants import AUDIT_MANAGER, AUDIT_VIEWER, GROUP_ADMIN, PERMISSION_AUDITOR, USER_ADMIN
 from grouper.fe.routes import HANDLERS as FE_HANDLERS
 from grouper.fe.template_util import get_template_env
 from grouper.graph import Graph
@@ -113,6 +113,7 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     grant_permission(groups["team-infra"], permissions["sudo"], argument="shell")
 
     add_member(groups["auditors"], users["zorkian@a.co"], role="owner")
+    grant_permission(groups["auditors"], permissions[AUDIT_VIEWER])
     grant_permission(groups["auditors"], permissions[AUDIT_MANAGER])
     grant_permission(groups["auditors"], permissions[PERMISSION_AUDITOR])
 
@@ -197,8 +198,8 @@ def service_accounts(session, users, groups):
 
 @pytest.fixture
 def permissions(session, users):
-    all_permissions = ["owner", "ssh", "sudo", "audited", AUDIT_MANAGER, PERMISSION_AUDITOR,
-                       "team-sre", USER_ADMIN, GROUP_ADMIN]
+    all_permissions = ["owner", "ssh", "sudo", "audited", AUDIT_MANAGER, AUDIT_VIEWER,
+                       PERMISSION_AUDITOR, "team-sre", USER_ADMIN, GROUP_ADMIN]
 
     permissions = {
         permission: Permission.get_or_create(

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,8 +1,10 @@
 from collections import namedtuple
 from datetime import datetime, timedelta
 from urllib import urlencode
+from grouper.constants import AUDIT_MANAGER, AUDIT_VIEWER
 
 import pytest
+from tornado.httpclient import HTTPError
 
 from fixtures import standard_graph, graph, users, groups, service_accounts, session, permissions  # noqa
 from fixtures import fe_app as app  # noqa
@@ -74,6 +76,42 @@ def test_assert_controllers_are_auditors(groups):  # noqa
     with pytest.raises(UserNotAuditor):
         assert not assert_controllers_are_auditors(groups["team-infra"])
 
+
+@pytest.mark.gen_test
+def test_toggle_perm_audited(groups, permissions, http_client, base_url):
+    perm_name = 'audited' # perm that is already audited
+    nonpriv_user_name = 'oliver@a.co' # user with no audit perms and without PERMISSION_ADMIN
+    nonpriv_user_team = 'sad-team'
+    nonpriv_headers = {'X-Grouper-User': nonpriv_user_name}
+    priv_user_name = 'zorkian@a.co' # user with AUDIT_MANAGER
+    priv_headers = {'X-Grouper-User': priv_user_name}
+    enable_url = url(base_url, '/permissions/{}/enable-auditing'.format(perm_name))
+    disable_url = url(base_url, '/permissions/{}/disable-auditing'.format(perm_name))
+
+    # Give nonpriv user audit view permissions, which shouldn't allow enabling/disabling auditing
+    grant_permission(groups[nonpriv_user_team], permissions[AUDIT_VIEWER], argument="")
+
+    # attempt to enable/disable auditing; both should fail due to lack of perms
+    with pytest.raises(HTTPError):
+        resp = yield http_client.fetch(enable_url, method="POST", headers=nonpriv_headers, body="")
+    with pytest.raises(HTTPError):
+        resp = yield http_client.fetch(disable_url, method="POST", headers=nonpriv_headers, body="")
+
+    # Now confirm that enabling/disabling auditing works as a privileged user
+    # Note that enabling audits on an audited perm succeeds (same for disabling)
+    resp = yield http_client.fetch(enable_url, method="POST", headers=priv_headers, body="")
+    assert resp.code == 200
+    # Perm is still audited
+    resp = yield http_client.fetch(disable_url, method="POST", headers=priv_headers, body="")
+    assert resp.code == 200
+    # Perm no longer audited
+    resp = yield http_client.fetch(disable_url, method="POST", headers=priv_headers, body="")
+    assert resp.code == 200
+    # Perm still not audited
+    resp = yield http_client.fetch(enable_url, method="POST", headers=priv_headers, body="")
+    assert resp.code == 200
+    # Perm audited again
+    
 
 @pytest.mark.gen_test
 def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):  # noqa

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -11,6 +11,7 @@ from fixtures import fe_app as app  # noqa
 from grouper.constants import (
         ARGUMENT_VALIDATION,
         AUDIT_MANAGER,
+        AUDIT_VIEWER,
         PERMISSION_ADMIN,
         PERMISSION_AUDITOR,
         PERMISSION_GRANT,
@@ -75,8 +76,8 @@ def test_basic_permission(standard_graph, session, users, groups, permissions): 
     assert sorted(get_user_permissions(graph, "zay@a.co")) == [
         "audited:", "ssh:*", "ssh:shell", "sudo:shell", "team-sre:*"]
     assert sorted(get_user_permissions(graph, "zorkian@a.co")) == [
-        "audited:", AUDIT_MANAGER + ":", PERMISSION_AUDITOR + ":", "owner:sad-team", "ssh:*",
-        "sudo:shell", "team-sre:*"]
+        "audited:", AUDIT_MANAGER + ":", AUDIT_VIEWER + ":", PERMISSION_AUDITOR + ":",
+        "owner:sad-team", "ssh:*", "sudo:shell", "team-sre:*"]
     assert sorted(get_user_permissions(graph, "testuser@a.co")) == []
     assert sorted(get_user_permissions(graph, "figurehead@a.co")) == [
         "sudo:shell"]


### PR DESCRIPTION
Adjusts FE handlers to accept `grouper.audit.manage` as an alternative to being a full permissions admin for enabling/disabling auditing.