### PR TITLE
Add code style badge for black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,14 @@
-=======
+=====
 merou
-=======
+=====
 
 .. image:: https://travis-ci.org/dropbox/merou.png?branch=master
     :alt: Build Status
     :target: https://travis-ci.org/dropbox/merou
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :alt: Code Style: Black
+    :target: https://github.com/ambv/black
 
 Description
 -----------


### PR DESCRIPTION
shields.io has a coding style badge for black.  Add it to README.rst
just for fun.