### PR TITLE
Allow a permission to be disabled

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -155,6 +155,8 @@ def get_auditors_group(settings, session):
         in the database. Raise GroupDoesNotHaveAuditPermission if the group
         does not actually have the PERMISSION_AUDITOR permission.
     """
+    # TODO: switch to exc.NoSuchGroup to remove one source dependency
+    # on graph.py
     group_name = get_auditors_group_name(settings)
     if not group_name:
         raise NoSuchGroup('Please ask your admin to configure the `auditors_group` settings')

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -12,7 +12,7 @@ from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
 from grouper.models.group import Group
 from grouper.models.permission import Permission
-from grouper.permissions import grant_permission
+from grouper.permissions import get_permission, grant_permission
 from grouper.settings import settings
 from grouper.util import get_auditors_group_name, get_database_url
 
@@ -29,7 +29,7 @@ def sync_db_command(args):
     session = make_session()
 
     for name, description in SYSTEM_PERMISSIONS:
-        test = Permission.get(session, name)
+        test = get_permission(session, name)
         if test:
             continue
         permission = Permission(name=name, description=description)
@@ -58,7 +58,7 @@ def sync_db_command(args):
             raise Exception('Failed to create group: grouper-administrators')
 
         for permission_name in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-            permission = Permission.get(session, permission_name)
+            permission = get_permission(session, permission_name)
             assert permission, "Permission should have been created earlier!"
             grant_permission(session, admin_group.id, permission.id)
 
@@ -80,7 +80,7 @@ def sync_db_command(args):
             session.rollback()
             raise Exception('Failed to create group: {}'.format(auditors_group_name))
 
-        permission = Permission.get(session, PERMISSION_AUDITOR)
+        permission = get_permission(session, PERMISSION_AUDITOR)
         assert permission, "Permission should have been created earlier!"
         grant_permission(session, auditors_group.id, permission.id)
 

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -32,7 +32,7 @@ def sync_db_command(args):
         if test:
             continue
         try:
-            permission = create_permission(session, name, description)
+            create_permission(session, name, description)
             session.flush()
         except IntegrityError:
             session.rollback()

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -11,8 +11,7 @@ from grouper.ctl.util import make_session
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
 from grouper.models.group import Group
-from grouper.models.permission import Permission
-from grouper.permissions import get_permission, grant_permission
+from grouper.permissions import create_permission, get_permission, grant_permission
 from grouper.settings import settings
 from grouper.util import get_auditors_group_name, get_database_url
 
@@ -32,9 +31,8 @@ def sync_db_command(args):
         test = get_permission(session, name)
         if test:
             continue
-        permission = Permission(name=name, description=description)
         try:
-            permission.add(session)
+            permission = create_permission(session, name, description)
             session.flush()
         except IntegrityError:
             session.rollback()

--- a/grouper/fe/handlers/group_permission_request.py
+++ b/grouper/fe/handlers/group_permission_request.py
@@ -6,8 +6,7 @@ from grouper.fe.forms import GroupPermissionRequestDropdownForm, GroupPermission
 from grouper.fe.settings import settings
 from grouper.fe.util import Alert, GrouperHandler
 from grouper.models.group import Group
-from grouper.models.permission import Permission
-from grouper.permissions import get_grantable_permissions
+from grouper.permissions import get_grantable_permissions, get_permission
 
 
 class GroupPermissionRequest(GrouperHandler):
@@ -78,7 +77,7 @@ class GroupPermissionRequest(GrouperHandler):
                     text_help=settings.permission_request_text_help,
                     )
 
-        permission = Permission.get(self.session, form.permission_name.data)
+        permission = get_permission(self.session, form.permission_name.data)
         assert permission is not None, "our prefilled permission should exist or we have problems"
 
         # save off request

--- a/grouper/fe/handlers/help.py
+++ b/grouper/fe/handlers/help.py
@@ -1,15 +1,12 @@
 from grouper.constants import PERMISSION_AUDITOR, PERMISSION_CREATE, PERMISSION_GRANT, TAG_EDIT
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
-from grouper.models.permission import Permission
+from grouper.permissions import get_all_enabled_permissions
 
 
 class Help(GrouperHandler):
     def get(self):
-        permissions = (
-            self.session.query(Permission)
-            .order_by(Permission.name)
-        )
+        permissions = get_all_enabled_permissions(self.session)
         d = {permission.name: permission for permission in permissions}
 
         self.render("help.html",

--- a/grouper/fe/handlers/help.py
+++ b/grouper/fe/handlers/help.py
@@ -1,18 +1,15 @@
 from grouper.constants import PERMISSION_AUDITOR, PERMISSION_CREATE, PERMISSION_GRANT, TAG_EDIT
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
-from grouper.permissions import get_all_enabled_permissions
+from grouper.permissions import get_permission
 
 
 class Help(GrouperHandler):
     def get(self):
-        permissions = get_all_enabled_permissions(self.session)
-        d = {permission.name: permission for permission in permissions}
-
         self.render("help.html",
                     how_to_get_help=settings.how_to_get_help,
                     site_docs=settings.site_docs,
-                    grant_perm=d[PERMISSION_GRANT],
-                    create_perm=d[PERMISSION_CREATE],
-                    audit_perm=d[PERMISSION_AUDITOR],
-                    tag_edit=d[TAG_EDIT])
+                    grant_perm=get_permission(self.session, PERMISSION_GRANT),
+                    create_perm=get_permission(self.session, PERMISSION_CREATE),
+                    audit_perm=get_permission(self.session, PERMISSION_AUDITOR),
+                    tag_edit=get_permission(self.session, TAG_EDIT))

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -1,0 +1,16 @@
+from grouper.fe.util import GrouperHandler
+from grouper.permissions import disable_permission, NoSuchPermission
+from grouper.user_permissions import user_is_permission_admin
+
+
+class PermissionDisable(GrouperHandler):
+    def post(self, user_id=None, name=None):
+        if not user_is_permission_admin(self.session, self.current_user):
+            return self.forbidden()
+        try:
+            disable_permission(self.session, name, self.current_user.id)
+        except NoSuchPermission:
+            return self.notfound()
+
+        # No explicit refresh because handler queries SQL.
+        return self.redirect("/permissions/{}".format(name))

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -15,12 +15,12 @@ class PermissionView(GrouperHandler):
             return self.notfound()
 
         can_change_audit_status = user_is_permission_admin(self.session, self.current_user)
-        can_delete = user_is_permission_admin(self.session, self.current_user)
+        can_disable = user_is_permission_admin(self.session, self.current_user)
         mapped_groups = get_groups_by_permission(self.session, permission)
         log_entries = get_log_entries_by_permission(self.session, permission)
 
         self.render(
-            "permission.html", permission=permission, can_delete=can_delete,
+            "permission.html", permission=permission, can_disable=can_disable,
             mapped_groups=mapped_groups, log_entries=log_entries,
             can_change_audit_status=can_change_audit_status,
         )

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -1,13 +1,16 @@
 from grouper.fe.util import GrouperHandler
-from grouper.models.permission import Permission
-from grouper.permissions import get_groups_by_permission, get_log_entries_by_permission
+from grouper.permissions import (
+    get_groups_by_permission,
+    get_log_entries_by_permission,
+    get_permission,
+)
 from grouper.user_permissions import user_is_permission_admin
 
 
 class PermissionView(GrouperHandler):
     def get(self, name=None):
         # TODO: use cached data instead, add refresh to appropriate redirects.
-        permission = Permission.get(self.session, name)
+        permission = get_permission(self.session, name)
         if not permission:
             return self.notfound()
 

--- a/grouper/fe/handlers/permissions_create.py
+++ b/grouper/fe/handlers/permissions_create.py
@@ -3,6 +3,7 @@ from sqlalchemy.exc import IntegrityError
 from grouper.fe.forms import PermissionCreateForm
 from grouper.fe.util import GrouperHandler, test_reserved_names
 from grouper.models.audit_log import AuditLog
+from grouper.permissions import create_permission
 from grouper.user_permissions import user_creatable_permissions
 from grouper.util import matches_glob
 
@@ -51,9 +52,9 @@ class PermissionsCreate(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors),
             )
 
-        permission = Permission(name=form.data["name"], description=form.data["description"])
         try:
-            permission.add(self.session)
+            permission = create_permission(
+                self.session, form.data["name"], form.data["description"])
             self.session.flush()
         except IntegrityError:
             self.session.rollback()

--- a/grouper/fe/handlers/permissions_create.py
+++ b/grouper/fe/handlers/permissions_create.py
@@ -3,7 +3,6 @@ from sqlalchemy.exc import IntegrityError
 from grouper.fe.forms import PermissionCreateForm
 from grouper.fe.util import GrouperHandler, test_reserved_names
 from grouper.models.audit_log import AuditLog
-from grouper.models.permission import Permission
 from grouper.user_permissions import user_creatable_permissions
 from grouper.util import matches_glob
 

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -5,8 +5,7 @@ from grouper.fe.forms import PermissionGrantForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.models.permission import Permission
-from grouper.permissions import grant_permission
+from grouper.permissions import get_permission, grant_permission
 from grouper.user_permissions import user_grantable_permissions
 from grouper.util import matches_glob
 
@@ -52,7 +51,7 @@ class PermissionsGrant(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors)
             )
 
-        permission = Permission.get(self.session, form.data["permission"])
+        permission = get_permission(self.session, form.data["permission"])
         if not permission:
             return self.notfound()  # Shouldn't happen.
 

--- a/grouper/fe/handlers/permissions_grant_tag.py
+++ b/grouper/fe/handlers/permissions_grant_tag.py
@@ -3,7 +3,7 @@ from grouper.fe.forms import PermissionGrantTagForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.public_key_tag import PublicKeyTag
-from grouper.permissions import get_all_enabled_permissions, get_permission, grant_permission_to_tag
+from grouper.permissions import get_all_permissions, get_permission, grant_permission_to_tag
 from grouper.user_permissions import user_has_permission
 
 
@@ -19,7 +19,7 @@ class PermissionsGrantTag(GrouperHandler):
         form = PermissionGrantTagForm()
         form.permission.choices = [["", "(select one)"]]
 
-        for perm in get_all_enabled_permissions(self.session):
+        for perm in get_all_permissions(self.session):
             form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
 
         return self.render(
@@ -37,7 +37,7 @@ class PermissionsGrantTag(GrouperHandler):
         form = PermissionGrantTagForm(self.request.arguments)
         form.permission.choices = [["", "(select one)"]]
 
-        for perm in get_all_enabled_permissions(self.session):
+        for perm in get_all_permissions(self.session):
             form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
 
         if not form.validate():

--- a/grouper/fe/handlers/permissions_grant_tag.py
+++ b/grouper/fe/handlers/permissions_grant_tag.py
@@ -2,9 +2,8 @@ from grouper.constants import TAG_EDIT
 from grouper.fe.forms import PermissionGrantTagForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
-from grouper.models.permission import Permission
 from grouper.models.public_key_tag import PublicKeyTag
-from grouper.permissions import grant_permission_to_tag
+from grouper.permissions import get_all_enabled_permissions, get_permission, grant_permission_to_tag
 from grouper.user_permissions import user_has_permission
 
 
@@ -20,7 +19,7 @@ class PermissionsGrantTag(GrouperHandler):
         form = PermissionGrantTagForm()
         form.permission.choices = [["", "(select one)"]]
 
-        for perm in self.session.query(Permission).all():
+        for perm in get_all_enabled_permissions(self.session):
             form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
 
         return self.render(
@@ -38,7 +37,7 @@ class PermissionsGrantTag(GrouperHandler):
         form = PermissionGrantTagForm(self.request.arguments)
         form.permission.choices = [["", "(select one)"]]
 
-        for perm in self.session.query(Permission).all():
+        for perm in get_all_enabled_permissions(self.session):
             form.permission.choices.append([perm.name, "{} (*)".format(perm.name)])
 
         if not form.validate():
@@ -47,7 +46,7 @@ class PermissionsGrantTag(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors)
             )
 
-        permission = Permission.get(self.session, form.data["permission"])
+        permission = get_permission(self.session, form.data["permission"])
         if not permission:
             return self.notfound()  # Shouldn't happen.
 

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -5,9 +5,8 @@ from grouper.fe.forms import ServiceAccountPermissionGrantForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.models.permission import Permission
 from grouper.models.service_account import ServiceAccount
-from grouper.permissions import grant_permission_to_service_account
+from grouper.permissions import get_permission, grant_permission_to_service_account
 from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_has_permission
 from grouper.util import matches_glob
@@ -73,7 +72,7 @@ class ServiceAccountPermissionGrant(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors)
             )
 
-        permission = Permission.get(self.session, form.data["permission"])
+        permission = get_permission(self.session, form.data["permission"])
         if not permission:
             return self.notfound()
 

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -1,7 +1,7 @@
 from grouper.constants import TAG_EDIT
 from grouper.fe.util import GrouperHandler
-from grouper.models.permission import Permission
 from grouper.models.public_key_tag import PublicKeyTag
+from grouper.permissions import get_all_enabled_permissions
 from grouper.public_key import get_public_key_tag_permissions
 from grouper.user_permissions import user_has_permission
 
@@ -16,7 +16,7 @@ class TagView(GrouperHandler):
         permissions = get_public_key_tag_permissions(self.session, tag)
         log_entries = tag.my_log_entries()
         is_owner = user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name)
-        can_grant = self.session.query(Permission).all() if is_owner else []
+        can_grant = get_all_enabled_permissions(self.session) if is_owner else []
 
         self.render(
             "tag.html", tag=tag, permissions=permissions, can_grant=can_grant,

--- a/grouper/fe/handlers/tag_view.py
+++ b/grouper/fe/handlers/tag_view.py
@@ -1,7 +1,7 @@
 from grouper.constants import TAG_EDIT
 from grouper.fe.util import GrouperHandler
 from grouper.models.public_key_tag import PublicKeyTag
-from grouper.permissions import get_all_enabled_permissions
+from grouper.permissions import get_all_permissions
 from grouper.public_key import get_public_key_tag_permissions
 from grouper.user_permissions import user_has_permission
 
@@ -16,7 +16,7 @@ class TagView(GrouperHandler):
         permissions = get_public_key_tag_permissions(self.session, tag)
         log_entries = tag.my_log_entries()
         is_owner = user_has_permission(self.session, self.current_user, TAG_EDIT, tag.name)
-        can_grant = get_all_enabled_permissions(self.session) if is_owner else []
+        can_grant = get_all_permissions(self.session) if is_owner else []
 
         self.render(
             "tag.html", tag=tag, permissions=permissions, can_grant=can_grant,

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -25,6 +25,7 @@ from grouper.fe.handlers.help import Help
 from grouper.fe.handlers.index import Index
 from grouper.fe.handlers.not_found import NotFound
 from grouper.fe.handlers.perf_profile import PerfProfile
+from grouper.fe.handlers.permission_disable import PermissionDisable
 from grouper.fe.handlers.permission_disable_auditing import PermissionDisableAuditing
 from grouper.fe.handlers.permission_enable_auditing import PermissionEnableAuditing
 from grouper.fe.handlers.permission_view import PermissionView
@@ -79,6 +80,7 @@ HANDLERS = [
     (r"/permissions/requests/(?P<request_id>[0-9]+)", PermissionsRequestUpdate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), PermissionView),
     (r"/permissions", PermissionsView),
+    (r"/permissions/{}/disable".format(PERMISSION_VALIDATION), PermissionDisable),
     (r"/permissions/{}/enable-auditing".format(PERMISSION_VALIDATION), PermissionEnableAuditing),
     (r"/permissions/{}/disable-auditing".format(PERMISSION_VALIDATION), PermissionDisableAuditing),
     (r"/permissions/grant/{}".format(NAME_VALIDATION), PermissionsGrant),

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -10,13 +10,18 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {% if can_change_audit_status %}
+    {% if permission.enabled and can_disable %}
+        <button class="btn btn-danger disable-permission" data-toggle="modal" data-target="#disablePermModal">
+            <i class="fa fa-minus"></i> Disable Permission
+        </button>
+    {% endif %}
+    {% if permission.enabled and can_change_audit_status %}
         {% if permission.audited %}
-            <button class="btn btn-danger" data-toggle="modal" data-target="#disableModal">
+            <button class="btn btn-danger" data-toggle="modal" data-target="#disableAuditingModal">
                 <i class="fa fa-minus"></i> Disable Auditing
             </button>
         {% else %}
-            <button class="btn btn-warning" data-toggle="modal" data-target="#enableModal">
+            <button class="btn btn-warning" data-toggle="modal" data-target="#enableAuditingModal">
                 <i class="fa fa-plus"></i> Enable Auditing
             </button>
         {% endif %}
@@ -26,35 +31,41 @@
 {% block content %}
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
-        {% if permission.audited %}
-        <div class="alert alert-warning">
-            <strong>This is an audited permission.</strong> Any group this permission is applied
-            to will become audited.
-        </div>
-        {% endif %}
-
-        <table class="table table-elist">
-            <thead>
-                <tr>
-                    <th class="col-sm-2">Group</th>
-                    <th class="col-sm-5">Argument</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for mapped_group in mapped_groups %}
-                <tr>
-                    <td><a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a></td>
-                    <td>{{mapped_group.argument|default("(unargumented)", True)}}</td>
-                </tr>
-            {% endfor %}
-            {% if not mapped_groups %}
-                <tr>
-                    <td colspan="2" class="text-center"><em>This permission is not mapped to any
-                    groups. To grant this permission to a group, visit the group page.</em></td>
-                </tr>
+        {% if not permission.enabled %}
+            <div class="alert alert-warning">
+                <strong>This permission is disabled.</strong> It continues to exist for the record but otherwise has no effect.
+            </div>
+        {% else %}
+            {% if permission.audited %}
+                <div class="alert alert-warning">
+                    <strong>This is an audited permission.</strong> Any group this permission is applied
+                    to will become audited.
+                </div>
             {% endif %}
-            </tbody>
-        </table>
+
+            <table class="table table-elist">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Group</th>
+                        <th class="col-sm-5">Argument</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for mapped_group in mapped_groups %}
+                    <tr>
+                        <td><a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a></td>
+                        <td>{{mapped_group.argument|default("(unargumented)", True)}}</td>
+                    </tr>
+                {% endfor %}
+                {% if not mapped_groups %}
+                    <tr>
+                        <td colspan="2" class="text-center"><em>This permission is not mapped to any
+                        groups. To grant this permission to a group, visit the group page.</em></td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        {% endif %}
     </div>
 </div>
 
@@ -64,8 +75,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="enableModal" tabindex="-1" role="dialog"
-      aria-labelledby="enableModal" aria-hidden="true">
+<div class="modal fade" id="enableAuditingModal" tabindex="-1" role="dialog"
+      aria-labelledby="enableAuditingModal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -91,8 +102,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="disableModal" tabindex="-1" role="dialog"
-      aria-labelledby="disableModal" aria-hidden="true">
+<div class="modal fade" id="disableAuditingModal" tabindex="-1" role="dialog"
+      aria-labelledby="disableAuditingModal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -109,6 +120,33 @@
                 <button type="button" class="btn btn-default"
                         data-dismiss="modal">Close</button>
                 <form action="/permissions/{{permission.name}}/disable-auditing" method="post"
+                      class="inline">
+                    {{ xsrf_form() }}
+                    <button type="submit" class="btn btn-primary">Disable</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="disablePermModal" tabindex="-1" role="dialog"
+      aria-labelledby="disablePermModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">&times;</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title">Disable Permission</h4>
+           </div>
+            <div class="modal-body">
+                <p>Are you sure you want to disable this permission?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default"
+                        data-dismiss="modal">Close</button>
+                <form action="/permissions/{{permission.name}}/disable" method="post"
                       class="inline">
                     {{ xsrf_form() }}
                     <button type="submit" class="btn btn-primary">Disable</button>

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -215,7 +215,8 @@ class GroupGraph(object):
     @staticmethod
     def _get_permission_metadata(session):
         '''
-        Returns a dict of groupname: { list of permissions }.
+        Returns a dict of groupname: { list of permissions }. Note
+        that disabled permissions are not included.
         '''
         out = defaultdict(list)  # groupid -> [ ... ]
 
@@ -223,6 +224,7 @@ class GroupGraph(object):
             Permission.id == PermissionMap.permission_id,
             PermissionMap.group_id == Group.id,
             Group.enabled == True,
+            Permission.enabled == True,
         )
 
         for (permission, permission_map) in permissions:

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -258,11 +258,10 @@ class GroupGraph(object):
         '''
         Returns a set of PermissionTuple instances.
         '''
+        # TODO: import here to avoid circular dependency
+        from grouper.permissions import get_all_enabled_permissions
         out = set()
-        permissions = (
-            session.query(Permission)
-            .order_by(Permission.name)
-        )
+        permissions = get_all_enabled_permissions(session)
         for permission in permissions:
             out.add(PermissionTuple(
                 id=permission.id,

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -259,9 +259,9 @@ class GroupGraph(object):
         Returns a set of PermissionTuple instances.
         '''
         # TODO: import here to avoid circular dependency
-        from grouper.permissions import get_all_enabled_permissions
+        from grouper.permissions import get_all_permissions
         out = set()
-        permissions = get_all_enabled_permissions(session)
+        permissions = get_all_permissions(session)
         for permission in permissions:
             out.add(PermissionTuple(
                 id=permission.id,

--- a/grouper/models/group.py
+++ b/grouper/models/group.py
@@ -154,6 +154,9 @@ class Group(Model, CommentObjectMixin):
         )
 
     def my_permissions(self):
+        """
+        NOTE: Disabled permissions are not returned
+        """
 
         permissions = self.session.query(
             Permission.id,
@@ -162,6 +165,7 @@ class Group(Model, CommentObjectMixin):
             PermissionMap.argument,
             PermissionMap.granted_on,
         ).filter(
+            Permission.enabled == True,
             PermissionMap.permission_id == Permission.id,
             PermissionMap.group_id == self.id,
         ).all()

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -26,6 +26,7 @@ class Permission(Model):
     description = Column(Text, nullable=False)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
     _audited = Column('audited', Boolean, default=False, nullable=False)
+    enabled = Column('enabled', Boolean, default=True, nullable=False)
 
     @staticmethod
     def get(session, name=None):

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from datetime import datetime
 
-from sqlalchemy import asc, Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.model_base import Model
@@ -33,10 +33,6 @@ class Permission(Model):
         if name is not None:
             return session.query(Permission).filter_by(name=name).scalar()
         return None
-
-    @staticmethod
-    def get_all(session):
-        return session.query(Permission).order_by(asc("name")).all()
 
     @property
     def audited(self):

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -27,7 +27,7 @@ from grouper.user_group import get_groups_by_user
 from grouper.util import matches_glob
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Set, TYPE_CHECKING  # noqa
+    from typing import Dict, List, Optional, Set  # noqa
     from grouper.models.base.session import Session  # noqa
 
 # Singleton
@@ -63,7 +63,7 @@ def create_permission(session, name, description):
     Returns:
         The created permission that has been added to the session
     """
