### PR TITLE
Add pytest-xdist to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,8 @@ groupy
 mock==2.0.0
 mrproxy==0.3.4
 py==1.5.2
-pytest-mock==1.9.0
-pytest-tornado==0.4.5
-pytest==3.4.2
+pytest-mock==1.10.0
+pytest-tornado==0.5.0
+pytest-xdist==1.10
+pytest==3.5.0
 selenium==3.6.0

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -45,7 +45,7 @@ def test_user_is_auditor(standard_graph):  # noqa
     assert not user_is_auditor("oliver@a.co")
 
 
-def test_assert_can_join(users, groups):  # noqa
+def test_assert_can_join(standard_graph, users, groups):  # noqa
     """ Test various audit constraints to ensure that users can/can't join as appropriate. """
 
     # Non-auditor can join non-audited group as owner.
@@ -76,7 +76,7 @@ def test_assert_can_join(users, groups):  # noqa
         assert not assert_can_join(groups["audited-team"], groups["serving-team"])
 
 
-def test_assert_controllers_are_auditors(groups):  # noqa
+def test_assert_controllers_are_auditors(standard_graph, groups):  # noqa
     """ Test the method that determines if a subtree is controlled by auditors. """
 
     # Group is safely controlled by auditors.


### PR DESCRIPTION
This allows running tests in parallel with -n.  Time to run all
tests and itests decreases to 28s from 1m 48s on my laptop.