### PR TITLE
Update permission requests page

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -249,7 +249,7 @@ class PermissionRequestsForm(Form):
         validators.Optional(),
     ], default='')
     direction = SelectField("Direction", [validators.DataRequired()],
-        choices=[("inbound", "inbound"), ("outbound", "outbound")], default="inbound")
+        choices=[("Waiting my approval", ""), ("Requested by me", "")], default="Waiting my approval")
 
 
 class PermissionRequestUpdateForm(Form):

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -248,9 +248,8 @@ class PermissionRequestsForm(Form):
     status = SelectField("New Status", [
         validators.Optional(),
     ], default='')
-    direction = SelectField("Direction", [validators.DataRequired(),],
+    direction = SelectField("Direction", [validators.DataRequired()],
         choices=[("inbound", "inbound"), ("outbound", "outbound")], default="inbound")
-        
 
 
 class PermissionRequestUpdateForm(Form):

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -248,6 +248,9 @@ class PermissionRequestsForm(Form):
     status = SelectField("New Status", [
         validators.Optional(),
     ], default='')
+    direction = SelectField("Direction", [validators.DataRequired(),],
+        choices=[("inbound", "inbound"), ("outbound", "outbound")], default="inbound")
+        
 
 
 class PermissionRequestUpdateForm(Form):

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -249,7 +249,8 @@ class PermissionRequestsForm(Form):
         validators.Optional(),
     ], default='')
     direction = SelectField("Direction", [validators.DataRequired()],
-        choices=[("Waiting my approval", ""), ("Requested by me", "")], default="Waiting my approval")
+        choices=[("Waiting my approval", ""), ("Requested by me", "")],
+        default="Waiting my approval")
 
 
 class PermissionRequestUpdateForm(Form):

--- a/grouper/fe/handlers/permissions_request_update.py
+++ b/grouper/fe/handlers/permissions_request_update.py
@@ -55,8 +55,8 @@ class PermissionsRequestUpdate(GrouperHandler):
             return self.notfound()
 
         # check that this user should be actioning this request
-        user_requests, total = permissions.get_requests_by_owner(self.session,
-                self.current_user, status="pending", limit=None, offset=0)
+        user_requests, total = permissions.get_requests(self.session,
+                status="pending", limit=None, offset=0, owner=self.current_user)
         user_request_ids = [ur.id for ur in user_requests.requests]
         if request.id not in user_request_ids:
             return self.forbidden()

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -18,9 +18,15 @@ class PermissionsRequests(GrouperHandler):
         else:
             alerts = []
             owners_by_arg_by_perm = permissions.get_owners_by_grantable_permission(self.session)
