### PR TITLE
call `graph.get_groups(audited=True)` instead of `get_audited_groups()`

### DIFF
--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -100,7 +100,8 @@ class BackgroundProcessor(object):
         # user is a nonauditor approver
         nonauditor_approver_to_groups = defaultdict(set)  # type: Dict[User, Set[str]]
         # TODO(tyleromeara): replace with graph call
-        for group in get_audited_groups(session):
+        for group_tuple in graph.get_groups(audited=True, directly_audited=False):
+            group = Group.get(session, pk=group_tuple.id)
             members = group.my_members()
             # Go through every member of the group and add them to
             # auditors group if they are an approver but not an

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -467,7 +467,16 @@ class GroupGraph(object):
             return sorted(self.disabled_group_tuples.values(), key=lambda g: g.groupname)
 
     def get_groups(self, audited=False, directly_audited=False):
-        """ Get the list of groups as GroupTuple instances sorted by groupname. """
+        """Get the list of groups as GroupTuple instances sorted by groupname.
+
+        Arg(s):
+            audited (bool): true to get only audited groups
+            directly_audited (bool): true to get only directly audited
+                groups (implies `audited` is true)
+
+        Return:
+            List of GroupTuple
+        """
         if directly_audited:
             audited = True
         with self.lock:


### PR DESCRIPTION
`get_audited_groups()` actually calls `get_all_groups()` :(
we already that data cached in the graph, so let's try to use it.