-    permission = Permission(session, name=name, description=description)
+    permission = Permission(name=name, description=description)
     permission.add(session)
     return permission
 
@@ -259,8 +259,8 @@ def disable_permission_auditing(session, permission_name, actor_user_id):
 
 
 def get_groups_by_permission(session, permission):
-    """For a given permission, return the groups and associated arguments that
-    have that permission.
+    """For an enabled permission, return the groups and associated arguments that
+    have that permission. If the permission is disabled, return empty list.
 
     Args:
         session(models.base.session.Session): database session

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -289,7 +289,8 @@ def get_owners_by_grantable_permission(session, separate_global=False):
         {argument: [owner1, ...], }, } where 'owners' are models.Group objects.
         And 'argument' can be '*' which means 'anything'.
     """
-    all_permissions = {permission.name: permission for permission in get_all_enabled_permissions(session)}
+    all_permissions = {permission.name: permission
+                       for permission in get_all_enabled_permissions(session)}
     all_groups = session.query(Group).filter(Group.enabled == True).all()
 
     owners_by_arg_by_perm = defaultdict(lambda: defaultdict(list))

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -213,11 +213,13 @@ def get_groups_by_permission(session, permission):
 
     Args:
         session(models.base.session.Session): database session
-        permission_name(Permission): permission in question
+        permission(models.Permission): permission in question
 
     Returns:
         List of 2-tuple of the form (Group, argument).
     """
