### PR TITLE
Fix circular dependency between User and UserToken

### DIFF
--- a/grouper/models/user.py
+++ b/grouper/models/user.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.model_base import Model
@@ -24,7 +23,6 @@ class User(Model, CommentObjectMixin):
     enabled = Column(Boolean, default=True, nullable=False)
     role_user = Column(Boolean, default=False, nullable=False)
     is_service_account = Column(Boolean, default=False, nullable=False)
-    tokens = relationship("UserToken", back_populates="user")
 
     @hybrid_property
     def name(self):

--- a/grouper/models/user_token.py
+++ b/grouper/models/user_token.py
@@ -29,7 +29,7 @@ class UserToken(Model):
 
     hashed_secret = Column(String(length=64), unique=True, nullable=False)
 
-    user = relationship("User", back_populates="tokens")
+    user = relationship("User", backref="tokens")
 
     __table_args__ = (UniqueConstraint("user_id", "name"),)
 


### PR DESCRIPTION
Switch to the SQLAlchemy syntax that correctly handles creating an
attribute on both objects (the same approach as ServiceAccount)
without creating a circular dependency or requiring that both
classes be loaded in order to create a User.