### PR TITLE
grouper-ctl command to create service account

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,23 @@ Once chromedriver is installed, the tests can be run using pytest:
 
 .. code:: bash
 
+    export PYTHONPATH=$(pwd)
+    export GROUPER_SETTINGS=$(pwd)/config/dev.yaml
+
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
     py.test tests
     py.test itests
+
+If you see test failures and suspect incompatible library versions
+(e.g., an existing tornado install at a different major release than
+that in our `requirements.txt`), then you can try using a virtual
+environment.
+
+.. code:: bash
+
+    virtualenv ~/merou-venv
+    ~/merou-venv/bin/pip install -r requirements.txt
+    ~/merou-venv/bin/pip install -r requirements-dev.txt
+    ~/merou-venv/bin/py.test tests
+    ~/merou-venv/bin/py.test itests

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -3,7 +3,7 @@ import logging
 import sys
 
 from grouper import __version__
-from grouper.ctl import dump_sql, group, oneoff, shell, sync_db, user, user_proxy
+from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings
@@ -32,6 +32,7 @@ def main(sys_argv=sys.argv, start_config_thread=True):
             dump_sql,
             group,
             oneoff,
+            service_account,
             shell,
             sync_db,
             user,

--- a/grouper/ctl/service_account.py
+++ b/grouper/ctl/service_account.py
@@ -1,9 +1,9 @@
 import logging
 
 from grouper.ctl.util import ensure_valid_service_account_name, make_session
-from grouper.models.user import User
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
+from grouper.models.user import User
 from grouper.service_account import create_service_account
 
 

--- a/grouper/ctl/service_account.py
+++ b/grouper/ctl/service_account.py
@@ -1,0 +1,56 @@
+import logging
+
+from grouper.ctl.util import ensure_valid_service_account_name, make_session
+from grouper.models.user import User
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.service_account import create_service_account
+
+
+@ensure_valid_service_account_name
+def service_account_command(args):
+    session = make_session()
+    actor_user = User.get(session, name=args.actor_name)
+    if not actor_user:
+        logging.fatal("Actor user \"{}\" is not a valid Grouper user".format(args.actor_name))
+        return
+
+    if args.subcommand == "create":
+        name = args.name
+        if ServiceAccount.get(session, name=name):
+            logging.info("{}: Already exists. Doing nothing.".format(name))
+            return
+        owner_group = Group.get(session, name=args.owner_group)
+        if not owner_group:
+            logging.fatal("Owner group \"{}\" does not exist.".format(args.owner_group))
+            return
+        logging.info("{}: No such service account, creating...".format(name))
+        description = args.description
+        machine_set = args.machine_set
+        create_service_account(session, actor_user, name, description, machine_set, owner_group)
+        return
+
+
+def add_parser(subparsers):
+    service_account_parser = subparsers.add_parser(
+        "service_account", help="Edit service account")
+    service_account_parser.set_defaults(func=service_account_command)
+    service_account_subparser = service_account_parser.add_subparsers(dest="subcommand")
+
+    required_options_group = service_account_parser.add_argument_group('required named arguments')
+    required_options_group.add_argument("-a", "--actor", required=True, dest="actor_name",
+                                        help=("Name of the entity performing this action. "
+                                              "Must be a valid Grouper human or service "
+                                              "account."))
+
+    service_account_create_parser = service_account_subparser.add_parser(
+        "create", help="Create a new service account")
+    service_account_create_parser.add_argument("name",
+                                               help=("Name for the service account"))
+    service_account_create_parser.add_argument("owner_group",
+                                               help=("Name of the owner group. Must be a valid "
+                                                     "Grouper group"))
+    service_account_create_parser.add_argument("machine_set",
+                                               help=("The machine set for the service account"))
+    service_account_create_parser.add_argument("description",
+                                               help=("Description for the service account"))

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -9,7 +9,7 @@ from sys import stdout
 
 from typing import Generator  # noqa
 
-from grouper.constants import NAME_VALIDATION, USERNAME_VALIDATION
+from grouper.constants import NAME_VALIDATION, SERVICE_ACCOUNT_VALIDATION, USERNAME_VALIDATION
 from grouper.models.base.session import get_db_engine, Session
 from grouper.settings import settings
 from grouper.util import get_database_url
@@ -41,6 +41,18 @@ def ensure_valid_groupname(f):
     def wrapper(args):
         if not re.match("^{}$".format(NAME_VALIDATION), args.groupname):
             logging.error("Invalid group name {}".format(args.groupname))