+    if not permission.enabled:
+        return []
     return session.query(
         Group.groupname,
         PermissionMap.argument,
@@ -301,9 +303,9 @@ def get_owners_by_grantable_permission(session, separate_global=False):
             PermissionMap.granted_on,
             Group,
     ).filter(
-            Permission.enabled == True,
             PermissionMap.group_id == Group.id,
             Permission.id == PermissionMap.permission_id,
+            Permission.enabled == True,
     ).all()
 
     grants_by_group = defaultdict(list)

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -51,8 +51,8 @@ class NoSuchPermission(Exception):
         self.name = name
 
 
-def create_permission(session, name, description):
-    # type: (Session, str, str) -> Permission
+def create_permission(session, name, description=''):
+    # type: (Session, str, Optional[str]) -> Permission
     """Create and add a new permission to database
 
     Arg(s):
@@ -63,7 +63,7 @@ def create_permission(session, name, description):
     Returns:
         The created permission that has been added to the session
     """
-    permission = Permission(name=name, description=description)
+    permission = Permission(name=name, description=description or '')
     permission.add(session)
     return permission
 
@@ -112,7 +112,7 @@ def get_permission(session, name):
     return Permission.get(session, name=name)
 
 
-def get_or_create_permission(session, name, description=None):
+def get_or_create_permission(session, name, description=''):
     # type: (Session, str, Optional[str]) -> Tuple[Optional[Permission], bool]
     """Get a permission or create it if it doesn't already exist
 
@@ -128,7 +128,7 @@ def get_or_create_permission(session, name, description=None):
     is_new = False
     if not perm:
         is_new = True
-        perm = create_permission(session, name, description)
+        perm = create_permission(session, name, description=description or '')
     return perm, is_new
 
 

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -92,7 +92,7 @@ def get_all_permissions(session, include_disabled=False):
 
     Arg(s):
         session(models.base.session.Session): database session
-        include_disabled(bool): True to include also disabled
+        include_disabled(bool): True to also include disabled
             permissions. Make sure you really want this.
 
     Returns:

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -51,6 +51,23 @@ class NoSuchPermission(Exception):
         self.name = name
 
 
+def create_permission(session, name, description):
+    # type: (Session, str, str) -> Permission
+    """Create and add a new permission to database
+
+    Arg(s):
+        session(models.base.session.Session): database session
+        name(str): the name of the permission
+        description(str): the description of the permission
+
+    Returns:
+        The created permission that has been added to the session
+    """
+    permission = Permission(session, name=name, description=description)
+    permission.add(session)
+    return permission
+
+
 def get_all_enabled_permissions(session):
     # type: (Session) -> List[Permission]
     """Get all enabled permissions
