### PR TITLE
Refactor list permissions

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -105,7 +105,7 @@ fe:
     # All traps are stored in the database in UTC. This option chooses the
     # timezone for displaying datetime values.
     # Type: str
-    timezone: "America/Los_Angeles"
+    timezone: "UTC"
 
     # The format in which to display dates in the interface. More details here:
     # https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+from typing import TYPE_CHECKING
 
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
@@ -11,10 +12,15 @@ from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings
 from grouper.util import get_loglevel
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import List, Optional
+
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
-def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
+def main(sys_argv=sys.argv, start_config_thread=True, session=None):
+    # type: (List[str], bool, Optional[Session]) -> None
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
@@ -47,7 +53,7 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
         user,
         user_proxy,
     ]:
-        subcommand_module.add_parser(subparsers)
+        subcommand_module.add_parser(subparsers)  # type: ignore
 
     subcommands = []
     for subcommand_class in [PermissionCommand]:

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -14,7 +14,7 @@ from grouper.util import get_loglevel
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
-def main(sys_argv=sys.argv, start_config_thread=True, session=None):
+def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
@@ -63,9 +63,9 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
 
     # TODO(rra): This is a hack that we can remove, along with the set_session() implementation,
     # once we have proper factories.
+    if not session:
+        session = make_session()
     for subcommand in subcommands:
-        if not session:
-            session = make_session()
         subcommand.set_session(session)
 
     log_level = get_loglevel(args, base=logging.INFO)

--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from grouper.ctl.base import CtlCommand
+from grouper.graph import Graph
 from grouper.repositories.factory import RepositoryFactory
 from grouper.services.factory import ServiceFactory
 from grouper.usecases.disable_permission import DisablePermissionUI
@@ -54,7 +55,7 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
     def run(self, args):
         # type: (Namespace) -> None
         """Run a permission command."""
-        repository_factory = RepositoryFactory(self.session)
+        repository_factory = RepositoryFactory(self.session, Graph())
         service_factory = ServiceFactory(self.session, repository_factory)
         usecase_factory = UseCaseFactory(service_factory)
         usecase = usecase_factory.create_disable_permission_usecase(args.actor_name, self)

--- a/grouper/entities/pagination.py
+++ b/grouper/entities/pagination.py
@@ -9,7 +9,7 @@ PaginatedList is the corresponding generic type for the value returned by the re
 list of some other entity along with the total entity count and information about the pagination.
 """
 
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -25,7 +25,7 @@ class Pagination(Generic[T]):
     """
 
     def __init__(self, sort_key, reverse_sort, offset, limit):
-        # type: (T, bool, int, int) -> None
+        # type: (T, bool, int, Optional[int]) -> None
         self.sort_key = sort_key
         self.reverse_sort = reverse_sort
         self.offset = offset

--- a/grouper/entities/pagination.py
+++ b/grouper/entities/pagination.py
@@ -1,0 +1,48 @@
+"""Data transfer object conveying a pagination request.
+
+Pagination is handled at the repository layer since it may done via SQL, so has to be passed from
+the UI through the use case to the service and repository.  Pagination is a data transfer object
+holding a generic sorting and pagination request.  It should be parameterized with the type of the
+sort key, which is an enum specific to a given use case.
+
+PaginatedList is the corresponding generic type for the value returned by the repository, holding a
+list of some other entity along with the total entity count and information about the pagination.
+"""
+
+from typing import Generic, List, TypeVar
+
+T = TypeVar("T")
+
+
+class Pagination(Generic[T]):
+    """Type for a pagination request.
+
+    Attributes:
+        sort_key: Enum instance representing the key on which to sort
+        reverse_sort: Whether to do an ascending (False) or descending (True) sort
+        offset: Offset from start of sorted list
+        limit: Total number of items to return
+    """
+
+    def __init__(self, sort_key, reverse_sort, offset, limit):
+        # type: (T, bool, int, int) -> None
+        self.sort_key = sort_key
+        self.reverse_sort = reverse_sort
+        self.offset = offset
+        self.limit = limit
+
+
+class PaginatedList(Generic[T]):
+    """Type for a paginated list.
+
+    Attributes:
+        values: The members of the list
+        total: Total number of list members were no pagination done
+        offset: Offset from start of sorted list
+    """
+
+    def __init__(self, values, total, offset):
+        # type: (List[T], int, int) -> None
+        self.values = values
+        self.total = total
+        self.offset = offset

--- a/grouper/entities/permission.py
+++ b/grouper/entities/permission.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import NamedTuple
 
-Permission = NamedTuple("Permission", [("name", str), ("enabled", bool)])
+Permission = NamedTuple("Permission", [("name", str), ("created_on", datetime)])
 
 
 class PermissionNotFoundException(Exception):

--- a/grouper/entities/permission.py
+++ b/grouper/entities/permission.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import NamedTuple
 
-Permission = NamedTuple("Permission", [("name", str), ("created_on", datetime)])
+Permission = NamedTuple(
+    "Permission", [("name", str), ("description", str), ("created_on", datetime)]
+)
 
 
 class PermissionNotFoundException(Exception):

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -1,0 +1,3 @@
+from typing import NamedTuple
+
+PermissionGrant = NamedTuple("PermissionGrant", [("name", str), ("argument", str)])

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -25,7 +25,7 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         return self.forbidden()
 
     def post(self, user_id=None, name=None):
