### PR TITLE
Scope down `grouper.user.enable` perm to only allow enabling a user without preserving group membership

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -55,7 +55,7 @@ SYSTEM_PERMISSIONS = [
     (AUDIT_SECURITY, "Ability to audit security related activity on the system."),
     (AUDIT_MANAGER, "Ability to start and view global audits, and toggle if a perm is audited."),
     (AUDIT_VIEWER, "Ability to view audit results and status."),
-    (USER_ENABLE, "Ability to enable a disabled user."),
+    (USER_ENABLE, "Ability to enable a disabled user without preserving group membership."),
     (USER_DISABLE, "Ability to disable an enabled user."),
     (TAG_EDIT, "Ability to edit the permissions granted to a tag."),
 ]

--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -35,8 +35,6 @@ def build_user_proxy_server(username, backend_port, listen_host, listen_port):
             self.backend_port = backend_port
             self.header = ["X-Grouper-User: %s" % username]
 
-    listen_port = 8889
-    print "Going to try user proxy on {}:{}".format(listen_host, listen_port)
     server = BaseHTTPServer.HTTPServer(
         (listen_host, listen_port), ProxyHandler
     )

--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -35,6 +35,8 @@ def build_user_proxy_server(username, backend_port, listen_host, listen_port):
             self.backend_port = backend_port
             self.header = ["X-Grouper-User: %s" % username]
 
+    listen_port = 8889
+    print "Going to try user proxy on {}:{}".format(listen_host, listen_port)
     server = BaseHTTPServer.HTTPServer(
         (listen_host, listen_port), ProxyHandler
     )

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -92,8 +92,8 @@ def get_user_view_template_vars(session, actor, user, graph):
     else:
         ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))
         ret["can_disable"] = UserDisable.check_access(session, actor, user)
-        ret["can_enable"] = UserEnable.check_access_preserving_membership(session, actor, user)
         ret["can_enable_preserving_membership"] = UserEnable.check_access(session, actor, user)
+        ret["can_enable"] = UserEnable.check_access_without_membership(session, actor, user)
 
     if user.id == actor.id:
         ret["num_pending_group_requests"] = user_requests_aggregate(session, actor).count()

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -87,7 +87,7 @@ def get_user_view_template_vars(session, actor, user, graph):
         )
         ret["can_disable"] = ret["can_control"]
         ret["can_enable"] = user_is_user_admin(session, actor)
-        ret["can_enable_with_permissions"] = user_is_user_admin(session, actor)
+        ret["can_enable_preserving_membership"] = user_is_user_admin(session, actor)
         ret["account"] = user.service_account
     else:
         ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -87,11 +87,13 @@ def get_user_view_template_vars(session, actor, user, graph):
         )
         ret["can_disable"] = ret["can_control"]
         ret["can_enable"] = user_is_user_admin(session, actor)
+        ret["can_enable_with_permissions"] = user_is_user_admin(session, actor)
         ret["account"] = user.service_account
     else:
         ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))
         ret["can_disable"] = UserDisable.check_access(session, actor, user)
-        ret["can_enable"] = UserEnable.check_access(session, actor, user)
+        ret["can_enable"] = UserEnable.check_access_preserving_membership(session, actor, user)
+        ret["can_enable_preserving_membership"] = UserEnable.check_access(session, actor, user)
 
     if user.id == actor.id:
         ret["num_pending_group_requests"] = user_requests_aggregate(session, actor).count()

--- a/grouper/fe/handlers/user_enable.py
+++ b/grouper/fe/handlers/user_enable.py
@@ -17,9 +17,10 @@ class UserEnable(GrouperHandler):
         )
 
     @staticmethod
-    def check_access_preserving_membership(session, actor, target):
+    def check_access_without_membership(session, actor, target):
         return (
-            self.check_access(session, actor, target) or
+            user_has_permission(session, actor, USER_ADMIN) or
+            (target.role_user and is_owner_of_role_user(session, actor, tuser=target)) or
             user_has_permission(session, actor, USER_ENABLE, argument=target.name)
         )
 
@@ -34,10 +35,10 @@ class UserEnable(GrouperHandler):
             return self.redirect("/users/{}?refresh=yes".format(user.name))
 
         if form.preserve_membership.data:
-            if not self.check_access_preserving_membership(self.session, self.current_user, user):
+            if not self.check_access(self.session, self.current_user, user):
                 return self.forbidden()
         else:
-            if not self.check_access(self.session, self.current_user, user):
+            if not self.check_access_without_membership(self.session, self.current_user, user):
                 return self.forbidden()
 
         if user.role_user:

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -135,10 +135,12 @@
             <form action="/users/{{user.id}}/enable" method="post">
                 <div class="modal-body">
                     <p>Are you sure you want to enable this user?</p>
+		    {% if can_enable_preserving_membership %}
                     <label class="checkbox" class="normal-weight">
                         <i>preserve any pre-existing group membership (you don't want this)</i>
                         <input type="checkbox" name="preserve_membership" value="true"/>
                     </label>
+		    {% endif %}
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default"


### PR DESCRIPTION
Distinguishes between the enabling a user preserving group membership and not preserving, allowing a user with only `grouper.user.enable` to only do the latter. User admins can still enable while preserving group membership.

Also adds a test case for the changed logic.