@@ -61,7 +78,11 @@ def get_all_enabled_permissions(session):
     Returns:
         List of all enabled permissions, sorted by ascending permission name
     """
-    return session.query(Permission).filter(Permission.enabled == True).order_by(asc(Permission.name)).all()
+    return session.query(
+        Permission,
+    ).filter(
+        Permission.enabled == True,
+    ).order_by(asc(Permission.name)).all()
 
 
 def get_all_permissions(session):

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -27,7 +27,7 @@ from grouper.user_group import get_groups_by_user
 from grouper.util import matches_glob
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Set  # noqa
+    from typing import Dict, List, Optional, Set, Tuple  # noqa
     from grouper.models.base.session import Session  # noqa
 
 # Singleton

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -112,6 +112,26 @@ def get_permission(session, name):
     return Permission.get(session, name=name)
 
 
+def get_or_create_permission(session, name, description=None):
+    # type: (Session, str, Optional[str]) -> Tuple[Optional[Permission], bool]
+    """Get a permission or create it if it doesn't already exist
+
+    Arg(s):
+        session(models.base.session.Session): database session
+        name(str): the name of the permission
+        description(str): the description for the permission if it is created
+
+    Returns:
+        (permission, is_new) tuple
+    """
+    perm = get_permission(session, name)
+    is_new = False
+    if not perm:
+        is_new = True
+        perm = create_permission(session, name, description)
+    return perm, is_new
+
+
 def grant_permission(session, group_id, permission_id, argument=''):
     """
     Grant a permission to this group. This will fail if the (permission, argument) has already

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -86,7 +86,7 @@ def create_permission(session, name, description=''):
 
 
 def get_all_permissions(session, include_disabled=False):
-    # type: (Session) -> List[Permission]
+    # type: (Session, Optional[bool]) -> List[Permission]
     """Get permissions that exist in the database, either only enabled
     permissions, or both enabled and disabled ones
 

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -99,7 +99,7 @@ def get_all_permissions(session):
 
 
 def get_permission(session, name):
-    # type: (Session) -> Optional[Permission]
+    # type: (Session, str) -> Optional[Permission]
     """Get a permission
 
     Arg(s):

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -53,12 +53,42 @@ class NoSuchPermission(Exception):
 
 def get_all_enabled_permissions(session):
     # type: (Session) -> List[Permission]
-    return session.query(Permission).filter(Permission.enabled == True).order_by(asc("name")).all()
+    """Get all enabled permissions
+
+    Arg(s):
+        session(models.base.session.Session): database session
+
+    Returns:
+        List of all enabled permissions, sorted by ascending permission name
+    """
+    return session.query(Permission).filter(Permission.enabled == True).order_by(asc(Permission.name)).all()
 
 
 def get_all_permissions(session):
     # type: (Session) -> List[Permission]
-    return session.query(Permission).order_by(asc("name")).all()
+    """Get all permissions, enabled or disabled
+
+    Arg(s):
+        session(models.base.session.Session): database session
+
+    Returns:
+        List of all permissions---enabled or not---sorted by ascending permission name
+    """
+    return session.query(Permission).order_by(asc(Permission.name)).all()
+
+
+def get_permission(session, name):
+    # type: (Session) -> Optional[Permission]
+    """Get a permission
+
+    Arg(s):
+        session(models.base.session.Session): database session
+        name(str): the name of the permission
+
+    Returns:
+        The permission if found, None otherwise
+    """
+    return Permission.get(session, name=name)
 
 
 def grant_permission(session, group_id, permission_id, argument=''):
@@ -153,7 +183,7 @@ def disable_permission(session, permission_name, actor_user_id):
         permission_name(str): name of permission in question
         actor_user_id(int): id of user who is disabling the permission
     """
-    permission = Permission.get(session, permission_name)
+    permission = get_permission(session, permission_name)
     if not permission:
         raise NoSuchPermission(name=permission_name)
     permission.enabled = False
@@ -171,7 +201,7 @@ def enable_permission_auditing(session, permission_name, actor_user_id):
         permission_name(str): name of permission in question
         actor_user_id(int): id of user who is enabling auditing
     """
-    permission = Permission.get(session, permission_name)
+    permission = get_permission(session, permission_name)
     if not permission:
         raise NoSuchPermission(name=permission_name)
 
