### PR TITLE
Clean up setup.py, remove paths for flake8 and pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,9 +107,8 @@ chromium-driver is installed, the tests can be run using pytest:
 
     pip install -r requirements.txt
     pip install -r requirements-dev.txt
-    py.test tests
-    py.test itests
-    flake8 grouper itests plugins tests
+    py.test
+    flake8
 
 If you see test failures and suspect incompatible library versions (e.g.,
 an existing tornado install at a different major release than that in our
@@ -120,8 +119,7 @@ an existing tornado install at a different major release than that in our
     virtualenv ~/merou-venv
     ~/merou-venv/bin/pip install -r requirements.txt
     ~/merou-venv/bin/pip install -r requirements-dev.txt
-    ~/merou-venv/bin/py.test tests
-    ~/merou-venv/bin/py.test itests
+    ~/merou-venv/bin/py.test
 
 To run mypy, you will need Python 3 and install a different set of
 requirements:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,14 +3,12 @@
 set -eux
 
 if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-  export PYTHONPATH="$PWD"
-  export PATH="${PWD}/chromedriver:$PATH"
-
-  py.test -x -v itests tests
+    export PATH="${PWD}/chromedriver:$PATH"
+    py.test -x -v
 fi
 
 if [[ "$TRAVIS_PYTHON_VERSION" == 3* ]]; then
-  ./mypy.sh
-  black --check .
-  flake8 --count grouper itests plugins tests
+    ./mypy.sh
+    black --check .
+    flake8 --count
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ plop==0.3.0
 pyflamegraph==0.0.2
 python-dateutil==2.4.2
 pytz==2017.2
+setuptools==40.0.0
 six==1.12.0
 sshpubkeys==2.2.0
 tornado==4.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test = pytest
+
 [flake8]
 max-line-length = 99
 import-order-style = smarkets

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python2
 
 import os
-import setuptools  # noqa
 
-from distutils.core import setup
+from setuptools import setup
 
 # this defines __version__ for use below without assuming grouper is in the
 # path or importable during build
-execfile("grouper/version.py")
+with open("grouper/version.py", "r") as version:
+    code = compile(version.read(), "grouper/version.py", "exec")
+    exec(code)
 
+# Installation requirements.
 with open("requirements.txt") as requirements:
     required = requirements.read().splitlines()
+
+# Test suite requirements.
+with open("requirements-dev.txt") as requirements:
+    test_required = requirements.read().splitlines()
 
 package_data = {}
 
@@ -42,6 +48,8 @@ kwargs = {
     "maintainer_email": "gary@dropbox.com",
     "license": "Apache",
     "install_requires": required,
+    "setup_requires": ["pytest-runner"],
+    "tests_require": test_required,
     "url": "https://github.com/dropbox/grouper",
     "download_url": "https://github.com/dropbox/grouper/archive/master.tar.gz",
     "classifiers": [


### PR DESCRIPTION
setup.py wasn't flake8-clean, which was the only thing preventing
flake8 from being run without a path.  Fix that, and drop the paths
in the documentation and CI script, and also drop the similarly
unnecessary py.test paths.

Do the minimum work required to make setup.py work, namely adding
setuptools to the dependencies and telling it to use pytest to run
tests (and what the test dependencies are).  Change the syntax used
to load the version file to be compatible with Python 3 and therefore
flake8 run under Python 3.