### PR TITLE
Stop requiring environment variables for tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,29 +93,26 @@ group.
 Running the tests
 -----------------
 
-Some tests require a recent (>= 2.31) version of chromedriver, which can be
-installed via apt or Homebrew:
+Some tests require a recent (>= 2.31) version of chromium-driver, which
+can be installed via apt or Homebrew:
 
 .. code:: bash
 
-    apt install chromium-chromedriver
+    apt install chromium-driver
 
-Once chromedriver is installed, the tests can be run using pytest:
+(This may be called chromium-chromedriver in older versions.)  Once
+chromium-driver is installed, the tests can be run using pytest:
 
 .. code:: bash
-
-    export PYTHONPATH=$(pwd)
-    export GROUPER_SETTINGS=$(pwd)/config/dev.yaml
 
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
     py.test tests
     py.test itests
 
-If you see test failures and suspect incompatible library versions
-(e.g., an existing tornado install at a different major release than
-that in our `requirements.txt`), then you can try using a virtual
-environment.
+If you see test failures and suspect incompatible library versions (e.g.,
+an existing tornado install at a different major release than that in our
+`requirements.txt`), then you can try using a virtual environment.
 
 .. code:: bash
 
@@ -124,3 +121,14 @@ environment.
     ~/merou-venv/bin/pip install -r requirements-dev.txt
     ~/merou-venv/bin/py.test tests
     ~/merou-venv/bin/py.test itests
+
+To run mypy, you will need Python 3 and install a different set of
+requirements:
+
+.. code:: bash
+
+    pip3 install -r requirements3.txt
+    ./mypy.sh
+
+You may want to create a separate virtual environment for Python 3,
+designating python3 as the Python interpreter for that environment.

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -8,7 +8,7 @@ from groupy.client import Groupy
 import pytest
 import selenium
 
-from tests.path_util import db_url, src_path
+from tests.path_util import bin_env, db_url, src_path
 
 
 def _get_unused_port():
@@ -49,7 +49,7 @@ def async_server(standard_graph, tmpdir):
 
     for cmd in cmds:
         print("Starting command: " + " ".join(cmd))
-        p = subprocess.Popen(cmd)
+        p = subprocess.Popen(cmd, env=bin_env())
         subprocesses.append(p)
 
     print("Waiting on server to come online")
@@ -77,7 +77,7 @@ def async_api_server(standard_graph, tmpdir):
     ]
 
     print("Starting server with command: " + " ".join(cmd))
-    p = subprocess.Popen(cmd)
+    p = subprocess.Popen(cmd, env=bin_env())
 
     print("Waiting on server to come online")
     wait_until_accept(api_port)

--- a/tests/path_util.py
+++ b/tests/path_util.py
@@ -1,13 +1,31 @@
 import os
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from py.path import LocalPath  # noqa: F401
+    from typing import Dict  # noqa: F401
+
 
 # TODO(cbguder): Replace uses of this function with something that doesn't depend on code layout
 def src_path(*args):
+    # type: (*str) -> str
     root = os.path.join(__file__, "..", "..")
     path = os.path.join(root, *args)
     return os.path.normpath(path)
 
 
 def db_url(tmpdir):
+    # type: (LocalPath) -> str
     db_path = tmpdir.join("grouper.sqlite")
     return "sqlite:///{}".format(db_path)
+
+
+def bin_env():
+    # type: () -> Dict[str, str]
+    """Return an environment suitable for running programs from bin."""
+    return {
+        "GROUPER_SETTINGS": src_path("config", "dev.yaml"),
+        "PATH": os.environ["PATH"],
+        "PYTHONPATH": src_path(),
+    }

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,27 +1,34 @@
+import os
 import subprocess
 
-from path_util import src_path
+from typing import TYPE_CHECKING
+
+from path_util import bin_env, src_path
 
 
 def test_api():
+    # type: () -> None
     bin_path = src_path("bin", "grouper-api")
-    out = subprocess.check_output([bin_path, "--help"])
+    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
     assert out.startswith("usage: grouper-api")
 
 
 def test_background():
+    # type: () -> None
     bin_path = src_path("bin", "grouper-background")
-    out = subprocess.check_output([bin_path, "--help"])
+    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
     assert out.startswith("usage: grouper-background")
 
 
 def test_ctl():
+    # type: () -> None
     bin_path = src_path("bin", "grouper-ctl")
-    out = subprocess.check_output([bin_path, "--help"])
+    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
     assert out.startswith("usage: grouper-ctl")
 
 
 def test_fe():
+    # type: () -> None
     bin_path = src_path("bin", "grouper-fe")
-    out = subprocess.check_output([bin_path, "--help"])
+    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
     assert out.startswith("usage: grouper-fe")

--- a/tools/test-all
+++ b/tools/test-all
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-pushd "$(dirname "$(dirname "$(readlink "$0")")")"
-
-PYTHONPATH=. exec py.test -v "$@"
-popd


### PR DESCRIPTION
Construct an appropriate environment when running programs from
bin with subprocess and drop the requirement that the user has
to set environment variables before running tests.  Add a
__init__.py file to itests so that pytest sets up the Python path
correctly.

Update the documentation for this, and add instructions for how to
run mypy.

Delete the now-useless tools/test-all wrapper.