+            return
+
+        return f(args)
+
+    return wrapper
+
+
+def ensure_valid_service_account_name(f):
+    @wraps(f)
+    def wrapper(args):
+        if not re.match("^{}$".format(SERVICE_ACCOUNT_VALIDATION), args.name):
+            logging.error("Invalid service account name \"{}\"".format(args.name))
             return
 
         return f(args)

--- a/tests/test_grouper_ctl_service_account.py
+++ b/tests/test_grouper_ctl_service_account.py
@@ -1,0 +1,62 @@
+from mock import patch
+import pytest
+
+from ctl_util import call_main
+from fixtures import standard_graph, graph, users, groups, session  # noqa
+from grouper.models.group import Group
+from grouper.models.service_account import ServiceAccount
+from grouper.group_service_account import get_service_accounts
+
+
+@patch('grouper.ctl.service_account.make_session')
+def test_service_account_create(make_session, session, users, groups):
+    make_session.return_value = session
+
+    machine_set = 'foo +bar -(org)'
+    description = 'this is a service account.\n\n it is for testing'
+    team_sre_group = Group.get(session, name='team-sre')
+    actor_username = 'gary@a.co'
+
+    # no-op if bad account name
+    name = 'bad'
+    assert ServiceAccount.get(session, name=name) is None
+    assert get_service_accounts(session, team_sre_group) == []
+    call_main('service_account', '--actor', actor_username, 'create',
+              name, team_sre_group.groupname, machine_set, description)
+    assert ServiceAccount.get(session, name=name) is None
+    assert get_service_accounts(session, team_sre_group) == []
+
+    # no-op if owner group doesn't exist
+    name = 'good@a.co'
+    assert ServiceAccount.get(session, name=name) is None
+    assert get_service_accounts(session, team_sre_group) == []
+    call_main('service_account', '--actor', actor_username, 'create',
+              name, 'this-group-does-not-exist', machine_set, description)
+    assert ServiceAccount.get(session, name=name) is None
+    assert get_service_accounts(session, team_sre_group) == []
+
+    # now it works
+    name = 'good@a.co'
+    assert ServiceAccount.get(session, name=name) is None
+    assert get_service_accounts(session, team_sre_group) == []
+    actor_username = 'gary@a.co'
+    call_main('service_account', '--actor', actor_username, 'create',
+              name, team_sre_group.groupname, machine_set, description)
+    service_account = ServiceAccount.get(session, name=name)
+    assert service_account, 'non-account should be created'
+    assert service_account.user.name == name
+    assert service_account.machine_set == machine_set
+    assert service_account.description == description
+    assert get_service_accounts(session, team_sre_group) == [service_account]
+
+    # no-op if account name already exists
+    call_main('service_account', '--actor', actor_username, 'create',
+              name, team_sre_group.groupname, machine_set, description)
+    service_account = ServiceAccount.get(session, name=name)
+    assert service_account, 'non-account should be created'
+    assert service_account.user.name == name
+    assert service_account.machine_set == machine_set
+    assert service_account.description == description
+    assert get_service_accounts(session, team_sre_group) == [service_account]
+
+    

--- a/tests/test_grouper_ctl_service_account.py
+++ b/tests/test_grouper_ctl_service_account.py
@@ -2,61 +2,64 @@ from mock import patch
 import pytest
 
 from ctl_util import call_main
-from fixtures import standard_graph, graph, users, groups, session  # noqa
+from fixtures import standard_graph, graph, users, groups, service_accounts, session  # noqa
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
 from grouper.group_service_account import get_service_accounts
 
 
 @patch('grouper.ctl.service_account.make_session')
-def test_service_account_create(make_session, session, users, groups):
+def test_service_account_create(make_session, groups, service_accounts, session, users):
     make_session.return_value = session
 
     machine_set = 'foo +bar -(org)'
     description = 'this is a service account.\n\n it is for testing'
-    team_sre_group = Group.get(session, name='team-sre')
-    actor_username = 'gary@a.co'
+    security_team_group = Group.get(session, name='security-team')
+    good_actor_username = 'gary@a.co'
+    good_service_account_name = 'good-service@a.co'
 