-        repository_factory = RepositoryFactory(self.session)
+        repository_factory = RepositoryFactory(self.session, self.graph)
         service_factory = ServiceFactory(self.session, repository_factory)
         usecase_factory = UseCaseFactory(service_factory)
         usecase = usecase_factory.create_disable_permission_usecase(

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -1,60 +1,48 @@
-from datetime import timedelta
-
+from grouper.entities.pagination import PaginatedList, Pagination
+from grouper.entities.permission import Permission
 from grouper.fe.util import GrouperHandler
-from grouper.user_permissions import user_creatable_permissions
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.usecases.factory import UseCaseFactory
+from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
 
 
-def _round_timestamp(timestamp):
-    return timestamp - timedelta(seconds=timestamp.second, microseconds=timestamp.microsecond)
+class PermissionsView(GrouperHandler, ListPermissionsUI):
+    """Controller for viewing the major permissions list.
 
-
-class PermissionsView(GrouperHandler):
+    There is no privacy here; the existence of a permission is public.
     """
-    Controller for viewing the major permissions list. There is no privacy here; the existence of
-    a permission is public.
-    """
 
-    def get(self, audited_only=False):
-        offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 100))
+    def listed_permissions(self, permissions, can_create):
+        # type: (PaginatedList[Permission], bool) -> None
         audited_only = bool(int(self.get_argument("audited", 0)))
-        sort_key = self.get_argument("sort_by", "")
-        sort_dir = self.get_argument("order", "")
-        if limit > 9000:
-            limit = 9000
-
-        sort_keys = {
-            "name": lambda p: p.name,
-            # round timestamps to the nearest minute so permissions created together will
-            # show up alphabetically
-            "date": lambda p: _round_timestamp(p.created_on),
-        }
-
-        if sort_key not in sort_keys:
-            sort_key = "name"
-
-        if sort_dir not in ("asc", "desc"):
-            sort_dir = "asc"
-
-        permissions = sorted(
-            self.graph.get_permissions(audited=audited_only),
-            key=sort_keys[sort_key],
-            reverse=(sort_dir == "desc"),
-        )
-
-        total = len(permissions)
-        permissions = permissions[offset : offset + limit]
-
-        can_create = user_creatable_permissions(self.session, self.current_user)
-
+        sort_key = self.get_argument("sort_by", "name")
+        sort_dir = self.get_argument("order", "asc")
         self.render(
             "permissions.html",
-            permissions=permissions,
-            offset=offset,
-            limit=limit,
-            total=total,
+            permissions=permissions.values,
+            offset=permissions.offset,
+            limit=len(permissions.values),
+            total=permissions.total,
             can_create=can_create,
             audited_permissions=audited_only,
             sort_key=sort_key,
             sort_dir=sort_dir,
         )
+
+    def get(self, audited_only=False):
+        offset = int(self.get_argument("offset", 0))
+        limit = int(self.get_argument("limit", 100))
+        audited_only = bool(int(self.get_argument("audited", 0)))
+        sort_key = ListPermissionsSortKey(self.get_argument("sort_by", "name"))
+        sort_dir = self.get_argument("order", "asc")
+
+        pagination = Pagination(
+            sort_key=sort_key, reverse_sort=(sort_dir == "desc"), offset=offset, limit=limit
+        )
+
+        repository_factory = RepositoryFactory(self.session, self.graph)
+        service_factory = ServiceFactory(self.session, repository_factory)
+        usecase_factory = UseCaseFactory(service_factory)
+        usecase = usecase_factory.create_list_permissions_usecase(self)
+        usecase.list_permissions(self.current_user.name, pagination, audited_only)

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -31,6 +31,7 @@ class PermissionsView(GrouperHandler, ListPermissionsUI):
         )
 
     def get(self, audited_only=False):
+        self.handle_refresh()
         offset = int(self.get_argument("offset", 0))
         limit = int(self.get_argument("limit", 100))
         audited_only = bool(int(self.get_argument("audited", 0)))

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -16,16 +16,16 @@
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
     {% if audited_permissions %}
-    <a class="btn btn-warning" href="{{update_qs(audited='0', offset='0')}}">
+    <a class="btn btn-warning show-all" href="{{update_qs(audited='0', offset='0')}}">
         <i class="fa"></i> Show all permissions
     </a>
     {% else %}
     {% if can_create %}
-    <a class="btn btn-success" href="/permissions/create">
+    <a class="btn btn-success create-permission" href="/permissions/create">
         <i class="fa fa-plus"></i> Create
     </a>
     {% endif %}
-    <a class="btn btn-warning" href="{{update_qs(audited='1', offset='0')}}">
+    <a class="btn btn-warning show-audited" href="{{update_qs(audited='1', offset='0')}}">
         <i class="fa"></i> Show audited permissions only
     </a>
     {% endif %}
@@ -38,15 +38,15 @@
                 <tr>
                     <th class="col-sm-2"><a href="{{update_qs(sort_by='name', order='desc' if sort_key == 'name' and sort_dir == 'asc' else 'asc', offset='0')}}" class="white">Name</a></th>
                     <th class="col-sm-5">Description</th>
-                    <th class="col-sm-2"><a href="{{update_qs(sort_by='date', order='asc' if sort_key == 'date' and sort_dir == 'desc' else 'desc', offset='0')}}" class="white">Created On</a></th>
+                    <th class="col-sm-2 col-date"><a href="{{update_qs(sort_by='date', order='asc' if sort_key == 'date' and sort_dir == 'desc' else 'desc', offset='0')}}" class="white">Created On</a></th>
                 </tr>
             </thead>
             <tbody>
             {% for perm in permissions %}
-                <tr>
-                    <td>{{ permission(perm) }}</td>
-                    <td>{{ perm.description|default("", True) | escape }}</td>
-                    <td>{{ perm.created_on | print_date}}</td>
+                <tr class="permission-row">
+                    <td class="permission-name">{{ permission(perm) }}</td>
+                    <td class="permission-description">{{ perm.description|default("", True) | escape }}</td>
+                    <td class="permission-created-on">{{ perm.created_on | print_date}}</td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from threading import RLock
+from typing import TYPE_CHECKING
 
 from networkx import DiGraph, single_source_shortest_path
 from sqlalchemy import or_
@@ -24,6 +25,10 @@ from grouper.public_key import get_all_public_key_tags
 from grouper.role_user import is_role_user
 from grouper.service_account import all_service_account_permissions
 from grouper.util import singleton
+
+if TYPE_CHECKING:
+    from grouper.service_account import ServiceAccountPermission
+    from typing import Any, Dict, List, Optional, Set
 
 MEMBER_TYPE_MAP = {"User": "users", "Group": "subgroups"}
 EPOCH = datetime(1970, 1, 1)
@@ -57,25 +62,46 @@ class NoSuchGroup(Exception):
 
 
 class GroupGraph(object):
+    """The cached permission graph.
+
+    Attributes:
+        lock: Read lock on the data
+        update_lock: Write lock on the data
+        users: Names of all enabled users
+        groups: Names of all enabled groups
+        permissions: Names of all enabled permissions
+        checkpoint: Revision of Grouper data
+        checkpoint_time: Last update time of Grouper data
+        user_metadata: Full information about each user
+        group_metadata: Full information about each group
+        group_service_accounts: Service accounts owned by groups
+        permission_metadata: Permission grant information for users
+        service_account_permissions: Permission grant information for service accounts
+        permission_tuples: Metadata for all enabled permissions
+        group_tuples: Metadata for all enabled groups
+        disabled_group_tuples: Metadata for all disabled groups
+    """
+
     def __init__(self):
+        # type: () -> None
         self.logger = logging.getLogger(__name__)
-        self._graph = None
-        self._rgraph = None
-        self.lock = RLock()  # Graph structure.
-        self.update_lock = RLock()  # Limit to 1 updating thread at a time.
-        self.users = set()  # Enabled user names.
-        self.groups = set()  # Group names.
-        self.permissions = set()  # Permission names.
+        self._graph = None  # type: Optional[DiGraph]
+        self._rgraph = None  # type: Optional[DiGraph]
+        self.lock = RLock()
+        self.update_lock = RLock()
+        self.users = set()  # type: Set[str]
+        self.groups = set()  # type: Set[str]
+        self.permissions = set()  # type: Set[str]
         self.checkpoint = 0
         self.checkpoint_time = 0
-        self.user_metadata = {}  # username -> {metadata:[{}] public_keys:[{}]}.
-        self.group_metadata = {}
-        self.group_service_accounts = {}
-        self.permission_metadata = {}  # TODO: rename.  This is about permission grants.
-        self.service_account_permissions = {}
-        self.permission_tuples = set()  # Mock Permission instances.
-        self.group_tuples = {}  # groupname -> Mock Group instance.
-        self.disabled_group_tuples = {}  # groupname -> Mock Group instance.
+        self.user_metadata = {}  # type: Dict[str, Dict[str, Any]]
+        self.group_metadata = {}  # type: Dict[str, Dict[str, Any]]
+        self.group_service_accounts = {}  # type: Dict[str, List[str]]
+        self.permission_metadata = {}  # type: Dict[str, List[MappedPermission]]
+        self.service_account_permissions = {}  # type: Dict[str, List[ServiceAccountPermission]]
+        self.permission_tuples = set()  # type: Set[PermissionTuple]
+        self.group_tuples = {}  # type: Dict[str, GroupTuple]
+        self.disabled_group_tuples = {}  # type: Dict[str, GroupTuple]
 
     @property
     def nodes(self):
@@ -401,11 +427,13 @@ class GroupGraph(object):
         return edges
 
     def get_permissions(self, audited=False):
-        """ Get the list of permissions as PermissionTuple instances sorted by name. """
+        # type: (bool) -> List[PermissionTuple]
+        """Get the list of permissions as PermissionTuple instances."""
         with self.lock:
-            permissions = sorted(self.permission_tuples, key=lambda p: p.name)
-        if audited:
-            permissions = filter(lambda p: p.audited, permissions)
+            if audited:
+                permissions = [p for p in self.permission_tuples if p.audited]
+            else:
+                permissions = list(self.permission_tuples)
         return permissions
 
     def get_permission_details(self, name, expose_aliases=True):

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -30,7 +30,8 @@ EPOCH = datetime(1970, 1, 1)
 
 
 @singleton
-def Graph():  # noqa
+def Graph():
+    # type: () -> GroupGraph
     return GroupGraph()
 
 

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,18 +1,27 @@
 from typing import TYPE_CHECKING
 
-from grouper.repositories.permission import PermissionRepository
+from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
+from grouper.repositories.permission_grant import GraphPermissionGrantRepository
 
 if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
+    from grouper.repositories.interfaces import PermissionRepository, PermissionGrantRepository
 
 
 class RepositoryFactory(object):
     """Create repositories, which abstract storage away from the database layer."""
 
-    def __init__(self, session):
-        # type: (Session) -> None
+    def __init__(self, session, graph):
+        # type: (Session, GroupGraph) -> None
         self.session = session
+        self.graph = graph
 
     def create_permission_repository(self):
         # type: () -> PermissionRepository
-        return PermissionRepository(self.session)
+        sql_permission_repository = SQLPermissionRepository(self.session)
+        return GraphPermissionRepository(self.graph, sql_permission_repository)
+
+    def create_permission_grant_repository(self):
+        # type: () -> PermissionGrantRepository
+        return GraphPermissionGrantRepository(self.graph)

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -1,0 +1,46 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from grouper.entities.pagination import PaginatedList, Pagination
+    from grouper.entities.permission import Permission
+    from grouper.entities.permission_grant import PermissionGrant
+    from grouper.usecases.list_permissions import ListPermissionsSortKey
+    from typing import List, Optional
+
+
+class PermissionRepository(object):
+    """Abstract base class for permission repositories."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def get_permission(self, name):
+        # type: (str) -> Optional[Permission]
+        pass
+
+    @abstractmethod
+    def disable_permission(self, name):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def list_permissions(self, pagination, audited_only):
+        # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]
+        pass
+
+
+class PermissionGrantRepository(object):
+    """Abstract base class for permission grants."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def permissions_for_user(self, user):
+        # type: (str) -> List[PermissionGrant]
+        pass
+
+    @abstractmethod
+    def user_has_permission(self, user, permission):
+        # type: (str, str) -> bool
+        pass

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -54,7 +54,10 @@ class GraphPermissionRepository(PermissionRepository):
             perm_tuples = perm_tuples[pagination.offset :]
 
         # Convert to the correct data transfer object.
-        permissions = [Permission(name=p.name, created_on=p.created_on) for p in perm_tuples]
+        permissions = [
+            Permission(name=p.name, description=p.description, created_on=p.created_on)
+            for p in perm_tuples
+        ]
         return PaginatedList[Permission](values=permissions, total=total, offset=pagination.offset)
 
 
@@ -70,7 +73,11 @@ class SQLPermissionRepository(PermissionRepository):
         permission = SQLPermission.get(self.session, name=name)
         if not permission:
             return None
-        return Permission(name=permission.name, created_on=permission.created_on)
+        return Permission(
+            name=permission.name,
+            description=permission.description,
+            created_on=permission.created_on,
+        )
 
     def disable_permission(self, name):
         # type: (str) -> None

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -1,0 +1,34 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.permission_grant import PermissionGrant
+from grouper.repositories.interfaces import PermissionGrantRepository
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from typing import List
+
+
+class GraphPermissionGrantRepository(PermissionGrantRepository):
+    """Graph-aware storage layer for permission grants."""
+
+    def __init__(self, graph):
+        # type: (GroupGraph) -> None
+        self.graph = graph
+
+    def permissions_for_user(self, user):
+        # type: (str) -> List[PermissionGrant]
+        user_details = self.graph.get_user_details(user)
+        permissions = []
+        for permission_data in user_details["permissions"]:
+            permission = PermissionGrant(
+                name=permission_data["permission"], argument=permission_data["argument"]
+            )
+            permissions.append(permission)
+        return permissions
+
+    def user_has_permission(self, user, permission):
+        # type: (str, str) -> bool
+        for user_permission in self.permissions_for_user(user):
+            if permission == user_permission.name:
+                return True
+        return False

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -3,12 +3,17 @@ from typing import TYPE_CHECKING
 from grouper.services.audit_log import AuditLogService
 from grouper.services.permission import PermissionService
 from grouper.services.transaction import TransactionService
+from grouper.services.user import UserService
 from grouper.usecases.interfaces import ServiceFactoryInterface
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.repositories.factory import RepositoryFactory
-    from grouper.usecases.interfaces import PermissionInterface, TransactionInterface
+    from grouper.usecases.interfaces import (
+        PermissionInterface,
+        TransactionInterface,
+        UserInterface,
+    )
 
 
 class ServiceFactory(ServiceFactoryInterface):
@@ -23,8 +28,13 @@ class ServiceFactory(ServiceFactoryInterface):
         # type: () -> PermissionInterface
         audit_log = AuditLogService(self.session)
         permission_repository = self.repository_factory.create_permission_repository()
-        return PermissionService(self.session, audit_log, permission_repository)
+        return PermissionService(audit_log, permission_repository)
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface
         return TransactionService(self.session)
+
+    def create_user_service(self):
+        # type: () -> UserInterface
+        permission_grant_repository = self.repository_factory.create_permission_grant_repository()
+        return UserService(permission_grant_repository)

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE
+from grouper.usecases.interfaces import UserInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.interfaces import PermissionGrantRepository
+
+
+class UserService(UserInterface):
+    """High-level logic to manipulate users."""
+
+    def __init__(self, permission_grant_repository):
+        # type: (PermissionGrantRepository) -> None
+        self.permission_grant_repository = permission_grant_repository
+
+    def user_is_permission_admin(self, user):
+        # type: (str) -> bool
+        return self.permission_grant_repository.user_has_permission(user, PERMISSION_ADMIN)
+
+    def user_can_create_permissions(self, user):
+        # type: (str) -> bool
+        return self.permission_grant_repository.user_has_permission(user, PERMISSION_CREATE)

--- a/grouper/usecases/disable_permission.py
+++ b/grouper/usecases/disable_permission.py
@@ -5,7 +5,11 @@ from grouper.entities.permission import PermissionNotFoundException
 from grouper.usecases.authorization import Authorization
 
 if TYPE_CHECKING:
-    from grouper.usecases.interfaces import PermissionInterface, TransactionInterface
+    from grouper.usecases.interfaces import (
+        PermissionInterface,
+        TransactionInterface,
+        UserInterface,
+    )
 
 
 class DisablePermissionUI(object):
@@ -37,18 +41,26 @@ class DisablePermissionUI(object):
 class DisablePermission(object):
     """Disable a permission."""
 
-    def __init__(self, actor, ui, permission_service, transaction_service):
-        # type: (str, DisablePermissionUI, PermissionInterface, TransactionInterface) -> None
+    def __init__(
+        self,
+        actor,  # type: str
+        ui,  # type: DisablePermissionUI
+        permission_service,  # type: PermissionInterface
+        user_service,  # type: UserInterface
+        transaction_service,  # type: TransactionInterface
+    ):
+        # type: (...) -> None
         self.actor = actor
         self.ui = ui
         self.permission_service = permission_service
+        self.user_service = user_service
         self.transaction_service = transaction_service
 
     def disable_permission(self, name):
         # type: (str) -> None
         if self.permission_service.is_system_permission(name):
             self.ui.disable_permission_failed_because_system_permission(name)
-        elif not self.permission_service.user_is_permission_admin(self.actor):
+        elif not self.user_service.user_is_permission_admin(self.actor):
             self.ui.disable_permission_failed_because_permission_denied(name)
         else:
             authorization = Authorization(self.actor)

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -1,10 +1,12 @@
 from typing import TYPE_CHECKING
 
 from grouper.usecases.disable_permission import DisablePermission
+from grouper.usecases.list_permissions import ListPermissions
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.usecases.disable_permission import DisablePermissionUI
+    from grouper.usecases.list_permissions import ListPermissionsUI
 
 
 class UseCaseFactory(object):
@@ -18,4 +20,11 @@ class UseCaseFactory(object):
         # type: (str, DisablePermissionUI) -> DisablePermission
         permission_service = self.service_factory.create_permission_service()
         transaction_service = self.service_factory.create_transaction_service()
-        return DisablePermission(actor, ui, permission_service, transaction_service)
+        user_service = self.service_factory.create_user_service()
+        return DisablePermission(actor, ui, permission_service, user_service, transaction_service)
+
+    def create_list_permissions_usecase(self, ui):
+        # type: (ListPermissionsUI) -> ListPermissions
+        permission_service = self.service_factory.create_permission_service()
+        user_service = self.service_factory.create_user_service()
+        return ListPermissions(ui, permission_service, user_service)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -15,11 +15,14 @@ from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from grouper.entities.pagination import PaginatedList, Pagination
+    from grouper.entities.permission import Permission
     from grouper.usecases.authorization import Authorization
+    from grouper.usecases.list_permissions import ListPermissionsSortKey
 
 
 class PermissionInterface(object):
-    """Abstract base class for permission storage layer."""
+    """Abstract base class for permission operations and queries."""
 
     __metaclass__ = ABCMeta
 
@@ -34,8 +37,8 @@ class PermissionInterface(object):
         pass
 
     @abstractmethod
-    def user_is_permission_admin(self, user_name):
-        # type: (str) -> bool
+    def list_permissions(self, pagination, audited_only):
+        # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]
         pass
 
 
@@ -63,4 +66,20 @@ class ServiceFactoryInterface(object):
     @abstractmethod
     def create_permission_service(self):
         # type: () -> PermissionInterface
+        pass
+
+
+class UserInterface(object):
+    """Abstract base class for user operations and queries."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def user_can_create_permissions(self, user):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def user_is_permission_admin(self, user):
+        # type: (str) -> bool
         pass

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 
 class ListPermissionsSortKey(Enum):
+    NONE = "none"
     NAME = "name"
     DATE = "date"
 
@@ -43,3 +44,12 @@ class ListPermissions(object):
         permissions = self.permission_service.list_permissions(pagination, audited_only)
         can_create = self.user_service.user_can_create_permissions(user)
         self.ui.listed_permissions(permissions, can_create)
+
+    def simple_list_permissions(self):
+        # type: () -> None
+        """List permissions with no selection, pagination, or current user."""
+        pagination = Pagination(
+            sort_key=ListPermissionsSortKey.NONE, reverse_sort=False, offset=0, limit=None
+        )
+        permissions = self.permission_service.list_permissions(pagination, False)
+        self.ui.listed_permissions(permissions, False)

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -1,0 +1,45 @@
+from abc import ABCMeta, abstractmethod
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from grouper.entities.pagination import Pagination
+
+if TYPE_CHECKING:
+    from grouper.entities.pagination import PaginatedList
+    from grouper.entities.permission import Permission
+    from grouper.usecases.interfaces import PermissionInterface, UserInterface
+
+
+class ListPermissionsSortKey(Enum):
+    NAME = "name"
+    DATE = "date"
+
+
+ListPermissionsPagination = Pagination[ListPermissionsSortKey]
+
+
+class ListPermissionsUI(object):
+    """Abstract base class for UI for ListPermissions."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def listed_permissions(self, permissions, can_create):
+        # type: (PaginatedList[Permission], bool) -> None
+        pass
+
+
+class ListPermissions(object):
+    """List all permissions."""
+
+    def __init__(self, ui, permission_service, user_service):
+        # type: (ListPermissionsUI, PermissionInterface, UserInterface) -> None
+        self.ui = ui
+        self.permission_service = permission_service
+        self.user_service = user_service
+
+    def list_permissions(self, user, pagination, audited_only):
+        # type: (str, ListPermissionsPagination, bool) -> None
+        permissions = self.permission_service.list_permissions(pagination, audited_only)
+        can_create = self.user_service.user_can_create_permissions(user)
+        self.ui.listed_permissions(permissions, can_create)

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -16,9 +16,6 @@ class ListPermissionsSortKey(Enum):
     DATE = "date"
 
 
-ListPermissionsPagination = Pagination[ListPermissionsSortKey]
-
-
 class ListPermissionsUI(object):
     """Abstract base class for UI for ListPermissions."""
 
@@ -40,7 +37,7 @@ class ListPermissions(object):
         self.user_service = user_service
 
     def list_permissions(self, user, pagination, audited_only):
-        # type: (str, ListPermissionsPagination, bool) -> None
+        # type: (str, Pagination[ListPermissionsSortKey], bool) -> None
         permissions = self.permission_service.list_permissions(pagination, audited_only)
         can_create = self.user_service.user_can_create_permissions(user)
         self.ui.listed_permissions(permissions, can_create)

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -1,0 +1,106 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import PERMISSION_CREATE
+from grouper.fe.settings import settings
+from grouper.fe.template_util import print_date
+from grouper.permissions import create_permission, grant_permission
+from itests.fixtures import async_server, browser  # noqa: F401
+from itests.pages.permissions import PermissionsPage
+from tests.fixtures import (  # noqa: F401
+    graph,
+    groups,
+    permissions,
+    service_accounts,
+    session,
+    standard_graph,
+    users,
+)
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.models.group import Group
+    from grouper.models.permission import Permission as Permission
+    from selenium.webdriver import Chrome
+    from typing import Dict
+
+
+def test_list(async_server, browser, permissions, session):  # noqa: F811
+    # type: (str, Chrome, Dict[str, Permission], Session) -> None
+    settings.override_timezone("UTC")
+    fe_url = url(async_server, "/permissions")
+    browser.get(fe_url)
+
+    # Check the basic permission list.
+    page = PermissionsPage(browser)
+    seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+    expected_permissions = [
+        (p.name, p.description, print_date(p.created_on)) for p in permissions.values()
+    ]
+    assert seen_permissions == sorted(expected_permissions)
+    assert page.heading == "Permissions"
+    assert page.subheading == "{} permission(s)".format(len(permissions))
+
+    # Switch to only audited permissions.
+    page.click_show_audited_button()
+    seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+    audited_permissions = [
+        (p.name, p.description, print_date(p.created_on))
+        for p in permissions.values()
+        if p._audited
+    ]
+    assert seen_permissions == sorted(audited_permissions)
+    assert page.heading == "Audited Permissions"
+    assert page.subheading == "{} permission(s)".format(len(audited_permissions))
+
+    # Switch back to all permissions and sort by date.
+    page.click_show_all_button()
+    page.click_sort_by_date()
+    seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+    expected_permissions = [
+        (p.name, p.description, print_date(p.created_on))
+        for p in sorted(permissions.values(), key=lambda p: p.created_on, reverse=True)
+    ]
+    assert seen_permissions == expected_permissions
+
+    # Reverse the sort order.
+    page.click_sort_by_date()
+    seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+    assert seen_permissions == list(reversed(expected_permissions))
+
+
+def test_list_pagination(async_server, browser, permissions, session):  # noqa: F811
+    # type: (str, Chrome, Dict[str, Permission], Session) -> None
+    """Test pagination.
+
+    This forces the pagination to specific values, rather than using the page controls, since we
+    don't create more than 100 permissions for testing.
+    """
+    settings.override_timezone("UTC")
+    fe_url = url(async_server, "/permissions?limit=1&offset=1")
+    browser.get(fe_url)
+    page = PermissionsPage(browser)
+    seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+    expected_permissions = [
+        (p.name, p.description, print_date(p.created_on)) for p in permissions.values()
+    ]
+    assert seen_permissions == sorted(expected_permissions)[1:2]
+
+
+def test_create_button(async_server, browser, groups, session):  # noqa: F811
+    # type: (str, Chrome, Dict[str, Group], Session) -> None
+    fe_url = url(async_server, "/permissions")
+    browser.get(fe_url)
+    page = PermissionsPage(browser)
+    assert not page.has_create_permission_button
+
+    # Now grant the permission to manage permissions to a group the test user is a member of.
+    group = groups["permission-admins"]
+    permission = create_permission(session, PERMISSION_CREATE)
+    session.commit()
+    grant_permission(session, group.id, permission.id, argument="*")
+
+    # Request the list again with a graph refresh and check that the button exists.
+    fe_url = url(async_server, "/permissions?refresh=yes")
+    browser.get(fe_url)
+    assert page.has_create_permission_button

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -3,12 +3,18 @@ import socket
 import subprocess
 import time
 from contextlib import closing
+from typing import TYPE_CHECKING
 
 import pytest
 import selenium
 from groupy.client import Groupy
 
 from tests.path_util import bin_env, db_url, src_path
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from py.local import LocalPath
+    from typing import Iterator
 
 
 def _get_unused_port():
@@ -19,6 +25,7 @@ def _get_unused_port():
 
 @pytest.yield_fixture
 def async_server(standard_graph, tmpdir):
+    # type: (GroupGraph, LocalPath) -> Iterator[str]
     proxy_port = _get_unused_port()
     fe_port = _get_unused_port()
 
@@ -90,6 +97,7 @@ def async_api_server(standard_graph, tmpdir):
 
 @pytest.yield_fixture
 def browser():
+    # type: () -> Iterator[selenium.webdriver.Chrome]
     options = selenium.webdriver.ChromeOptions()
     options.add_argument("headless")
     options.add_argument("no-sandbox")

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -15,17 +15,30 @@ class BaseFinder(object):
     def find_element_by_id(self, id_):
         return self.root.find_element_by_id(id_)
 
+    def find_element_by_link_text(self, link_text):
+        return self.root.find_element_by_link_text(link_text)
+
     def find_element_by_tag_name(self, name):
         return self.root.find_element_by_tag_name(name)
 
-    def find_element_by_link_text(self, link_text):
-        return self.root.find_element_by_link_text(link_text)
+    def find_element_by_xpath(self, path):
+        return self.root.find_element_by_xpath(path)
 
 
 class BasePage(BaseFinder):
     @property
     def current_url(self):
         return self.root.current_url
+
+    @property
+    def heading(self):
+        # type: () -> str
+        return self.find_element_by_xpath("//div[@class='header']/h2[1]").text
+
+    @property
+    def subheading(self):
+        # type: () -> str
+        return self.find_element_by_xpath("//div[@class='header']/h3[1]/small[1]").text
 
     def has_text(self, text):
         return text in self.root.page_source

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -2,7 +2,7 @@ from selenium.webdriver.support.select import Select
 
 from itests.pages.base import BaseElement, BaseModal, BasePage
 from itests.pages.exceptions import NoSuchElementException
-from itests.pages.permissions import PermissionRow
+from itests.pages.permissions import PermissionGrantRow
 
 
 class GroupEditMemberPage(BasePage):
@@ -45,7 +45,7 @@ class GroupViewPage(BasePage):
 
     def find_permission_rows(self, name, argument=None):
         elements = self.find_elements_by_class_name("permission-row")
-        rows = [PermissionRow(el) for el in elements]
+        rows = [PermissionGrantRow(el) for el in elements]
 
         rows = [row for row in rows if row.name == name]
 

--- a/itests/pages/permissions.py
+++ b/itests/pages/permissions.py
@@ -1,7 +1,58 @@
-from base import BaseElement
+from typing import TYPE_CHECKING
+
+from itests.pages.base import BaseElement, BasePage
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+class PermissionsPage(BasePage):
+    @property
+    def has_create_permission_button(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("create-permission") != []
+
+    @property
+    def permission_rows(self):
+        # type: () -> List[PermissionRow]
+        all_permission_rows = self.find_elements_by_class_name("permission-row")
+        return [PermissionRow(row) for row in all_permission_rows]
+
+    def click_show_all_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("show-all")
+        button.click()
+
+    def click_show_audited_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("show-audited")
+        button.click()
+
+    def click_sort_by_date(self):
+        # type: () -> None
+        heading = self.find_element_by_class_name("col-date")
+        link = heading.find_element_by_tag_name("a")
+        self.root.get(link.get_attribute("href"))
 
 
 class PermissionRow(BaseElement):
+    @property
+    def name(self):
+        # type: () -> str
+        return self.find_element_by_class_name("permission-name").text
+
+    @property
+    def description(self):
+        # type: () -> str
+        return self.find_element_by_class_name("permission-description").text
+
+    @property
+    def created_on(self):
+        # type: () -> str
+        return self.find_element_by_class_name("permission-created-on").text
+
+
+class PermissionGrantRow(BaseElement):
     @property
     def name(self):
         return self.find_element_by_class_name("permission-name").text

--- a/itests/pages/users.py
+++ b/itests/pages/users.py
@@ -1,6 +1,6 @@
 from itests.pages.base import BaseElement, BaseModal, BasePage
 from itests.pages.exceptions import NoSuchElementException
-from itests.pages.permissions import PermissionRow
+from itests.pages.permissions import PermissionGrantRow
 
 
 class PublicKeysPage(BasePage):
@@ -44,7 +44,7 @@ class UserViewPage(BasePage):
 
     def find_permission_rows(self, name, argument=None):
         elements = self.find_elements_by_class_name("permission-row")
-        rows = [PermissionRow(el) for el in elements]
+        rows = [PermissionGrantRow(el) for el in elements]
 
         rows = [row for row in rows if row.name == name]
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -87,6 +87,7 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
     |                       |
     |  permission-admins    |
     |    * gary (o)         |
+    |    * cbguder          |
     |                       |
     +-----------------------+
 

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
     from grouper.usecases.disable_permission import DisablePermission
 
 
-def create_disable_permission_usecase(session, actor, ui):  # noqa: F811
-    # type: (Session, str, MagicMock) -> DisablePermission
-    repository_factory = RepositoryFactory(session)
+def create_disable_permission_usecase(session, graph, actor, ui):  # noqa: F811
+    # type: (Session, GroupGraph, str, MagicMock) -> DisablePermission
+    repository_factory = RepositoryFactory(session, graph)
     service_factory = ServiceFactory(session, repository_factory)
     usecase_factory = UseCaseFactory(service_factory)
     return usecase_factory.create_disable_permission_usecase(actor, ui)
@@ -33,7 +33,7 @@ def create_disable_permission_usecase(session, actor, ui):  # noqa: F811
 def test_permission_disable(session, standard_graph):  # noqa: F811
     # type: (Session, GroupGraph) -> None
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, "gary@a.co", mock_ui)
+    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
     usecase.disable_permission("audited")
     assert mock_ui.mock_calls == [call.disabled_permission("audited")]
 
@@ -41,7 +41,7 @@ def test_permission_disable(session, standard_graph):  # noqa: F811
 def test_permission_disable_denied(session, standard_graph):  # noqa: F811
     # type: (Session, GroupGraph) -> None
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, "zorkian@a.co", mock_ui)
+    usecase = create_disable_permission_usecase(session, standard_graph, "zorkian@a.co", mock_ui)
     usecase.disable_permission("audited")
     assert mock_ui.mock_calls == [
         call.disable_permission_failed_because_permission_denied("audited")
@@ -51,7 +51,7 @@ def test_permission_disable_denied(session, standard_graph):  # noqa: F811
 def test_permission_disable_system(session, standard_graph):  # noqa: F811
     # type: (Session, GroupGraph) -> None
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, "gary@a.co", mock_ui)
+    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
     usecase.disable_permission(PERMISSION_CREATE)
     assert mock_ui.mock_calls == [
         call.disable_permission_failed_because_system_permission(PERMISSION_CREATE)
@@ -61,6 +61,6 @@ def test_permission_disable_system(session, standard_graph):  # noqa: F811
 def test_permission_not_found(session, standard_graph):  # noqa: F811
     # type: (Session, GroupGraph) -> None
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, "gary@a.co", mock_ui)
+    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
     usecase.disable_permission("nonexistent")
     assert mock_ui.mock_calls == [call.disable_permission_failed_because_not_found("nonexistent")]

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -1,0 +1,173 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from grouper.constants import PERMISSION_CREATE
+from grouper.entities.pagination import PaginatedList, Pagination
+from grouper.entities.permission import Permission
+from grouper.graph import GroupGraph
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.counter import Counter
+from grouper.models.group import Group
+from grouper.models.group_edge import GroupEdge
+from grouper.models.permission import Permission as SQLPermission
+from grouper.models.permission_map import PermissionMap
+from grouper.models.user import User
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.usecases.factory import UseCaseFactory
+from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
+from tests.fixtures import session  # noqa: F401
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.usecases.list_permissions import ListPermissions
+    from typing import Any, List, Optional
+
+
+class MockUI(ListPermissionsUI):
+    def __init__(self, sort=False):
+        # type: (bool) -> None
+        self.sort = sort
+
+    def listed_permissions(self, permissions, can_create):
+        # type: (PaginatedList[Permission], bool) -> None
+        self.permissions = permissions
+        if self.sort:
+            self.permissions.values = sorted(self.permissions.values)
+        self.can_create = can_create
+
+
+def assert_paginated_list_equal(left, right):
+    # type: (PaginatedList[Any], PaginatedList[Any]) -> None
+    """mypy NamedTuples don't compare with simple equality."""
+    assert left.values == right.values
+    assert left.total == right.total
+    assert left.offset == right.offset
+
+
+def create_test_data(session):  # noqa: F811
+    # type: (Session) -> List[Permission]
+    """Sets up a very basic test graph and returns the permission objects."""
+    early_date = datetime.utcfromtimestamp(1)
+    permissions = [
+        Permission(name="first-permission", description="first", created_on=datetime.utcnow()),
+        Permission(name="audited-permission", description="", created_on=datetime.utcnow()),
+        Permission(name="early-permission", description="is early", created_on=early_date),
+    ]
+    for permission in permissions:
+        sql_permission = SQLPermission(
+            name=permission.name,
+            description=permission.description,
+            created_on=permission.created_on,
+        )
+        sql_permission.add(session)
+    SQLPermission.get(session, name="audited-permission")._audited = True
+    SQLPermission(name="disabled", description="", enabled=False).add(session)
+    User(username="gary@a.co").add(session)
+    Counter.incr(session, "updates")
+    session.commit()
+    return permissions
+
+
+def create_list_permissions_usecase(session, ui, graph=None):  # noqa: F811
+    # type: (Session, ListPermissionsUI, Optional[GroupGraph]) -> ListPermissions
+    if not graph:
+        graph = GroupGraph()
+    graph.update_from_db(session)
+    repository_factory = RepositoryFactory(session, graph)
+    service_factory = ServiceFactory(session, repository_factory)
+    usecase_factory = UseCaseFactory(service_factory)
+    return usecase_factory.create_list_permissions_usecase(ui)
+
+
+def test_simple_list_permissions(session):  # noqa: F811
+    # type: (Session) -> None
+    permissions = create_test_data(session)
+    mock_ui = MockUI(sort=True)
+    usecase = create_list_permissions_usecase(session, mock_ui)
+    usecase.simple_list_permissions()
+    assert not mock_ui.can_create
+    expected = PaginatedList(values=sorted(permissions), total=3, offset=0)
+    assert_paginated_list_equal(mock_ui.permissions, expected)
+
+
+def test_list_permissions_pagination(session):  # noqa: F811
+    # type: (Session) -> None
+    permissions = create_test_data(session)
+    mock_ui = MockUI()
+    usecase = create_list_permissions_usecase(session, mock_ui)
+
+    # Sorted by name, limited to 2.
+    pagination = Pagination(
+        sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=2
+    )
+    usecase.list_permissions("gary@a.co", pagination, audited_only=False)
+    expected = PaginatedList(values=sorted(permissions)[:2], total=3, offset=0)
+    assert_paginated_list_equal(mock_ui.permissions, expected)
+
+    # Sorted by date, using offset, limit longer than remaining items.
+    pagination = Pagination(
+        sort_key=ListPermissionsSortKey.DATE, reverse_sort=False, offset=2, limit=10
+    )
+    usecase.list_permissions("gary@a.co", pagination, audited_only=False)
+    expected_values = sorted(permissions, key=lambda p: p.created_on)[2:]
+    expected = PaginatedList(values=expected_values, total=3, offset=2)
+    assert_paginated_list_equal(mock_ui.permissions, expected)
+
+    # Sorted by name, reversed, limit of one 1 and offset of 1.
+    pagination = Pagination(
+        sort_key=ListPermissionsSortKey.NAME, reverse_sort=True, offset=1, limit=1
+    )
+    usecase.list_permissions("gary@a.co", pagination, audited_only=False)
+    expected_values = sorted(permissions, reverse=True)[1:2]
+    expected = PaginatedList(values=expected_values, total=3, offset=1)
+    assert_paginated_list_equal(mock_ui.permissions, expected)
+
+
+def test_list_permissions_audited_only(session):  # noqa: F811
+    # type: (Session) -> None
+    permissions = create_test_data(session)
+    mock_ui = MockUI()
+    usecase = create_list_permissions_usecase(session, mock_ui)
+    pagination = Pagination(
+        sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=None
+    )
+    usecase.list_permissions("gary@a.co", pagination, audited_only=True)
+    expected_values = [p for p in permissions if p.name == "audited-permission"]
+    expected = PaginatedList(values=expected_values, total=1, offset=0)
+    assert_paginated_list_equal(mock_ui.permissions, expected)
+
+
+def test_list_permissions_can_create(session):  # noqa: F811
+    # type: (Session) -> None
+    user = User(username="gary@a.co")
+    user.add(session)
+    SQLPermission(name=PERMISSION_CREATE, description="").add(session)
+    Counter.incr(session, "updates")
+    session.commit()
+    graph = GroupGraph()
+    mock_ui = MockUI()
+    usecase = create_list_permissions_usecase(session, mock_ui, graph)
+
+    # User has no permissions.
+    pagination = Pagination(
+        sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=None
+    )
+    usecase.list_permissions("gary@a.co", pagination, audited_only=False)
+    assert not mock_ui.can_create
+
+    # Create a group, grant the permission to the group, and add the user to the group.
+    permission = SQLPermission.get(session, name=PERMISSION_CREATE)
+    group = Group(groupname="creators")
+    group.add(session)
+    GroupEdge(
+        group_id=group.id, member_type=OBJ_TYPES["User"], member_pk=user.id, active=True
+    ).add(session)
+    PermissionMap(permission_id=permission.id, group_id=group.id, argument="*").add(session)
+    Counter.incr(session, "updates")
+    session.commit()
+    graph.update_from_db(session)
+
+    # Now the can_create flag should be set to true.
+    usecase.list_permissions("gary@a.co", pagination, audited_only=False)
+    assert mock_ui.can_create


### PR DESCRIPTION
Add a new ListPermissions use case, backed by the graph, and replace
the frontend handler code with code that calls it.
    
This also refactors the PermissionRepository to have two
implementations, one based on the graph and one based on SQL.  The
grouper-ctl permission command now instantiates the graph so it is
(hopefully temporarily) rather slow.
    
Refactor interfaces that ask about the permissions held by a user
into a separate UserService instead of the PermissionService.