### PR TITLE
Also run tests with MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: python
-sudo: required
 addons:
   chrome: stable
+services:
+  - mysql
 python:
-- 2.7
-- 3.6
-sudo: false
+  - 2.7
+  - 3.6
 cache:
   directories:
     - $HOME/.cache/pip
 install: ci/setup.sh
 script: ci/test.sh
-notifications:
-  slack:
-    secure: glh+QNow84MLh3SXM+5l1C0Mxz7aYWLmE+iShUixbwQzv702rneznGutyjyN8oR42T5EEg5ilN5WR0Ni0xIFVc81ZtVDJkndjNHgXp6SgizWI0qpBQj9m1/3yrXMh5SAd168ZXtc3Y5sOOYWFs/8mrBcdYEFE3k+wkX1/GwGD3A=

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -3,13 +3,15 @@
 set -eux
 
 if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-  wget "https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip"
-  unzip chromedriver_linux64.zip -d chromedriver
+    wget 'https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip'
+    unzip chromedriver_linux64.zip -d chromedriver
 
-  pip install -r requirements-dev.txt
-  pip install -r requirements.txt
+    mysql -e 'CREATE DATABASE merou;'
+
+    pip install -r requirements-dev.txt
+    pip install -r requirements.txt
 fi
 
 if [[ "$TRAVIS_PYTHON_VERSION" == 3* ]]; then
-  pip install -r requirements3.txt
+    pip install -r requirements3.txt
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -2,11 +2,16 @@
 
 set -eux
 
+# Add chromedriver to PATH, manually installed by ci/setup.sh.
+export PATH="${PWD}/chromedriver:$PATH"
+
+# Tests run under Python 2.  Run once with SQLite and again with MySQL.
 if [[ "$TRAVIS_PYTHON_VERSION" == 2* ]]; then
-    export PATH="${PWD}/chromedriver:$PATH"
+    MEROU_TEST_DATABASE='mysql://travis:@localhost/merou' py.test -v
     py.test -x -v
 fi
 
+# Python 3 currently only does static analysis.
 if [[ "$TRAVIS_PYTHON_VERSION" == 3* ]]; then
     mypy .
     black --check .

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from grouper.api.routes import HANDLERS as API_HANDLERS
@@ -153,17 +155,19 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
 def session(request, tmpdir):
     db_engine = get_db_engine(db_url(tmpdir))
 
+    # Create the database schema and the corresponding session.
     Model.metadata.create_all(db_engine)
     Session.configure(bind=db_engine)
     session = Session()
 
     def fin():
+        # type: () -> None
+        """Explicitly close the session and clean up if using a persistent database."""
         session.close()
-        # Useful if testing against MySQL
-        # Model.metadata.drop_all(db_engine)
+        if "MEROU_TEST_DATABASE" in os.environ:
+            Model.metadata.drop_all(db_engine)
 
     request.addfinalizer(fin)
-
     return session
 
 

--- a/tests/path_util.py
+++ b/tests/path_util.py
@@ -16,6 +16,8 @@ def src_path(*args):
 
 def db_url(tmpdir):
     # type: (LocalPath) -> str
+    if "MEROU_TEST_DATABASE" in os.environ:
+        return os.environ["MEROU_TEST_DATABASE"]
     db_path = tmpdir.join("grouper.sqlite")
     return "sqlite:///{}".format(db_path)
 


### PR DESCRIPTION
We use MySQL in production, and SQLite (which is used by default
for the tests) does not do schema checking and thus won't uncover
some issues.  Add a mechanism to configure a database URL via an
environment variable, and run tests twice, once with MySQL and
once with SQLite.