@@ -193,7 +223,7 @@ def disable_permission_auditing(session, permission_name, actor_user_id):
         permission_name(str): name of permission in question
         actor_user_id(int): id of user who is disabling auditing
     """
-    permission = Permission.get(session, permission_name)
+    permission = get_permission(session, permission_name)
     if not permission:
         raise NoSuchPermission(name=permission_name)
 

--- a/grouper/public_key.py
+++ b/grouper/public_key.py
@@ -265,6 +265,7 @@ def get_public_key_tag_permissions(session, tag):
     ).filter(
         TagPermissionMap.permission_id == Permission.id,
         TagPermissionMap.tag_id == tag.id,
+        Permission.enabled == True,
     ).all()
 
     return permissions

--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -180,6 +180,7 @@ def service_account_permissions(session, service_account):
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
         ServiceAccount.user_id == User.id,
         User.enabled == True,
+        Permission.enabled == True,
     )
     out = []
     for permission in permissions:
@@ -201,6 +202,7 @@ def all_service_account_permissions(session):
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
         ServiceAccount.user_id == User.id,
         User.enabled == True,
+        Permission.enabled == True,
     )
     for permission in permissions:
         out[permission[1].service_account.user.username].append(ServiceAccountPermission(

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -79,10 +79,10 @@ def user_grantable_permissions(session, user):
     Returns a list of tuples (Permission, argument) that the user is allowed to grant.
     '''
     # avoid circular dependency
-    from grouper.permissions import filter_grantable_permissions
+    from grouper.permissions import filter_grantable_permissions, get_all_enabled_permissions
 
     all_permissions = {permission.name: permission
-                       for permission in Permission.get_all(session)}
+                       for permission in get_all_enabled_permissions(session)}
     if user_is_permission_admin(session, user):
         result = [(perm, '*') for perm in all_permissions.values()]
         return sorted(result, key=lambda x: x[0].name + x[1])

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -13,6 +13,8 @@ from grouper.models.permission_map import PermissionMap
 def user_has_permission(session, user, permission, argument=None):
     """See if this user has a given permission/argument
 
+    NOTE: only enabled permissions are considered.
+
     This walks a user's permissions (local/direct only) and determines if they have the given
     permission. If an argument is specified, we validate if they have exactly that argument
     or if they have the wildcard ('*') argument.
@@ -35,6 +37,7 @@ def user_has_permission(session, user, permission, argument=None):
 
 
 def user_permissions(session, user):
+    """Return a user's enabled permissions"""
 
     # TODO: Make this walk the tree, so we can get a user's entire set of permissions.
     now = datetime.utcnow()
@@ -52,6 +55,7 @@ def user_permissions(session, user):
         GroupEdge.active == True,
         user.enabled == True,
         Group.enabled == True,
