### PR TITLE
Ignore .pytest_cache anywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ pip-log.txt
 nosetests.xml
 /.cache/
 /.mypy_cache/
-/.pytest_cache/
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
It apparently isn't always created at the top level.