-    # no-op if bad account name
-    name = 'bad'
-    assert ServiceAccount.get(session, name=name) is None
-    assert get_service_accounts(session, team_sre_group) == []
-    call_main('service_account', '--actor', actor_username, 'create',
-              name, team_sre_group.groupname, machine_set, description)
-    assert ServiceAccount.get(session, name=name) is None
-    assert get_service_accounts(session, team_sre_group) == []
-
-    # no-op if owner group doesn't exist
-    name = 'good@a.co'
-    assert ServiceAccount.get(session, name=name) is None
-    assert get_service_accounts(session, team_sre_group) == []
-    call_main('service_account', '--actor', actor_username, 'create',
-              name, 'this-group-does-not-exist', machine_set, description)
-    assert ServiceAccount.get(session, name=name) is None
-    assert get_service_accounts(session, team_sre_group) == []
+    assert ServiceAccount.get(session, name=good_service_account_name) is None
+    assert get_service_accounts(session, security_team_group) == []
+    # no-op if non-existing actor
+    call_main('service_account', '--actor', 'no-such-actor@a.co', 'create',
+              good_service_account_name, security_team_group.groupname, machine_set, description)
+    # ... or if bad account name
+    call_main('service_account', '--actor', good_actor_username, 'create',
+              'bad-service-account-name', security_team_group.groupname, machine_set, description)
+    # ... or non-existing owner group
+    call_main('service_account', '--actor', good_actor_username, 'create',
+              good_service_account_name, 'non-such-owner-group', machine_set, description)
+    # make sure no change was made
+    assert ServiceAccount.get(session, name=good_service_account_name) is None
+    assert get_service_accounts(session, security_team_group) == []
 
     # now it works
-    name = 'good@a.co'
-    assert ServiceAccount.get(session, name=name) is None
-    assert get_service_accounts(session, team_sre_group) == []
-    actor_username = 'gary@a.co'
-    call_main('service_account', '--actor', actor_username, 'create',
-              name, team_sre_group.groupname, machine_set, description)
-    service_account = ServiceAccount.get(session, name=name)
-    assert service_account, 'non-account should be created'
-    assert service_account.user.name == name
+    call_main('service_account', '--actor', good_actor_username, 'create',
+              good_service_account_name, security_team_group.groupname, machine_set, description)
+    service_account = ServiceAccount.get(session, name=good_service_account_name)
+    assert service_account, 'non-existing account should be created'
+    assert service_account.user.name == good_service_account_name
     assert service_account.machine_set == machine_set
     assert service_account.description == description
-    assert get_service_accounts(session, team_sre_group) == [service_account]
+    assert get_service_accounts(session, security_team_group) == [service_account]
 
     # no-op if account name already exists
-    call_main('service_account', '--actor', actor_username, 'create',
-              name, team_sre_group.groupname, machine_set, description)
-    service_account = ServiceAccount.get(session, name=name)
+    call_main('service_account', '--actor', good_actor_username, 'create',
+              good_service_account_name, security_team_group.groupname, machine_set, description)
+    service_account = ServiceAccount.get(session, name=good_service_account_name)
     assert service_account, 'non-account should be created'
-    assert service_account.user.name == name
+    assert service_account.user.name == good_service_account_name
     assert service_account.machine_set == machine_set
     assert service_account.description == description
-    assert get_service_accounts(session, team_sre_group) == [service_account]
+    assert get_service_accounts(session, security_team_group) == [service_account]
 
-    
+    # actor can be a service account as well
+    call_main('service_account', '--actor', 'service@a.co', 'create',
+              'service-2@a.co', security_team_group.groupname, machine_set + '2', description + '2')
+    service_account_2 = ServiceAccount.get(session, name='service-2@a.co')
+    assert service_account_2, 'non-existing account should be created'
+    assert service_account_2.user.name == 'service-2@a.co'
+    assert service_account_2.machine_set == (machine_set + '2')
+    assert service_account_2.description == (description + '2')
+    assert set(get_service_accounts(session, security_team_group)) == set(
+        [service_account, service_account_2])


### PR DESCRIPTION
```
$ python grouper/ctl/main.py service_account -h 
usage: main.py service_account [-h] -a ACTOR_NAME {create} ...

positional arguments:
  {create}
    create              Create a new service account

optional arguments:
  -h, --help            show this help message and exit

required named arguments:
  -a ACTOR_NAME, --actor ACTOR_NAME
                        Name of the entity performing this action. Must be a
                        valid Grouper human or service account.
$
$ python grouper/ctl/main.py service_account create -h
usage: main.py service_account create [-h]
                                      name owner_group machine_set description

positional arguments:
  name         Name for the service account
  owner_group  Name of the owner group. Must be a valid Grouper group
  machine_set  The machine set for the service account
  description  Description for the service account

optional arguments:
  -h, --help   show this help message and exit
$
```