+        Permission.enabled == True,
         or_(
             GroupEdge.expiration > now,
             GroupEdge.expiration == None

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -79,10 +79,10 @@ def user_grantable_permissions(session, user):
     Returns a list of tuples (Permission, argument) that the user is allowed to grant.
     '''
     # avoid circular dependency
-    from grouper.permissions import filter_grantable_permissions, get_all_enabled_permissions
+    from grouper.permissions import filter_grantable_permissions, get_all_permissions
 
     all_permissions = {permission.name: permission
-                       for permission in get_all_enabled_permissions(session)}
+                       for permission in get_all_permissions(session)}
     if user_is_permission_admin(session, user):
         result = [(perm, '*') for perm in all_permissions.values()]
         return sorted(result, key=lambda x: x[0].name + x[1])

--- a/itests/test_fe_permission_requests.py
+++ b/itests/test_fe_permission_requests.py
@@ -11,9 +11,8 @@ from tests.url_util import url
 from tests.util import grant_permission
 
 from grouper.constants import PERMISSION_ADMIN, PERMISSION_GRANT
-from grouper.models.permission import Permission
 from grouper.models.permission_request import PermissionRequest
-from grouper.permissions import create_request, update_request
+from grouper.permissions import create_request, get_or_create_permission, update_request
 
 # Set up a permission requesting scenario in which REQUESTING_USER has both
 # inbound and outbound requests that they should be able to see on the requests
@@ -35,12 +34,12 @@ ADMIN_USER = 'cbguder@a.co'
 def do_request_perms(groups, permissions, session, users):
     # Create the two test perms + PERMISSION_GRANT + PERMISSION_ADMIN, give GRANTING_TEAM
     # appropriate PERMISSION_GRANT, and make sure there's an admin (has PERMISSION_ADMIN)
-    test_perm_granter = Permission.get_or_create(
-        session, name=PERM_WITH_GRANTER, description='perm with granter')[0]
-    test_perm_nogranter = Permission.get_or_create(
-        session, name=PERM_NO_GRANTER, description='perm without granter')[0]
-    grant_perm = Permission.get_or_create(session, name=PERMISSION_GRANT, description='')[0]
-    admin_perm = Permission.get_or_create(session, name=PERMISSION_ADMIN, description='')[0]
+    test_perm_granter = get_or_create_permission(
+        session, PERM_WITH_GRANTER, description='perm with granter')[0]
+    test_perm_nogranter = get_or_create_permission(
+        session, PERM_NO_GRANTER, description='perm without granter')[0]
+    grant_perm = get_or_create_permission(session, PERMISSION_GRANT, description='')[0]
+    admin_perm = get_or_create_permission(session, PERMISSION_ADMIN, description='')[0]
 
     session.commit()
 

--- a/itests/test_fe_permission_requests.py
+++ b/itests/test_fe_permission_requests.py
@@ -38,8 +38,8 @@ def do_request_perms(groups, permissions, session, users):
         session, PERM_WITH_GRANTER, description='perm with granter')[0]
     test_perm_nogranter = get_or_create_permission(
         session, PERM_NO_GRANTER, description='perm without granter')[0]
-    grant_perm = get_or_create_permission(session, PERMISSION_GRANT, description='')[0]
-    admin_perm = get_or_create_permission(session, PERMISSION_ADMIN, description='')[0]
+    grant_perm = get_or_create_permission(session, PERMISSION_GRANT)[0]
+    admin_perm = get_or_create_permission(session, PERMISSION_ADMIN)[0]
 
     session.commit()
 

--- a/itests/test_fe_users.py
+++ b/itests/test_fe_users.py
@@ -11,7 +11,7 @@ from tests.util import add_member, grant_permission
 
 from fixtures import async_server, browser  # noqa: F401
 from grouper.constants import AUDIT_SECURITY
-from grouper.models.permission import Permission
+from grouper.permissions import get_or_create_permission
 from grouper.models.public_key import PublicKey
 
 
@@ -31,7 +31,7 @@ def test_disable_last_owner(async_server, browser):  # noqa: F811
 
 
 def test_list_public_keys(async_server, browser, session, users, groups):  # noqa: F811
-    permission = Permission.get_or_create(session, name=AUDIT_SECURITY, description="")[0]
+    permission = get_or_create_permission(session, AUDIT_SECURITY, description="")[0]
     user = users["cbguder@a.co"]
     group = groups["group-admins"]
 

--- a/itests/test_fe_users.py
+++ b/itests/test_fe_users.py
@@ -11,8 +11,8 @@ from tests.util import add_member, grant_permission
 
 from fixtures import async_server, browser  # noqa: F401
 from grouper.constants import AUDIT_SECURITY
-from grouper.permissions import get_or_create_permission
 from grouper.models.public_key import PublicKey
+from grouper.permissions import get_or_create_permission
 
 
 def test_disable_last_owner(async_server, browser):  # noqa: F811

--- a/itests/test_fe_users.py
+++ b/itests/test_fe_users.py
@@ -31,7 +31,7 @@ def test_disable_last_owner(async_server, browser):  # noqa: F811
 
 
 def test_list_public_keys(async_server, browser, session, users, groups):  # noqa: F811
-    permission = get_or_create_permission(session, AUDIT_SECURITY, description="")[0]
+    permission = get_or_create_permission(session, AUDIT_SECURITY)[0]
     user = users["cbguder@a.co"]
     group = groups["group-admins"]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,9 +9,8 @@ from grouper.graph import Graph
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import Session, get_db_engine
 from grouper.models.group import Group
-from grouper.models.permission import Permission
 from grouper.models.user import User
-from grouper.permissions import enable_permission_auditing
+from grouper.permissions import create_permission, enable_permission_auditing, get_or_create_permission
 from grouper.service_account import create_service_account
 from path_util import db_url
 from util import add_member, grant_permission
@@ -202,8 +201,8 @@ def permissions(session, users):
                        PERMISSION_AUDITOR, "team-sre", USER_ADMIN, GROUP_ADMIN]
 
     permissions = {
-        permission: Permission.get_or_create(
-            session, name=permission, description="{} permission".format(permission)
+        permission: get_or_create_permission(
+            session, permission, "{} permission".format(permission)
         )[0]
         for permission in all_permissions
     }

--- a/tests/test_api_handlers.py
+++ b/tests/test_api_handlers.py
@@ -11,10 +11,9 @@ from fixtures import api_app as app  # noqa
 from fixtures import standard_graph, graph, users, groups, service_accounts, session, permissions  # noqa
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.models.counter import Counter
-from grouper.models.permission import Permission
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user_token import UserToken
-from grouper.permissions import grant_permission_to_service_account
+from grouper.permissions import get_permission, grant_permission_to_service_account
 from grouper.public_key import add_public_key
 from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
 from grouper.user_password import add_new_user_password, delete_user_password, user_passwords
@@ -125,7 +124,7 @@ def test_service_accounts(session, standard_graph, users, http_client, base_url)
 
     # Delegate a permission to the service account and check for it.
     service_account = ServiceAccount.get(session, name="service@a.co")
-    permission = Permission.get(session, name="team-sre")
+    permission = get_permission(session, "team-sre")
     grant_permission_to_service_account(session, service_account, permission, "*")
     graph.update_from_db(session)
     resp = yield http_client.fetch(api_url)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -21,7 +21,7 @@ from grouper.models.audit_log import AuditLogCategory, AuditLog
 from grouper.models.group import Group
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
-from grouper.permissions import create_permission, enable_permission_auditing
+from grouper.permissions import enable_permission_auditing, get_or_create_permission
 from grouper.settings import settings
 from url_util import url
 from util import add_member, get_users, grant_permission
@@ -280,9 +280,9 @@ def test_auditor_promotion(mock_nnp, mock_gagn, session, graph, permissions, use
     })
     # create permissions
     permissions.update({
-        permission: create_permission(
-            session, permission, "{} permission".format(permission)
-        )
+        permission: get_or_create_permission(
+            session, permission, description="{} permission".format(permission)
+        )[0]
         for permission in [PERMISSION_NAME]
     })
     # add users to groups

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -19,10 +19,9 @@ from grouper.constants import AUDIT_MANAGER, AUDIT_VIEWER, PERMISSION_AUDITOR
 from grouper.graph import NoSuchGroup
 from grouper.models.audit_log import AuditLogCategory, AuditLog
 from grouper.models.group import Group
-from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
-from grouper.permissions import enable_permission_auditing
+from grouper.permissions import create_permission, enable_permission_auditing
 from grouper.settings import settings
 from url_util import url
 from util import add_member, get_users, grant_permission
@@ -281,9 +280,9 @@ def test_auditor_promotion(mock_nnp, mock_gagn, session, graph, permissions, use
     })
     # create permissions
     permissions.update({
-        permission: Permission.get_or_create(
-            session, name=permission, description="{} permission".format(permission)
-        )[0]
+        permission: create_permission(
+            session, permission, "{} permission".format(permission)
+        )
         for permission in [PERMISSION_NAME]
     })
     # add users to groups

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,8 @@
 from fixtures import graph, groups, service_accounts, permissions, session, standard_graph, users  # noqa
 
-from grouper.permissions import disable_permission, get_groups_by_permission
+from grouper.permissions import disable_permission, get_groups_by_permission, get_permission
 from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES
-from grouper.models.permission import Permission
 
 
 def test_group_edge_roles_order_unchanged():
@@ -19,7 +18,7 @@ def test_group_edge_roles_order_unchanged():
 def test_permission_exclude_inactive_groups(session, standard_graph):
     """Ensure disabled groups are excluded from permission data."""
     group = Group.get(session, name="team-sre")
-    permission = Permission.get(session, name="ssh")
+    permission = get_permission(session, "ssh")
     assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
     group.disable()
     assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]
@@ -27,7 +26,7 @@ def test_permission_exclude_inactive_groups(session, standard_graph):
 
 def test_permission_exclude_inactive_permissions(session, standard_graph, users):
     """Ensure disabled permissions are excluded from permission data."""
-    permission = Permission.get(session, name="ssh")
+    permission = get_permission(session, "ssh")
     assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
     disable_permission(session, "ssh", users['cbguder@a.co'].id)
     assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,11 +22,3 @@ def test_permission_exclude_inactive_groups(session, standard_graph):
     assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
     group.disable()
     assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]
-
-
-def test_permission_exclude_inactive_permissions(session, standard_graph, users):
-    """Ensure disabled permissions are excluded from permission data."""
-    permission = get_permission(session, "ssh")
-    assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
-    disable_permission(session, "ssh", users['cbguder@a.co'].id)
-    assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from fixtures import graph, groups, service_accounts, permissions, session, standard_graph, users  # noqa
 
-from grouper.permissions import get_groups_by_permission
+from grouper.permissions import disable_permission, get_groups_by_permission
 from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES
 from grouper.models.permission import Permission
@@ -16,10 +16,18 @@ def test_group_edge_roles_order_unchanged():
     assert GROUP_EDGE_ROLES.index("np-owner") == 3
 
 
-def test_permission_exclude_inactive(session, standard_graph):
+def test_permission_exclude_inactive_groups(session, standard_graph):
     """Ensure disabled groups are excluded from permission data."""
     group = Group.get(session, name="team-sre")
     permission = Permission.get(session, name="ssh")
     assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
     group.disable()
+    assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]
+
+
+def test_permission_exclude_inactive_permissions(session, standard_graph, users):
+    """Ensure disabled permissions are excluded from permission data."""
+    permission = Permission.get(session, name="ssh")
+    assert "team-sre" in [g[0] for g in get_groups_by_permission(session, permission)]
+    disable_permission(session, "ssh", users['cbguder@a.co'].id)
     assert "team-sre" not in [g[0] for g in get_groups_by_permission(session, permission)]

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -30,7 +30,6 @@ from grouper.permissions import (
         create_permission,
         disable_permission,
         filter_grantable_permissions,
-        get_all_enabled_permissions,
         get_all_permissions,
         get_grantable_permissions,
         get_groups_by_permission,
@@ -247,7 +246,7 @@ def test_permission_grant_to_owners(session, standard_graph, groups, grantable_p
     grant_permission(groups["security-team"], perm_admin)
 
     owners_by_arg_by_perm = get_owners_by_grantable_permission(session)
-    all_permissions = get_all_enabled_permissions(session)
+    all_permissions = get_all_permissions(session)
     for perm in all_permissions:
         assert perm.name in owners_by_arg_by_perm, 'all permission should be represented'
         assert groups["security-team"] in owners_by_arg_by_perm[perm.name]["*"], \
@@ -601,8 +600,9 @@ def test_exclude_inactive_permissions(
     grant_perms = [x for x in user_permissions(session, users['cbguder@a.co'])
                    if x.name == PERMISSION_GRANT]
     assert 'ssh' == filter_grantable_permissions(session, grant_perms)[0][0].name
-    assert "ssh" in (p.name for p in get_all_enabled_permissions(session))
     assert "ssh" in (p.name for p in get_all_permissions(session))
+    assert "ssh" in (p.name for p in get_all_permissions(session, include_disabled=False))
+    assert "ssh" in (p.name for p in get_all_permissions(session, include_disabled=True))
     assert "ssh" in get_grantable_permissions(session, [])
     assert "team-sre" in [g[0] for g in get_groups_by_permission(session, perm_ssh)]
     assert get_owner_arg_list(session, perm_ssh, "*")
@@ -617,8 +617,9 @@ def test_exclude_inactive_permissions(
     grant_perms = [x for x in user_permissions(session, users['cbguder@a.co'])
                    if x.name == PERMISSION_GRANT]
     assert not filter_grantable_permissions(session, grant_perms)
-    assert not "ssh" in (p.name for p in get_all_enabled_permissions(session))
-    assert "ssh" in (p.name for p in get_all_permissions(session))
+    assert not "ssh" in (p.name for p in get_all_permissions(session))
+    assert not "ssh" in (p.name for p in get_all_permissions(session, include_disabled=False))
+    assert "ssh" in (p.name for p in get_all_permissions(session, include_disabled=True))
     assert not "ssh" in get_grantable_permissions(session, [])
     assert not get_groups_by_permission(session, perm_ssh)
     assert not get_owner_arg_list(session, perm_ssh, "*")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -582,10 +582,10 @@ def test_reject_disabling_system_permissions(perm_name, session, permissions):
     assert exc.value.name == perm_name
 
 
-def test_exclude_inactive_permissions(
+def test_exclude_disabled_permissions(
         session, standard_graph, users, groups, permissions):
     """
-    Ensure disabled permissions are excluded from various
+    Ensure that disabled permissions are excluded from various
     functions/methods that return data from the models.
     """
     perm_ssh = get_permission(session, "ssh")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -26,6 +26,7 @@ from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
 from grouper.permissions import (
         disable_permission,
+        get_all_enabled_permissions,
         get_grantable_permissions,
         get_owner_arg_list,
         get_owners_by_grantable_permission,
@@ -235,7 +236,7 @@ def test_permission_grant_to_owners(session, standard_graph, groups, grantable_p
     grant_permission(groups["security-team"], perm_admin)
 
     owners_by_arg_by_perm = get_owners_by_grantable_permission(session)
-    all_permissions = Permission.get_all(session)
+    all_permissions = get_all_enabled_permissions(session)
     for perm in all_permissions:
         assert perm.name in owners_by_arg_by_perm, 'all permission should be represented'
         assert groups["security-team"] in owners_by_arg_by_perm[perm.name]["*"], \
@@ -502,6 +503,7 @@ def test_disabling_permission(session, groups, standard_graph, http_client, base
     priv_user_name = 'cbguder@a.co' # user with PERMISSION_ADMIN
     priv_headers = {'X-Grouper-User': priv_user_name}
     disable_url = url(base_url, '/permissions/{}/disable'.format(perm_name))
+    disable_url_non_exist_perm = url(base_url, '/permissions/no.exists/disable')
 
     graph = standard_graph
 
@@ -536,5 +538,5 @@ def test_disabling_permission(session, groups, standard_graph, http_client, base
 
     with pytest.raises(HTTPError) as exc:
         yield http_client.fetch(
-            url(base_url, '/permissions/no.exists/disable'), method="POST", headers=priv_headers, body="")
+            disable_url_non_exist_perm, method="POST", headers=priv_headers, body="")
     assert exc.value.code == 404

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -42,10 +42,10 @@ from util import get_group_permissions, get_user_permissions, grant_permission
 
 @pytest.fixture
 def grantable_permissions(session, standard_graph):
-    perm_grant = create_permission(session, PERMISSION_GRANT, "")
-    perm0 = create_permission(session, "grantable", "")
-    perm1 = create_permission(session, "grantable.one", "")
-    perm2 = create_permission(session, "grantable.two", "")
+    perm_grant = create_permission(session, PERMISSION_GRANT)
+    perm0 = create_permission(session, "grantable")
+    perm1 = create_permission(session, "grantable.one")
+    perm2 = create_permission(session, "grantable.two")
     session.commit()
 
     return perm_grant, perm0, perm1, perm2
@@ -232,7 +232,7 @@ def test_permission_grant_to_owners(session, standard_graph, groups, grantable_p
     assert sorted(res) == [groups["all-teams"]], "negative test of substring wildcard matches"
 
     # permission admins have all the power
-    perm_admin = create_permission(session, PERMISSION_ADMIN, "")
+    perm_admin = create_permission(session, PERMISSION_ADMIN)
     session.commit()
     grant_permission(groups["security-team"], perm_admin)
 
@@ -397,7 +397,7 @@ def test_limited_permissions_global_approvers(session, standard_graph, groups, g
         http_client, base_url):
     """Test that notifications are not sent to global approvers."""
     perm_grant, _, perm1, _ = grantable_permissions
-    perm_admin = create_permission(session, PERMISSION_ADMIN, "")
+    perm_admin = create_permission(session, PERMISSION_ADMIN)
     session.commit()
     # one circuit-breaking admin grant, one wildcard grant
     grant_permission(groups["sad-team"], perm_admin, argument="")
@@ -424,7 +424,7 @@ def test_regress_permreq_global_approvers(session, standard_graph, groups, grant
         http_client, base_url):
     """Validates that we can render a permission request form where a global approver exists"""
     perm_grant, _, perm1, _ = grantable_permissions
-    perm_admin = create_permission(session, PERMISSION_ADMIN, "")
+    perm_admin = create_permission(session, PERMISSION_ADMIN)
     session.commit()
     grant_permission(groups["security-team"], perm_admin)
 
@@ -448,7 +448,7 @@ def test_grant_and_revoke(session, standard_graph, graph, groups, permissions,
                 graph.permission_metadata[group_name]))
 
     # make some permission admins
-    perm_admin = create_permission(session, PERMISSION_ADMIN, "")
+    perm_admin = create_permission(session, PERMISSION_ADMIN)
     session.commit()
     grant_permission(groups["security-team"], perm_admin)
 
@@ -508,7 +508,7 @@ def test_disabling_permission(session, groups, standard_graph, http_client, base
 
     graph = standard_graph
 
-    perm_admin = create_permission(session, PERMISSION_ADMIN, "")
+    perm_admin = create_permission(session, PERMISSION_ADMIN)
     session.commit()
     # overload `group-admins` for also permission admin
     grant_permission(groups["group-admins"], perm_admin)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -25,6 +25,7 @@ from grouper.models.service_account import ServiceAccount
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
 from grouper.permissions import (
+        disable_permission,
         get_grantable_permissions,
         get_owner_arg_list,
         get_owners_by_grantable_permission,
@@ -491,3 +492,49 @@ def test_grant_and_revoke(session, standard_graph, graph, groups, permissions,
 
     graph.update_from_db(session)
     assert not _check_graph_for_perm(graph), "permissions revoked successfully"
+
+
+@pytest.mark.gen_test
+def test_disabling_permission(session, groups, standard_graph, http_client, base_url):
+    perm_name = 'sudo'
+    nonpriv_user_name = 'oliver@a.co' # user without PERMISSION_ADMIN
+    nonpriv_headers = {'X-Grouper-User': nonpriv_user_name}
+    priv_user_name = 'cbguder@a.co' # user with PERMISSION_ADMIN
+    priv_headers = {'X-Grouper-User': priv_user_name}
+    disable_url = url(base_url, '/permissions/{}/disable'.format(perm_name))
+
+    graph = standard_graph
+
+    perm_admin, _ = Permission.get_or_create(session, name=PERMISSION_ADMIN, description="")
+    session.commit()
+    # overload `group-admins` for also permission admin
+    grant_permission(groups["group-admins"], perm_admin)
+
+    assert Permission.get(session, name=perm_name).enabled
+    assert 'sudo:shell' in get_user_permissions(graph, 'gary@a.co')
+    assert 'sudo:shell' in get_user_permissions(graph, 'oliver@a.co')
+
+    # attempt to disable the permission -> should fail cuz actor
+    # doesn't have PERMISSION_ADMIN
+    with pytest.raises(HTTPError) as exc:
+        yield http_client.fetch(disable_url, method="POST", headers=nonpriv_headers, body="")
+    assert exc.value.code == 403
+    # check that no change
+    assert Permission.get(session, name=perm_name).enabled
+    graph.update_from_db(session)
+    assert 'sudo:shell' in get_user_permissions(graph, 'gary@a.co')
+    assert 'sudo:shell' in get_user_permissions(graph, 'oliver@a.co')
+
+    # an actor with PERMISSION_ADMIN is allowed to disable the
+    # permission
+    resp = yield http_client.fetch(disable_url, method="POST", headers=priv_headers, body="")
+    assert resp.code == 200
+    assert not Permission.get(session, name=perm_name).enabled
+    graph.update_from_db(session)
+    assert not 'sudo:shell' in get_user_permissions(graph, 'gary@a.co')
+    assert not 'sudo:shell' in get_user_permissions(graph, 'oliver@a.co')
+
+    with pytest.raises(HTTPError) as exc:
+        yield http_client.fetch(
+            url(base_url, '/permissions/no.exists/disable'), method="POST", headers=priv_headers, body="")
+    assert exc.value.code == 404

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -251,11 +251,10 @@ def test_grant_permission_to_tag(users, http_client, base_url, session):
 
     user = session.query(User).filter_by(username="testuser@a.co").scalar()
 
-    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
+    perm = create_permission(session, TAG_EDIT)
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")
 
     fe_url = url(base_url, '/tags')
     resp = yield http_client.fetch(fe_url, method="POST",
@@ -294,11 +293,10 @@ def test_edit_tag(users, http_client, base_url, session):
 
     user = session.query(User).filter_by(username="testuser@a.co").scalar()
 
-    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
+    perm = create_permission(session, TAG_EDIT)
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")
 
     fe_url = url(base_url, '/tags')
     resp = yield http_client.fetch(fe_url, method="POST",
@@ -327,17 +325,14 @@ def test_permissions(users, http_client, base_url, session):
 
     user = session.query(User).filter_by(username="testuser@a.co").scalar()
 
-    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
+    perm = create_permission(session, TAG_EDIT)
     session.commit()
 
-    perm = create_permission(session, "it.literally.does.not.matter",
-                             "Why is this not nullable?")
+    perm = create_permission(session, "it.literally.does.not.matter")
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, TAG_EDIT), "*")
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, "it.literally.does.not.matter"), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, "it.literally.does.not.matter"), "*")
 
     fe_url = url(base_url, '/tags')
     resp = yield http_client.fetch(fe_url, method="POST",
@@ -406,11 +401,10 @@ def test_revoke_permission_from_tag(users, http_client, base_url, session):
 
     user = session.query(User).filter_by(username="testuser@a.co").scalar()
 
-    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
+    perm = create_permission(session, TAG_EDIT)
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")
 
     fe_url = url(base_url, '/tags')
     resp = yield http_client.fetch(fe_url, method="POST",

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -25,10 +25,8 @@ def test_tags(session, http_client, base_url, graph):
     perm2 = create_permission(session, "it.literally.does.not.matter", "Why is this not nullable?")
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, TAG_EDIT), "*")
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
-                     get_permission(session, "it.literally.does.not.matter"), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, "it.literally.does.not.matter"), "*")
 
     tag = PublicKeyTag(name="tyler_was_here")
     tag.add(session)

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -7,11 +7,10 @@ from fixtures import api_app as app  # noqa
 from fixtures import standard_graph, graph, users, groups, service_accounts, session, permissions  # noqa
 from grouper.constants import TAG_EDIT
 from grouper.models.group import Group
-from grouper.models.permission import Permission
 from grouper.models.public_key import PublicKey
 from grouper.models.public_key_tag import PublicKeyTag
 from grouper.models.user import User
-from grouper.permissions import grant_permission_to_tag
+from grouper.permissions import create_permission, get_permission, grant_permission_to_tag
 from grouper.public_key import add_public_key, add_tag_to_public_key, get_public_key_permissions
 from grouper.user_permissions import user_permissions
 from url_util import url
@@ -20,16 +19,16 @@ from util import grant_permission
 
 @pytest.mark.gen_test
 def test_tags(session, http_client, base_url, graph):
-    perm = Permission(name=TAG_EDIT, description="Why is this not nullable?")
-    perm.add(session)
+    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
     session.commit()
 
-    perm2 = Permission(name="it.literally.does.not.matter", description="Why is this not nullable?")
-    perm2.add(session)
+    perm2 = create_permission(session, "it.literally.does.not.matter", "Why is this not nullable?")
     session.commit()
 
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name=TAG_EDIT).scalar(), "*")
-    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), session.query(Permission).filter_by(name="it.literally.does.not.matter").scalar(), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
+                     get_permission(session, TAG_EDIT), "*")
+    grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(),
+                     get_permission(session, "it.literally.does.not.matter"), "*")
 
     tag = PublicKeyTag(name="tyler_was_here")
     tag.add(session)

--- a/tests/test_tags_api.py
+++ b/tests/test_tags_api.py
@@ -19,10 +19,10 @@ from util import grant_permission
 
 @pytest.mark.gen_test
 def test_tags(session, http_client, base_url, graph):
-    perm = create_permission(session, TAG_EDIT, "Why is this not nullable?")
+    perm = create_permission(session, TAG_EDIT)
     session.commit()
 
-    perm2 = create_permission(session, "it.literally.does.not.matter", "Why is this not nullable?")
+    perm2 = create_permission(session, "it.literally.does.not.matter")
     session.commit()
 
     grant_permission(session.query(Group).filter_by(groupname="all-teams").scalar(), get_permission(session, TAG_EDIT), "*")

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -72,18 +72,20 @@ def test_usertokens(standard_graph, session, users, groups, permissions):  # noq
 @pytest.fixture
 def user_admin_perm_to_auditors(session, groups):
     """Adds a USER_ADMIN permission to the "auditors" group"""
-    user_admin_perm, _ = get_or_create_permission(
-        session, USER_ADMIN, description="grouper.admin.users permission")
+    user_admin_perm, is_new = get_or_create_permission(session, USER_ADMIN,
+        description="grouper.admin.users permission")
     session.commit()
+
     grant_permission(groups["auditors"], user_admin_perm)
 
 
 @pytest.fixture
 def user_enable_perm_to_sre(session, groups):
     """Adds the (USER_ENABLE, *) permission to the group `team-sre` """
-    user_enable_perm, _ = get_or_create_permission(
-        session, USER_ENABLE, description="grouper.user.enable perm")
+    user_enable_perm, is_new = get_or_create_permission(session, USER_ENABLE,
+        description="grouper.user.enable perm")
     session.commit()
+
     grant_permission(groups["team-sre"], user_enable_perm, argument="*")
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -6,9 +6,9 @@ from tornado.httpclient import HTTPError
 from fixtures import fe_app as app  # noqa: F401
 from fixtures import standard_graph, graph, users, groups, service_accounts, session, permissions  # noqa: F401
 from grouper.constants import USER_ADMIN, USER_ENABLE
-from grouper.models.permission import Permission
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
+from grouper.permissions import get_or_create_permission
 from grouper.plugin.base import BasePlugin
 from grouper.plugin.proxy import PluginProxy
 from grouper.role_user import create_role_user
@@ -72,20 +72,18 @@ def test_usertokens(standard_graph, session, users, groups, permissions):  # noq
 @pytest.fixture
 def user_admin_perm_to_auditors(session, groups):
     """Adds a USER_ADMIN permission to the "auditors" group"""
-    user_admin_perm, is_new = Permission.get_or_create(session, name=USER_ADMIN,
-        description="grouper.admin.users permission")
+    user_admin_perm, _ = get_or_create_permission(
+        session, USER_ADMIN, description="grouper.admin.users permission")
     session.commit()
-
     grant_permission(groups["auditors"], user_admin_perm)
 
 
 @pytest.fixture
 def user_enable_perm_to_sre(session, groups):
     """Adds the (USER_ENABLE, *) permission to the group `team-sre` """
-    user_enable_perm, is_new = Permission.get_or_create(session, name=USER_ENABLE,
-        description="grouper.user.enable perm")
+    user_enable_perm, _ = get_or_create_permission(
+        session, USER_ENABLE, description="grouper.user.enable perm")
     session.commit()
-
     grant_permission(groups["team-sre"], user_enable_perm, argument="*")
 
 


### PR DESCRIPTION
Add a new `enabled` flag for permission. A disabled permission continues to exist in the database but its `enabled` flag is switched off, and, this is crucial, all the code that queries for a user's/group's permissions must skip this permission. (Alternatively we could delete the permission, but we are opting to avoid that so that we keep the history/paper trail of the permission.)

Introduce `get_all_permissions()`, `get_[or_create_]permission()`, and `create_permission`, into `grouper/permission.py`, and make existing code outside of business logic layer that directly uses the `Permission` model to use these new functions. These changes are not strictly necessary for this PR but help me ensure all existing code that queries for permissions only queries for enabled permissions.

No plan to support for enabling a disabled permission in this PR.

On the front-end, the permission view page will not show either button, and also will not show the groups that have the perm, if it is disabled.