### PR TITLE
callers pass in the settings to get the `auditors_group` name

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -2,7 +2,6 @@ from grouper.constants import PERMISSION_AUDITOR
 from grouper.graph import Graph, NoSuchGroup
 from grouper.models.audit import Audit
 from grouper.models.group import Group
-from grouper.settings import settings
 from grouper.util import get_auditors_group_name
 
 
@@ -139,10 +138,11 @@ def get_audits(session, only_open):
     return query
 
 
-def get_auditors_group(session):
+def get_auditors_group(settings, session):
     """Retrieve the group for auditors
 
     Arg(s):
+        settings (settings): settings, to get the `auditors_group` name
         session (session): database session
 
     Return:
@@ -157,7 +157,7 @@ def get_auditors_group(session):
     """
     group_name = get_auditors_group_name(settings)
     if not group_name:
-        raise NoSuchGroup('Please ask your admin to configure the default auditors group name')
+        raise NoSuchGroup('Please ask your admin to configure the `auditors_group` settings')
     group = Group.get(session, name=group_name)
     if not group:
         raise NoSuchGroup('Please ask your admin to configure the default group for auditors')

--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -112,7 +112,7 @@ class BackgroundProcessor(object):
                     nonauditor_approver_to_groups[username].add(group_tuple.groupname)
 
         if nonauditor_approver_to_groups:
-            auditors_group = get_auditors_group(session)
+            auditors_group = get_auditors_group(self.settings, session)
             for username, group_names in nonauditor_approver_to_groups.items():
                 reason = 'auto-added due to having approver role(s) in group(s): {}'.format(
                     ', '.join(group_names))


### PR DESCRIPTION
Previously `get_auditors_group_name()` in `audit.py` used its own `grouper.settings` import, which is not updated by the binaries at run time.