-            request_tuple, total = permissions.get_requests_by_owner(self.session,
-                    self.current_user, status=form.status.data,
-                    limit=form.limit.data, offset=form.offset.data,
+            if form.direction.data == "inbound":
+                owner = self.current_user
+                requester = None
+            else: # Outbound
+                owner = None
+                requester = self.current_user
+                
+            request_tuple, total = permissions.get_requests(self.session, status=form.status.data,
+                    limit=form.limit.data, offset=form.offset.data, owner=owner, requester=requester,
                     owners_by_arg_by_perm=owners_by_arg_by_perm)
             granters_by_arg_by_perm = {}
             for request in request_tuple.requests:

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -32,8 +32,10 @@ class PermissionsRequests(GrouperHandler):
             for request in request_tuple.requests:
                 owners = permissions.get_owner_arg_list(self.session, request.permission,
                         request.argument, owners_by_arg_by_perm=owners_by_arg_by_perm)
-                granters_by_arg = {request.argument: [owner_pair[0].name for owner_pair in owners]}
-                granters_by_arg_by_perm[request.permission.name] = granters_by_arg
+                granters_by_arg = [owner_pair[0].name for owner_pair in owners]
+                if request.permission.name not in granters_by_arg_by_perm:
+                    granters_by_arg_by_perm[request.permission.name] = {}
+                granters_by_arg_by_perm[request.permission.name][request.argument] = granters_by_arg
 
         return self.render("permission-requests.html", form=form, request_tuple=request_tuple,
                            granters=granters_by_arg_by_perm, alerts=alerts, total=total,

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -21,13 +21,13 @@ class PermissionsRequests(GrouperHandler):
             if form.direction.data == "inbound":
                 owner = self.current_user
                 requester = None
-            else: # Outbound
+            else:  # outbound
                 owner = None
                 requester = self.current_user
-                
+
             request_tuple, total = permissions.get_requests(self.session, status=form.status.data,
-                    limit=form.limit.data, offset=form.offset.data, owner=owner, requester=requester,
-                    owners_by_arg_by_perm=owners_by_arg_by_perm)
+                    limit=form.limit.data, offset=form.offset.data, owner=owner,
+                    requester=requester, owners_by_arg_by_perm=owners_by_arg_by_perm)
             granters_by_arg_by_perm = {}
             for request in request_tuple.requests:
                 owners = permissions.get_owner_arg_list(self.session, request.permission,

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -18,10 +18,10 @@ class PermissionsRequests(GrouperHandler):
         else:
             alerts = []
             owners_by_arg_by_perm = permissions.get_owners_by_grantable_permission(self.session)
-            if form.direction.data == "inbound":
+            if form.direction.data == "Waiting my approval":
                 owner = self.current_user
                 requester = None
-            else:  # outbound
+            else:  # "Requested by me"
                 owner = None
                 requester = self.current_user
 

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from grouper import permissions
 from grouper.fe.forms import PermissionRequestsForm
 from grouper.fe.util import GrouperHandler
@@ -28,13 +30,11 @@ class PermissionsRequests(GrouperHandler):
             request_tuple, total = permissions.get_requests(self.session, status=form.status.data,
                     limit=form.limit.data, offset=form.offset.data, owner=owner,
                     requester=requester, owners_by_arg_by_perm=owners_by_arg_by_perm)
-            granters_by_arg_by_perm = {}
+            granters_by_arg_by_perm = defaultdict(dict)
             for request in request_tuple.requests:
                 owners = permissions.get_owner_arg_list(self.session, request.permission,
                         request.argument, owners_by_arg_by_perm=owners_by_arg_by_perm)
                 granters_by_arg = [owner_pair[0].name for owner_pair in owners]
-                if request.permission.name not in granters_by_arg_by_perm:
-                    granters_by_arg_by_perm[request.permission.name] = {}
                 granters_by_arg_by_perm[request.permission.name][request.argument] = granters_by_arg
 
         return self.render("permission-requests.html", form=form, request_tuple=request_tuple,

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -34,8 +34,8 @@ class PermissionsRequests(GrouperHandler):
             for request in request_tuple.requests:
                 owners = permissions.get_owner_arg_list(self.session, request.permission,
                         request.argument, owners_by_arg_by_perm=owners_by_arg_by_perm)
-                granters_by_arg = [owner_pair[0].name for owner_pair in owners]
-                granters_by_arg_by_perm[request.permission.name][request.argument] = granters_by_arg
+                granters = [owner_pair[0].name for owner_pair in owners]
+                granters_by_arg_by_perm[request.permission.name][request.argument] = granters
 
         return self.render("permission-requests.html", form=form, request_tuple=request_tuple,
                            granters=granters_by_arg_by_perm, alerts=alerts, total=total,

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -24,9 +24,9 @@ class PermissionsRequests(GrouperHandler):
                     owners_by_arg_by_perm=owners_by_arg_by_perm)
             granters_by_arg_by_perm = {}
             for request in request_tuple.requests:
-                owners = get_owner_arg_list(self.session, request.permission, request.argument,
-                                            owners_by_arg_by_perm=owners_by_arg_by_perm)
-                granters_by_arg = {request.argument: owners}
+                owners = permissions.get_owner_arg_list(self.session, request.permission,
+                        request.argument, owners_by_arg_by_perm=owners_by_arg_by_perm)
+                granters_by_arg = {request.argument: [owner_pair[0].name for owner_pair in owners]}
                 granters_by_arg_by_perm[request.permission.name] = granters_by_arg
 
         return self.render("permission-requests.html", form=form, request_tuple=request_tuple,

--- a/grouper/fe/handlers/permissions_requests.py
+++ b/grouper/fe/handlers/permissions_requests.py
@@ -14,11 +14,21 @@ class PermissionsRequests(GrouperHandler):
             alerts = self.get_form_alerts(form.errors)
             request_tuple = None
             total = 0
+            granters_by_arg_by_perm = None
         else:
             alerts = []
+            owners_by_arg_by_perm = permissions.get_owners_by_grantable_permission(self.session)
             request_tuple, total = permissions.get_requests_by_owner(self.session,
                     self.current_user, status=form.status.data,
-                    limit=form.limit.data, offset=form.offset.data)
+                    limit=form.limit.data, offset=form.offset.data,
+                    owners_by_arg_by_perm=owners_by_arg_by_perm)
+            granters_by_arg_by_perm = {}
+            for request in request_tuple.requests:
+                owners = get_owner_arg_list(self.session, request.permission, request.argument,
+                                            owners_by_arg_by_perm=owners_by_arg_by_perm)
+                granters_by_arg = {request.argument: owners}
+                granters_by_arg_by_perm[request.permission.name] = granters_by_arg
 
         return self.render("permission-requests.html", form=form, request_tuple=request_tuple,
-                alerts=alerts, total=total, statuses=REQUEST_STATUS_CHOICES)
+                           granters=granters_by_arg_by_perm, alerts=alerts, total=total,
+                           statuses=REQUEST_STATUS_CHOICES)

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -87,7 +87,7 @@ def get_user_view_template_vars(session, actor, user, graph):
         )
         ret["can_disable"] = ret["can_control"]
         ret["can_enable"] = user_is_user_admin(session, actor)
-        ret["can_enable_with_permissions"] = user_is_user_admin(session, actor)
+        ret["can_enable_preserving_membership"] = user_is_user_admin(session, actor)
         ret["account"] = user.service_account
     else:
         ret["can_control"] = (user.name == actor.name or user_is_user_admin(session, actor))

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -5,8 +5,7 @@ from grouper.group_requests import count_requests_by_group
 from grouper.group_service_account import get_service_accounts
 from grouper.models.audit_member import AUDIT_STATUS_CHOICES
 from grouper.models.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
-from grouper.permissions import (get_owner_arg_list, get_pending_request_by_group,
-    get_requests_by_owner)
+from grouper.permissions import get_owner_arg_list, get_pending_request_by_group, get_requests
 from grouper.public_key import (get_public_key_permissions, get_public_key_tags,
     get_public_keys_of_user)
 from grouper.role_user import can_manage_role_user
@@ -97,8 +96,8 @@ def get_user_view_template_vars(session, actor, user, graph):
 
     if user.id == actor.id:
         ret["num_pending_group_requests"] = user_requests_aggregate(session, actor).count()
-        _, ret["num_pending_perm_requests"] = get_requests_by_owner(session, actor,
-            status='pending', limit=1, offset=0)
+        _, ret["num_pending_perm_requests"] = get_requests(session, status='pending',
+            limit=1, offset=0, owner=actor)
     else:
         ret["num_pending_group_requests"] = None
         ret["num_pending_perm_requests"] = None

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -31,7 +31,7 @@
             <tbody>
                 {% if not request_tuple or not request_tuple.requests %}
                 <tr>
-                    <td colspan="4" class="text-center">no requests fit the criteria</td>
+                    <td colspan="4" class="text-center request-dne">no requests fit the criteria</td>
                 </tr>
                 {% endif %}
                 {% for request in request_tuple.requests %}
@@ -53,9 +53,9 @@
                 </tr>
                 {% for status_change in request_tuple.status_change_by_request_id[request.id] %}
                 {% set comment = request_tuple.comment_by_status_change_id[status_change.id] %}
-                <tr class="active">
+                <tr class="active request-status-change-row">
                     <td>&nbsp;</td>
-                    <td colspan="5">
+                    <td colspan="4">
                         <dl class="dl-horizontal no-margin-bottom">
                             <dt>Group:</dt>
 			    <dd class="request-group">{{ request.group.name }}</dd>

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -23,7 +23,6 @@
                 <tr>
                     <th class="col-sm-1">Modify</th>
                     <th class="col-sm-2">Requested</th>
-                    <th class="col-sm-2">Requester</th>
 		    <th class="col-sm-2">Approvers</th>
                     <th class="col-sm-2">Status</th>
                     <th class="col-sm-2">Requested At</th>
@@ -32,7 +31,7 @@
             <tbody>
                 {% if not request_tuple or not request_tuple.requests %}
                 <tr>
-                    <td colspan="5" class="text-center">no requests fit the criteria</td>
+                    <td colspan="4" class="text-center">no requests fit the criteria</td>
                 </tr>
                 {% endif %}
                 {% for request in request_tuple.requests %}
@@ -46,7 +45,6 @@
                     <td class="request-requested">
                         {{ request.permission.name }}, {{ request.argument }}
                     </td>
-                    <td class="request-requester">{{ request.requester }}</td>
 		    <td class="request-approvers">
 		        {{ ", ".join(granters[request.permission.name][request.argument]) }}
 		    </td>

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -36,20 +36,22 @@
                 </tr>
                 {% endif %}
                 {% for request in request_tuple.requests %}
-                <tr>
-                    <td>
+                <tr class="request-row">
+                    <td class="request-modify">
                         <a href="/permissions/requests/{{ request.id }}"
                            class="btn btn-default btn-xs">
                             <i class="fa fa-edit"></i>
                         </a>
                     </td>
-                    <td>
+                    <td class="request-requested">
                         {{ request.permission.name }}, {{ request.argument }}
                     </td>
-                    <td>{{ request.requester }}</td>
-		    <td>{{ ", ".join(granters[request.permission.name][request.argument]) }}</td>
-                    <td>{{ request.status }}</td>
-                    <td>{{ request.requested_at | print_date }}</td>
+                    <td class="request-requester">{{ request.requester }}</td>
+		    <td class="request-approvers">
+		        {{ ", ".join(granters[request.permission.name][request.argument]) }}
+		    </td>
+                    <td class="request-status">{{ request.status }}</td>
+                    <td class="request-requested-at">{{ request.requested_at | print_date }}</td>
                 </tr>
                 {% for status_change in request_tuple.status_change_by_request_id[request.id] %}
                 {% set comment = request_tuple.comment_by_status_change_id[status_change.id] %}
@@ -57,13 +59,15 @@
                     <td>&nbsp;</td>
                     <td colspan="5">
                         <dl class="dl-horizontal no-margin-bottom">
-                            <dt>Group:</dt><dd>{{ request.group.name }}</dd>
+                            <dt>Group:</dt>
+			    <dd class="request-group">{{ request.group.name }}</dd>
                             <dt>Who:</dt>
-                            <dd>
+                            <dd class="request-who">
                                 {{ status_change.user.name  }}
                                 ({{ status_change.change_at|long_ago_str }})
                             </dd>
-                            <dt>Reason:</dt> <dd>{{ comment.comment }}</dd>
+                            <dt>Reason:</dt>
+			    <dd class="request-reason">{{ comment.comment }}</dd>
                         </dl>
                     </td>
                 </tr>

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -24,6 +24,7 @@
                     <th class="col-sm-1">Modify</th>
                     <th class="col-sm-2">Requested</th>
                     <th class="col-sm-2">Requester</th>
+		    <th class="col-sm-2">Approvers</th>
                     <th class="col-sm-2">Status</th>
                     <th class="col-sm-2">Requested At</th>
                 </tr>
@@ -46,6 +47,7 @@
                         {{ request.permission.name }}, {{ request.argument }}
                     </td>
                     <td>{{ request.requester }}</td>
+		    <td>{{ ", ".join(grants[request.permission.name][request.argument]) }}</td>
                     <td>{{ request.status }}</td>
                     <td>{{ request.requested_at | print_date }}</td>
                 </tr>

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -11,6 +11,7 @@
 
 {% block headingbuttons %}
     {{ dropdown("status", form.status.data, statuses, allow_none=True) }}
+    {{ dropdown("direction", form.direction.data, ["inbound", "outbound"]) }}
     {{ dropdown("limit", form.limit.data, [100, 250, 500]) }}
     {{ paginator(form.offset.data, form.limit.data, total) }}
 {% endblock %}

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -11,7 +11,7 @@
 
 {% block headingbuttons %}
     {{ dropdown("status", form.status.data, statuses, allow_none=True) }}
-    {{ dropdown("direction", form.direction.data, ["inbound", "outbound"]) }}
+    {{ dropdown("direction", form.direction.data, ["Waiting my approval", "Requested by me"]) }}
     {{ dropdown("limit", form.limit.data, [100, 250, 500]) }}
     {{ paginator(form.offset.data, form.limit.data, total) }}
 {% endblock %}

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -47,7 +47,7 @@
                         {{ request.permission.name }}, {{ request.argument }}
                     </td>
                     <td>{{ request.requester }}</td>
-		    <td>{{ ", ".join(grants[request.permission.name][request.argument]) }}</td>
+		    <td>{{ ", ".join(granters[request.permission.name][request.argument]) }}</td>
                     <td>{{ request.status }}</td>
                     <td>{{ request.requested_at | print_date }}</td>
                 </tr>
@@ -55,7 +55,7 @@
                 {% set comment = request_tuple.comment_by_status_change_id[status_change.id] %}
                 <tr class="active">
                     <td>&nbsp;</td>
-                    <td colspan="4">
+                    <td colspan="5">
                         <dl class="dl-horizontal no-margin-bottom">
                             <dt>Group:</dt><dd>{{ request.group.name }}</dd>
                             <dt>Who:</dt>

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -352,6 +352,7 @@ def get_owner_arg_list(session, permission, argument, owners_by_arg_by_perm=None
         owners_by_arg_by_perm(Dict): list of groups that can grant a given
             permission, argument pair in the format of
             {perm_name: {argument: [group1, group2, ...], ...}, ...}
+            This is for convenience/caching if the value has already been fetched.
     Returns:
         list of 2-tuple of (group, argument) where group is the models.Group
         grouper groups responsibile for permimssion+argument and argument is
@@ -550,6 +551,7 @@ def get_requests(session, status, limit, offset,
         owners_by_arg_by_perm(Dict): list of groups that can grant a given
             permission, argument pair in the format of
             {perm_name: {argument: [group1, group2, ...], ...}, ...}
+            This is for convenience/caching if the value has already been fetched.
 
     Returns:
         2-tuple of (Requests, total) where total is total result size and

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -533,16 +533,20 @@ def can_approve_request(session, request, owner, group_ids=None, owners_by_arg_b
     return group_ids.intersection([o.id for o, arg in owner_arg_list])
 
 
-def get_requests_by_owner(session, owner, status, limit, offset, owners_by_arg_by_perm=None):
-    """Load pending requests for a particular owner.
+def get_requests(session, status, limit, offset,
+                 owner=None, requester=None, owners_by_arg_by_perm=None):
+    """Load requests using the given filters.
 
     Args:
         session(sqlalchemy.orm.session.Session): database session
-        owner(models.User): model of user in question
         status(models.base.constants.REQUEST_STATUS_CHOICES): if not None,
                 filter by particular status
         limit(int): how many results to return
         offset(int): the offset into the result set that should be applied
+        owner(models.User): if not None, filter by requests that the owner
+            can action
+        requester(models.User): if not None, filter by requests that the
+            requester made
         owners_by_arg_by_perm(Dict): list of groups that can grant a given
             permission, argument pair in the format of
             {perm_name: {argument: [group1, group2, ...], ...}, ...}
@@ -552,24 +556,25 @@ def get_requests_by_owner(session, owner, status, limit, offset, owners_by_arg_b
         Requests is the namedtuple with requests and associated
         comments/changes.
     """
-    # get owners groups
-    group_ids = {g.id for g, _ in get_groups_by_user(session, owner)}
-
     # get all requests
     all_requests = session.query(PermissionRequest)
     if status:
         all_requests = all_requests.filter(PermissionRequest.status == status)
+    if requester:
+        all_requests = all_requests.filter(PermissionRequest.requester_id == requester.id)
 
     all_requests = all_requests.order_by(PermissionRequest.requested_at.desc()).all()
 
     if owners_by_arg_by_perm is None:
         owners_by_arg_by_perm = get_owners_by_grantable_permission(session)
 
-    requests = []
-    for request in all_requests:
-        if can_approve_request(session, request, owner, group_ids=group_ids,
-                               owners_by_arg_by_perm=owners_by_arg_by_perm):
-            requests.append(request)
+    if owner:
+        group_ids = {g.id for g, _ in get_groups_by_user(session, owner)}
+        requests = [request for request in all_requests if
+                    can_approve_request(session, request, owner, group_ids=group_ids,
+                                        owners_by_arg_by_perm=owners_by_arg_by_perm)]
+    else:
+        requests = all_requests
 
     total = len(requests)
     requests = requests[offset:limit]

--- a/itests/pages/permission_requests.py
+++ b/itests/pages/permission_requests.py
@@ -1,0 +1,55 @@
+from base import BaseElement, BasePage
+
+class PermissionRequestsPage(BasePage):
+    @property
+    def request_rows(self):
+        all_request_rows = self.find_elements_by_class_name('request-row')
+        return [RequestViewRow(row) for row in all_request_rows]
+
+    @property
+    def status_change_rows(self):
+        all_sc_rows = self.find_elements_by_class_name('request-status-change-row')
+        return [StatusChangeRow(row) for row in all_sc_rows]
+
+    @property
+    def no_requests_row(self):
+        return self.find_element_by_class_name('request-dne')
+
+
+class RequestViewRow(BaseElement):
+    @property
+    def modify_link(self):
+        modify = self.find_element_by_class_name('request-modify')
+        link = modify.find_element_by_tag_name('a')
+        return link.get_attribute('href')
+
+    @property
+    def requested(self):
+        return self.find_element_by_class_name('request-requested').text
+
+    @property
+    def approvers(self):
+        return self.find_element_by_class_name('request-approvers').text
+
+    @property
+    def status(self):
+        return self.find_element_by_class_name('request-status').text
+
+    @property
+    def requested_at(self):
+        return self.find_element_by_class_name('request-requested-at').text
+
+
+class StatusChangeRow(BaseElement):
+    @property
+    def group(self):
+        return self.find_element_by_class_name('request-group').text
+
+    @property
+    def who(self):
+        return self.find_element_by_class_name('request-who').text
+
+    @property
+    def reason(self):
+        return self.find_element_by_class_name('request-reason').text
+        

--- a/itests/test_fe_permission_requests.py
+++ b/itests/test_fe_permission_requests.py
@@ -1,0 +1,132 @@
+import pytest
+
+from fixtures import async_server, browser
+
+from grouper.constants import PERMISSION_ADMIN, PERMISSION_GRANT
+from grouper.models.permission import Permission
+from grouper.models.permission_request import PermissionRequest
+from grouper.permissions import create_request, update_request
+
+from pages.exceptions import NoSuchElementException
+from pages.permission_requests import PermissionRequestsPage, RequestViewRow, StatusChangeRow
+
+from tests.fixtures import (
+    graph, groups, service_accounts, permissions, session, standard_graph, users
+)
+from tests.url_util import url
+from tests.util import grant_permission
+
+# Set up a permission requesting scenario in which REQUESTING_USER has both
+# inbound and outbound requests that they should be able to see on the requests
+# page. Do this because the itest infrastructure visits all pages as cbguder.
+PERM_WITH_GRANTER = 'perm.hasgranter'
+PERM_NO_GRANTER = 'perm.nogranter'
+ARGUMENT = 'a'
+REASON = 'because reasons'
+COMMENT = 'why actioned/cancelled'
+GRANTING_TEAM = 'auditors'
+GRANTING_USER = 'zorkian@a.co'
+REQUESTING_TEAM = 'group-admins'
+REQUESTING_USER = 'cbguder@a.co'
+ADMIN_TEAM = 'group-admins'
+ADMIN_USER = 'cbguder@a.co'
+
+@pytest.fixture
+def do_request_perms(groups, permissions, session, users):
+    # Create the two test perms + PERMISSION_GRANT + PERMISSION_ADMIN, give GRANTING_TEAM
+    # appropriate PERMISSION_GRANT, and make sure there's an admin (has PERMISSION_ADMIN)
+    test_perm_granter = Permission.get_or_create(
+        session, name=PERM_WITH_GRANTER, description='perm with granter')[0]
+    test_perm_nogranter = Permission.get_or_create(
+        session, name=PERM_NO_GRANTER, description='perm without granter')[0]
+    grant_perm = Permission.get_or_create(session, name=PERMISSION_GRANT, description='')[0]
+    admin_perm = Permission.get_or_create(session, name=PERMISSION_ADMIN, description='')[0]
+
+    session.commit()
+
+    grant_permission(groups[GRANTING_TEAM], grant_perm,
+                     argument='{}/{}'.format(PERM_WITH_GRANTER, ARGUMENT))
+    grant_permission(groups[ADMIN_TEAM], admin_perm, argument="")
+
+    # Request the two test perms from REQUESTING_TEAM
+    create_request(session, users[REQUESTING_USER], groups[REQUESTING_TEAM],
+                   test_perm_granter, ARGUMENT, REASON)
+    create_request(session, users[REQUESTING_USER], groups[REQUESTING_TEAM],
+                   test_perm_nogranter, ARGUMENT, REASON)
+
+    session.commit()
+
+
+@pytest.fixture
+def do_action_requests(session, permissions, users, do_request_perms):
+    # Action (approve) the request for PERM_WITH_GRANTER, and
+    # cancel (deny) the request for PERM_NO_GRANTER.
+    all_requests = session.query(PermissionRequest)
+    for request in all_requests:
+        if request.status == 'pending' and request.permission.name == PERM_WITH_GRANTER:
+            update_request(session, request, users[GRANTING_USER], 'actioned', REASON)
+        if request.status == 'pending' and request.permission.name == PERM_NO_GRANTER:
+            update_request(session, request, users[ADMIN_USER], 'cancelled', REASON)
+
+    session.commit()
+
+
+def test_pending_inbound_requests(async_server, browser, do_request_perms):
+    fe_url = url(async_server, "/permissions/requests?status=pending")
+    browser.get(fe_url)
+
+    # Check that the request rows have info we expect
+    page = PermissionRequestsPage(browser)
+    request_rows = page.request_rows
+    expected_perms = [
+        '{}, {}'.format(PERM_WITH_GRANTER, ARGUMENT),
+        '{}, {}'.format(PERM_NO_GRANTER, ARGUMENT)
+    ]
+    request_perms = [row.requested for row in request_rows]
+    assert sorted(expected_perms) == sorted(request_perms)
+
+    # Check the status change rows as well
+    sc_rows = page.status_change_rows
+    expected_groups = [REQUESTING_TEAM, REQUESTING_TEAM]
+    request_groups = [row.group for row in sc_rows]
+    assert expected_groups == request_groups
+            
+    # and make sure the "no requests" row doesn't show up
+    with pytest.raises(Exception):
+        dne_row = page.no_requests_row
+
+
+def test_completed_inbound_requests(async_server, browser, do_action_requests):
+    fe_url = url(async_server, "/permissions/requests?")
+    browser.get(fe_url)
+
+    # Check that the request rows have info we expect
+    page = PermissionRequestsPage(browser)
+    request_rows = page.request_rows
+    expected_perms = [
+        '{}, {}'.format(PERM_WITH_GRANTER, ARGUMENT),
+        '{}, {}'.format(PERM_NO_GRANTER, ARGUMENT)
+    ]
+    request_perms = [row.requested for row in request_rows]
+    assert sorted(expected_perms) == sorted(request_perms)
+
+    # Check the status change rows as well
+    sc_rows = page.status_change_rows
+    expected_whos = ([REQUESTING_USER] * 3) + [GRANTING_USER]
+    expected_whos = ['{} (now)'.format(user) for user in expected_whos]
+    request_whos = [row.who for row in sc_rows]
+    assert sorted(expected_whos) == sorted(request_whos)
+            
+    # and make sure the "no requests" row doesn't show up
+    with pytest.raises(Exception):
+        dne_row = page.no_requests_row
+
+def test_no_requests(async_server, browser, do_action_requests):
+    fe_url = url(async_server, "/permissions/requests?status=pending")
+    browser.get(fe_url)
+
+    page = PermissionRequestsPage(browser)
+    assert page.no_requests_row is not None
+
+    assert len(page.request_rows) == 0
+    assert len(page.status_change_rows) == 0

--- a/itests/test_fe_permission_requests.py
+++ b/itests/test_fe_permission_requests.py
@@ -129,7 +129,7 @@ def test_completed_inbound_requests(async_server, browser, do_action_requests): 
 
 
 def test_outbound_requests(async_server, browser, do_request_perms):  # noqa: F811
-    fe_url = url(async_server, "/permissions/requests?direction=outbound")
+    fe_url = url(async_server, "/permissions/requests?direction=Requested+by+me")
     browser.get(fe_url)
 
     # Check that the request rows have info we expect, namely the 2 requests
@@ -155,7 +155,7 @@ def test_outbound_requests(async_server, browser, do_request_perms):  # noqa: F8
 
 
 def test_no_requests(async_server, browser, do_action_requests):  # noqa: F811
-    fe_url = url(async_server, "/permissions/requests?status=pending&direction=outbound")
+    fe_url = url(async_server, "/permissions/requests?status=pending&direction=Requested+by+me")
     browser.get(fe_url)
 
     page = PermissionRequestsPage(browser)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -28,7 +28,7 @@ from grouper.permissions import (
         get_grantable_permissions,
         get_owner_arg_list,
         get_owners_by_grantable_permission,
-        get_requests_by_owner,
+        get_requests,
         grant_permission_to_service_account,
         )
 from grouper.models.permission import Permission
@@ -284,11 +284,11 @@ def test_permission_request_flow(session, standard_graph, groups, grantable_perm
     assert "grantable.one" not in perms, "requested permission shouldn't be granted immediately"
 
     user = User.get(session, name='zorkian@a.co')
-    request_tuple, total = get_requests_by_owner(session, user, "pending", 10, 0)
+    request_tuple, total = get_requests(session, "pending", 10, 0, owner=user)
     assert len(request_tuple.requests) == 0, "random user shouldn't have a request"
 
     user = User.get(session, name='testuser@a.co')
-    request_tuple, total = get_requests_by_owner(session, user, "pending", 10, 0)
+    request_tuple, total = get_requests(session, "pending", 10, 0, owner=user)
     assert len(request_tuple.requests) == 1, "user in group with grant should have a request"
 
     # APPROVE grant: have 'testuser@a.co' action this request as owner of
@@ -318,7 +318,7 @@ def test_permission_request_flow(session, standard_graph, groups, grantable_perm
     assert resp.code == 200
 
     user = User.get(session, name='testuser@a.co')
-    request_tuple, total = get_requests_by_owner(session, user, "pending", 10, 0)
+    request_tuple, total = get_requests(session, "pending", 10, 0, owner=user)
     assert len(request_tuple.requests) == 0, "request for existing perm should fail"
 
     # REQUEST: 'grantable.two', 'some argument' for 'serving-team'
@@ -340,11 +340,11 @@ def test_permission_request_flow(session, standard_graph, groups, grantable_perm
     assert "grantable.two" not in perms, "requested permission shouldn't be granted immediately"
 
     user = User.get(session, name='zorkian@a.co')
-    request_tuple, total = get_requests_by_owner(session, user, "pending", 10, 0)
+    request_tuple, total = get_requests(session, "pending", 10, 0, owner=user)
     assert len(request_tuple.requests) == 0, "random user shouldn't have a request"
 
     user = User.get(session, name='testuser@a.co')
-    request_tuple, total = get_requests_by_owner(session, user, "pending", 10, 0)
+    request_tuple, total = get_requests(session, "pending", 10, 0, owner=user)
     assert len(request_tuple.requests) == 1, "user in group with grant should have a request"
 
     # CANCEL request: have 'testuser@a.co' cancel this request


### PR DESCRIPTION
<img width="1300" alt="screen shot 2019-01-03 at 4 35 19 pm" src="https://user-images.githubusercontent.com/45474816/50665276-9d877000-0f75-11e9-8849-33ec860ccaf2.png">

Now featuring tests!

Changes (all three shown in screenshot):
- Remove redundant `Requester` column
- Add `Approvers` column that lists groups that can approve the request
- Allows viewing either requests to your groups (inbound) or requests that you made (outbound)

(Note: the naming, e.g. 'inbound' and 'outbound', doesn't feel great -- if anyone has suggestions lmk)