### PR TITLE
Refactor test setup for usecase tests

### DIFF
--- a/itests/api/permissions_test.py
+++ b/itests/api/permissions_test.py
@@ -21,9 +21,9 @@ def test_get_permissions(tmpdir, setup):
 
 def test_get_permission(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
-    setup.grant_permission_to_group("sad-team", "ssh", "foo")
-    setup.grant_permission_to_group("team-sre", "ssh", "bar")
-    setup.grant_permission_to_group("tech-ops", "ssh", "*")
+    setup.grant_permission_to_group("ssh", "foo", "sad-team")
+    setup.grant_permission_to_group("ssh", "bar", "team-sre")
+    setup.grant_permission_to_group("ssh", "*", "tech-ops")
     setup.commit()
     with api_server(tmpdir) as api_url:
         api_client = Groupy(api_url)

--- a/itests/api/permissions_test.py
+++ b/itests/api/permissions_test.py
@@ -1,20 +1,31 @@
-from itests.fixtures import api_client, async_api_server  # noqa: F401
-from tests.fixtures import (  # noqa: F401
-    graph,
-    groups,
-    permissions,
-    service_accounts,
-    session,
-    standard_graph,
-    users,
-)
+from typing import TYPE_CHECKING
+
+from groupy.client import Groupy
+
+from itests.setup import api_server
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from tests.setup import SetupTest
 
 
-def test_get_permissions(api_client, permissions):  # noqa: F811
-    api_permissions = list(api_client.permissions)
-    assert sorted(api_permissions) == sorted(permissions)
+def test_get_permissions(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    setup.create_permission("some-permission")
+    setup.create_permission("another-permission")
+    setup.commit()
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        assert sorted(api_client.permissions) == ["another-permission", "some-permission"]
 
 
-def test_get_permission(api_client):  # noqa: F811
-    permission = api_client.permissions.get("ssh")
-    assert sorted(permission.groups) == ["sad-team", "team-sre", "tech-ops"]
+def test_get_permission(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    setup.grant_permission_to_group("sad-team", "ssh", "foo")
+    setup.grant_permission_to_group("team-sre", "ssh", "bar")
+    setup.grant_permission_to_group("tech-ops", "ssh", "*")
+    setup.commit()
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        permission = api_client.permissions.get("ssh")
+        assert sorted(permission.groups) == ["sad-team", "team-sre", "tech-ops"]

--- a/itests/conftest.py
+++ b/itests/conftest.py
@@ -1,6 +1,6 @@
 """Provide pytest fixtures for test setup.
 
-When testing with a persistant database, we have to explicitly close the database session after
+When testing with a persistent database, we have to explicitly close the database session after
 each test.  Otherwise, the presence of an open session will prevent dropping all tables to ensure a
 clean test context.  The easiest way to provide that is via pytest fixtures.
 

--- a/itests/conftest.py
+++ b/itests/conftest.py
@@ -1,0 +1,37 @@
+"""Provide pytest fixtures for test setup.
+
+When testing with a persistant database, we have to explicitly close the database session after
+each test.  Otherwise, the presence of an open session will prevent dropping all tables to ensure a
+clean test context.  The easiest way to provide that is via pytest fixtures.
+
+This file is automatically loaded by pytest and injects available fixtures into every test without
+requiring the flake8 noqa annotations normally needed by explicit fixture imports.
+"""
+
+from contextlib import closing
+from typing import TYPE_CHECKING
+
+import pytest
+
+from itests.setup import selenium_browser
+from tests.setup import SetupTest
+
+if TYPE_CHECKING:
+    from py import LocalPath
+    from selenium.webdriver import Chrome
+    from typing import Iterator
+
+
+@pytest.yield_fixture
+def browser():
+    # type: () -> Iterator[Chrome]
+    driver = selenium_browser()
+    yield driver
+    driver.quit()
+
+
+@pytest.yield_fixture
+def setup(tmpdir):
+    # type: (LocalPath) -> Iterator[SetupTest]
+    with closing(SetupTest(tmpdir)) as test_setup:
+        yield test_setup

--- a/itests/fe/audits_test.py
+++ b/itests/fe/audits_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from itests.fixtures import async_server, browser  # noqa: F401
+from itests.fixtures import async_server  # noqa: F401
 from itests.pages.audits import AuditsCreatePage
 from itests.pages.groups import GroupViewPage
 from plugins import group_ownership_policy

--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from itests.fixtures import async_server, browser  # noqa: F401
+from itests.fixtures import async_server  # noqa: F401
 from itests.pages.exceptions import NoSuchElementException
 from itests.pages.groups import (
     GroupEditMemberPage,

--- a/itests/fe/permission_requests_test.py
+++ b/itests/fe/permission_requests_test.py
@@ -3,7 +3,7 @@ import pytest
 from grouper.constants import PERMISSION_ADMIN, PERMISSION_GRANT
 from grouper.models.permission_request import PermissionRequest
 from grouper.permissions import create_request, get_or_create_permission, update_request
-from itests.fixtures import async_server, browser  # noqa: F401
+from itests.fixtures import async_server  # noqa: F401
 from itests.pages.permission_requests import PermissionRequestsPage
 from tests.fixtures import (  # noqa: F401
     graph,

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from time import time
 from typing import TYPE_CHECKING
@@ -55,7 +54,6 @@ def test_list(tmpdir, setup, browser):
 
         # Check the basic permission list.
         page = PermissionsPage(browser)
-        logging.warning("%s", page.root.page_source)
         seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
         assert seen_permissions == sorted(expected_permissions)
         assert page.heading == "Permissions"
@@ -97,7 +95,6 @@ def test_list_pagination(tmpdir, setup, browser):
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions?limit=1&offset=1"))
         page = PermissionsPage(browser)
-        logging.warning("%s", page.root.page_source)
         seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
         assert seen_permissions == sorted(expected_permissions)[1:2]
 
@@ -110,7 +107,6 @@ def test_create_button(tmpdir, setup, browser):
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions"))
         page = PermissionsPage(browser)
-        logging.warning("%s", page.root.page_source)
         assert not page.has_create_permission_button
 
         setup.grant_permission_to_group(PERMISSION_CREATE, "*", "admins")

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -113,7 +113,7 @@ def test_create_button(tmpdir, setup, browser):
         logging.warning("%s", page.root.page_source)
         assert not page.has_create_permission_button
 
-        setup.grant_permission_to_group("admins", PERMISSION_CREATE, "*")
+        setup.grant_permission_to_group(PERMISSION_CREATE, "*", "admins")
         setup.add_user_to_group("gary@a.co", "admins")
         setup.commit()
         browser.get(url(frontend_url, "/permissions?refresh=yes"))

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -1,4 +1,4 @@
-from itests.fixtures import async_server, browser  # noqa: F401
+from itests.fixtures import async_server  # noqa: F401
 from itests.pages.groups import GroupViewPage
 from itests.pages.service_accounts import (
     ServiceAccountCreatePage,

--- a/itests/fe/users_test.py
+++ b/itests/fe/users_test.py
@@ -3,7 +3,7 @@ import pytest
 from grouper.constants import AUDIT_SECURITY
 from grouper.models.public_key import PublicKey
 from grouper.permissions import get_or_create_permission
-from itests.fixtures import async_server, browser  # noqa: F401
+from itests.fixtures import async_server  # noqa: F401
 from itests.pages.exceptions import NoSuchElementException
 from itests.pages.users import PublicKeysPage, UserViewPage
 from plugins import group_ownership_policy

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -95,21 +95,6 @@ def async_api_server(standard_graph, tmpdir):
     p.kill()
 
 
-@pytest.yield_fixture
-def browser():
-    # type: () -> Iterator[selenium.webdriver.Chrome]
-    options = selenium.webdriver.ChromeOptions()
-    options.add_argument("headless")
-    options.add_argument("no-sandbox")
-    options.add_argument("window-size=1920,1080")
-
-    driver = selenium.webdriver.Chrome(chrome_options=options)
-
-    yield driver
-
-    driver.quit()
-
-
 @pytest.fixture
 def api_client(async_api_server):
     return Groupy(async_api_server)

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -6,7 +6,6 @@ from contextlib import closing
 from typing import TYPE_CHECKING
 
 import pytest
-import selenium
 from groupy.client import Groupy
 
 from tests.path_util import bin_env, db_url, src_path

--- a/itests/setup.py
+++ b/itests/setup.py
@@ -1,0 +1,111 @@
+"""Utilities to set up integration tests.
+
+Contains only test setup code specific to integration tests, such as spawning separate servers and
+managing Selenium.  More general test setup code goes in tests.setup.
+"""
+
+import errno
+import logging
+import socket
+import subprocess
+import time
+from contextlib import closing, contextmanager
+from typing import TYPE_CHECKING
+
+from selenium.webdriver import Chrome, ChromeOptions
+
+from tests.path_util import bin_env, db_url, src_path
+
+if TYPE_CHECKING:
+    from py.local import LocalPath
+    from typing import Iterator
+
+
+def _get_unused_port():
+    # type: () -> int
+    """Bind, requesting a system-allocated port, and return it.
+
+    This isn't strictly correct in that there's a race condition where the port could be taken by
+    something else before the server we launch uses it.  Hopefully this will not be common.
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_until_accept(port, timeout=3.0):
+    # type: (int, float) -> None
+    """Wait until a server accepts connections on the specified port."""
+    deadline = time.time() + timeout
+    while True:
+        socket_timeout = deadline - time.time()
+        if socket_timeout < 0.0:
+            assert False, "server did not start on port {} within {}s".format(port, timeout)
+        try:
+            s = socket.socket()
+            s.settimeout(socket_timeout)
+            s.connect(("localhost", port))
+        except socket.timeout:
+            pass
+        except socket.error as e:
+            if e.errno not in [errno.ETIMEDOUT, errno.ECONNREFUSED]:
+                raise
+        else:
+            s.close()
+            return
+        time.sleep(0.1)
+
+
+@contextmanager
+def frontend_server(tmpdir, user):
+    # type: (LocalPath, str) -> Iterator[str]
+    proxy_port = _get_unused_port()
+    fe_port = _get_unused_port()
+
+    cmds = [
+        [
+            src_path("bin", "grouper-ctl"),
+            "-vvc",
+            src_path("config", "dev.yaml"),
+            "user_proxy",
+            "-P",
+            str(fe_port),
+            "-p",
+            str(proxy_port),
+            user,
+        ],
+        [
+            src_path("bin", "grouper-fe"),
+            "-vvc",
+            src_path("config", "dev.yaml"),
+            "-p",
+            str(fe_port),
+            "-d",
+            db_url(tmpdir),
+        ],
+    ]
+
+    subprocesses = []
+    for cmd in cmds:
+        logging.info("Starting command: %s", " ".join(cmd))
+        p = subprocess.Popen(cmd, env=bin_env())
+        subprocesses.append(p)
+
+    logging.info("Waiting on server to come online")
+    _wait_until_accept(proxy_port)
+    _wait_until_accept(fe_port)
+    logging.info("Connection established")
+
+    yield "http://localhost:{}".format(proxy_port)
+
+    for p in subprocesses:
+        p.kill()
+
+
+def selenium_browser():
+    # type: () -> Chrome
+    options = ChromeOptions()
+    options.add_argument("headless")
+    options.add_argument("no-sandbox")
+    options.add_argument("window-size=1920,1080")
+    return Chrome(chrome_options=options)

--- a/itests/setup.py
+++ b/itests/setup.py
@@ -57,6 +57,33 @@ def _wait_until_accept(port, timeout=3.0):
 
 
 @contextmanager
+def api_server(tmpdir):
+    # type: (LocalPath) -> Iterator[str]
+    api_port = _get_unused_port()
+
+    cmd = [
+        src_path("bin", "grouper-api"),
+        "-c",
+        src_path("config", "dev.yaml"),
+        "-p",
+        str(api_port),
+        "-d",
+        db_url(tmpdir),
+    ]
+
+    logging.info("Starting server with command: %s", " ".join(cmd))
+    p = subprocess.Popen(cmd, env=bin_env())
+
+    logging.info("Waiting on server to come online")
+    _wait_until_accept(api_port)
+    logging.info("Connection established")
+
+    yield "localhost:{}".format(api_port)
+
+    p.kill()
+
+
+@contextmanager
 def frontend_server(tmpdir, user):
     # type: (LocalPath, str) -> Iterator[str]
     proxy_port = _get_unused_port()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Provide pytest fixtures for test setup.
 
-When testing with a persistant database, we have to explicitly close the database session after
+When testing with a persistent database, we have to explicitly close the database session after
 each test.  Otherwise, the presence of an open session will prevent dropping all tables to ensure a
 clean test context.  The easiest way to provide that is via pytest fixtures.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Provide pytest fixtures for test setup.
+
+When testing with a persistant database, we have to explicitly close the database session after
+each test.  Otherwise, the presence of an open session will prevent dropping all tables to ensure a
+clean test context.  The easiest way to provide that is via pytest fixtures.
+
+This file is automatically loaded by pytest and injects available fixtures into every test without
+requiring the flake8 noqa annotations normally needed by explicit fixture imports.
+"""
+
+from contextlib import closing
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.setup import SetupTest
+
+if TYPE_CHECKING:
+    from py import LocalPath
+    from typing import Iterator
+
+
+@pytest.yield_fixture
+def setup(tmpdir):
+    # type: (LocalPath) -> Iterator[SetupTest]
+    with closing(SetupTest(tmpdir)) as test_setup:
+        yield test_setup

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,149 @@
+"""Utilities to set up test cases.
+
+Provides a SetupTest object that creates the database session, provides use case factories for
+individual tests, and provides methods to create objects in the test database.  These methods try
+to minimize the amount of code required to set up a test by creating new objects whenever needed.
+So, for instance, one can just call:
+
+    setup.add_user_to_group("user@a.co", "some-group")
+
+without creating the user and group first, and both will be created if not present.
+
+This is the new test setup mechanism, replacing the fixtures defined in tests.fixtures.  All new
+tests should use this mechanism and not rely on standard_graph or other pytest fixtures.
+"""
+
+import os
+from datetime import datetime
+from time import time
+from typing import TYPE_CHECKING
+
+from grouper.graph import GroupGraph
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import get_db_engine, Session
+from grouper.models.counter import Counter
+from grouper.models.group import Group
+from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.permission import Permission
+from grouper.models.permission_map import PermissionMap
+from grouper.models.user import User
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.usecases.factory import UseCaseFactory
+from tests.path_util import db_url
+
+if TYPE_CHECKING:
+    from py.local import LocalPath
+    from typing import Optional
+
+
+class SetupTest(object):
+    """Set up the environment for a test.
+
+    Attributes:
+        graph: Underlying graph (not refreshed from the database automatically!)
+        repository_factory: Factory for repository objects
+        session: The underlying database session
+        service_factory: Factory for service objects
+        usecase_factory: Factory for usecase objects
+    """
+
+    def __init__(self, tmpdir):
+        # type: (LocalPath) -> None
+        self.session = self.create_session(tmpdir)
+        self.graph = GroupGraph()
+        self.repository_factory = RepositoryFactory(self.session, self.graph)
+        self.service_factory = ServiceFactory(self.session, self.repository_factory)
+        self.usecase_factory = UseCaseFactory(self.service_factory)
+
+    def create_session(self, tmpdir):
+        # type: (LocalPath) -> Session
+        db_engine = get_db_engine(db_url(tmpdir))
+
+        # If using a persistant database, clear the database first.
+        if "MEROU_TEST_DATABASE" in os.environ:
+            Model.metadata.drop_all(db_engine)
+
+        # Create the database schema and the corresponding session.
+        Model.metadata.create_all(db_engine)
+        Session.configure(bind=db_engine)
+        return Session()
+
+    def commit(self):
+        # type: () -> None
+        Counter.incr(self.session, "updates")
+        self.session.commit()
+        self.graph.update_from_db(self.session)
+
+    def close(self):
+        # type: () -> None
+        self.session.close()
+
+    def create_group(self, name):
+        # type: (str) -> None
+        """Create a group, does nothing if it already exists."""
+        if Group.get(self.session, name=name):
+            return
+        group = Group(groupname=name)
+        group.add(self.session)
+
+    def create_permission(
+        self, name, description="", audited=False, enabled=True, created_on=None
+    ):
+        # type: (str, str, bool, bool, Optional[datetime]) -> None
+        """Create a permission, does nothing if it already exists.
+
+        Avoid milliseconds in the creation timestamp since they behave differently in SQLite (which
+        preserves them) and MySQL (which drops them).
+        """
+        if Permission.get(self.session, name=name):
+            return
+        if not created_on:
+            created_on = datetime.utcfromtimestamp(int(time()))
+        permission = Permission(
+            name=name,
+            description=description,
+            _audited=audited,
+            enabled=enabled,
+            created_on=created_on,
+        )
+        permission.add(self.session)
+
+    def create_user(self, name):
+        # type: (str) -> None
+        """Create a user, does nothing if it already exists."""
+        if User.get(self.session, name=name):
+            return
+        user = User(username=name)
+        user.add(self.session)
+
+    def add_user_to_group(self, user, group, role="member"):
+        # type: (str, str, str) -> None
+        self.create_user(user)
+        self.create_group(group)
+        user_obj = User.get(self.session, name=user)
+        assert user_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+        edge = GroupEdge(
+            group_id=group_obj.id,
+            member_type=OBJ_TYPES["User"],
+            member_pk=user_obj.id,
+            active=True,
+            _role=GROUP_EDGE_ROLES.index(role),
+        )
+        edge.add(self.session)
+
+    def grant_permission_to_group(self, group, permission, argument):
+        # type: (str, str, str) -> None
+        self.create_group(group)
+        self.create_permission(permission)
+        permission_obj = Permission.get(self.session, name=permission)
+        assert permission_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+        grant = PermissionMap(
+            permission_id=permission_obj.id, group_id=group_obj.id, argument=argument
+        )
+        grant.add(self.session)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -61,7 +61,7 @@ class SetupTest(object):
         # type: (LocalPath) -> Session
         db_engine = get_db_engine(db_url(tmpdir))
 
-        # If using a persistant database, clear the database first.
+        # If using a persistent database, clear the database first.
         if "MEROU_TEST_DATABASE" in os.environ:
             Model.metadata.drop_all(db_engine)
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -135,7 +135,7 @@ class SetupTest(object):
         )
         edge.add(self.session)
 
-    def grant_permission_to_group(self, group, permission, argument):
+    def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
         self.create_group(group)
         self.create_permission(permission)

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 def test_permission_disable(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
     setup.add_user_to_group("gary@a.co", "admins")
     setup.create_permission("some-permission")
     setup.commit()
@@ -38,7 +38,7 @@ def test_permission_disable_denied(setup):
 
 def test_permission_disable_system(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
     setup.add_user_to_group("gary@a.co", "admins")
     setup.create_permission(PERMISSION_CREATE)
     setup.commit()
@@ -52,7 +52,7 @@ def test_permission_disable_system(setup):
 
 def test_permission_not_found(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
     setup.add_user_to_group("gary@a.co", "admins")
     setup.commit()
     mock_ui = MagicMock()

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -2,65 +2,60 @@ from typing import TYPE_CHECKING
 
 from mock import call, MagicMock
 
-from grouper.constants import PERMISSION_CREATE
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.usecases.factory import UseCaseFactory
-from tests.fixtures import (  # noqa: F401
-    graph,
-    groups,
-    permissions,
-    service_accounts,
-    session,
-    standard_graph,
-    users,
-)
+from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE
+from grouper.models.permission import Permission
 
 if TYPE_CHECKING:
-    from dropbox.models.base.session import Session
-    from dropbox.graph import GroupGraph
-    from grouper.usecases.disable_permission import DisablePermission
+    from tests.setup import SetupTest
 
 
-def create_disable_permission_usecase(session, graph, actor, ui):  # noqa: F811
-    # type: (Session, GroupGraph, str, MagicMock) -> DisablePermission
-    repository_factory = RepositoryFactory(session, graph)
-    service_factory = ServiceFactory(session, repository_factory)
-    usecase_factory = UseCaseFactory(service_factory)
-    return usecase_factory.create_disable_permission_usecase(actor, ui)
-
-
-def test_permission_disable(session, standard_graph):  # noqa: F811
-    # type: (Session, GroupGraph) -> None
+def test_permission_disable(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_permission("some-permission")
+    setup.commit()
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
-    usecase.disable_permission("audited")
-    assert mock_ui.mock_calls == [call.disabled_permission("audited")]
+    usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
+    usecase.disable_permission("some-permission")
+    assert mock_ui.mock_calls == [call.disabled_permission("some-permission")]
+    assert not Permission.get(setup.session, name="some-permission").enabled
 
 
-def test_permission_disable_denied(session, standard_graph):  # noqa: F811
-    # type: (Session, GroupGraph) -> None
+def test_permission_disable_denied(setup):
+    # type: (SetupTest) -> None
+    setup.create_user("zorkian@a.co")
+    setup.create_permission("some-permission")
+    setup.commit()
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, standard_graph, "zorkian@a.co", mock_ui)
-    usecase.disable_permission("audited")
+    usecase = setup.usecase_factory.create_disable_permission_usecase("zorkian@a.co", mock_ui)
+    usecase.disable_permission("some-permission")
     assert mock_ui.mock_calls == [
-        call.disable_permission_failed_because_permission_denied("audited")
+        call.disable_permission_failed_because_permission_denied("some-permission")
     ]
+    assert Permission.get(setup.session, name="some-permission").enabled
 
 
-def test_permission_disable_system(session, standard_graph):  # noqa: F811
-    # type: (Session, GroupGraph) -> None
+def test_permission_disable_system(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_permission(PERMISSION_CREATE)
+    setup.commit()
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
+    usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission(PERMISSION_CREATE)
     assert mock_ui.mock_calls == [
         call.disable_permission_failed_because_system_permission(PERMISSION_CREATE)
     ]
 
 
-def test_permission_not_found(session, standard_graph):  # noqa: F811
-    # type: (Session, GroupGraph) -> None
+def test_permission_not_found(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group("admins", PERMISSION_ADMIN, "")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.commit()
     mock_ui = MagicMock()
-    usecase = create_disable_permission_usecase(session, standard_graph, "gary@a.co", mock_ui)
+    usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission("nonexistent")
     assert mock_ui.mock_calls == [call.disable_permission_failed_because_not_found("nonexistent")]

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -5,24 +5,11 @@ from typing import TYPE_CHECKING
 from grouper.constants import PERMISSION_CREATE
 from grouper.entities.pagination import PaginatedList, Pagination
 from grouper.entities.permission import Permission
-from grouper.graph import GroupGraph
-from grouper.models.base.constants import OBJ_TYPES
-from grouper.models.counter import Counter
-from grouper.models.group import Group
-from grouper.models.group_edge import GroupEdge
-from grouper.models.permission import Permission as SQLPermission
-from grouper.models.permission_map import PermissionMap
-from grouper.models.user import User
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.usecases.factory import UseCaseFactory
 from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
-from tests.fixtures import session  # noqa: F401
 
 if TYPE_CHECKING:
-    from grouper.models.base.session import Session
-    from grouper.usecases.list_permissions import ListPermissions
-    from typing import Any, List, Optional
+    from tests.setup import SetupTest
+    from typing import Any, List
 
 
 class MockUI(ListPermissionsUI):
@@ -46,8 +33,8 @@ def assert_paginated_list_equal(left, right):
     assert left.offset == right.offset
 
 
-def create_test_data(session):  # noqa: F811
-    # type: (Session) -> List[Permission]
+def create_test_data(setup):
+    # type: (SetupTest) -> List[Permission]
     """Sets up a very basic test graph and returns the permission objects.
 
     Be careful not to include milliseconds in the creation timestamps since this causes different
@@ -62,47 +49,34 @@ def create_test_data(session):  # noqa: F811
         Permission(name="early-permission", description="is early", created_on=early_date),
     ]
     for permission in permissions:
-        sql_permission = SQLPermission(
+        setup.create_permission(
             name=permission.name,
             description=permission.description,
             created_on=permission.created_on,
+            audited=(permission.name == "audited-permission"),
         )
-        sql_permission.add(session)
-    SQLPermission.get(session, name="audited-permission")._audited = True
-    SQLPermission(name="disabled", description="", enabled=False).add(session)
-    User(username="gary@a.co").add(session)
-    Counter.incr(session, "updates")
-    session.commit()
+    setup.create_permission("disabled", enabled=False)
+    setup.create_user("gary@a.co")
+    setup.commit()
     return permissions
 
 
-def create_list_permissions_usecase(session, ui, graph=None):  # noqa: F811
-    # type: (Session, ListPermissionsUI, Optional[GroupGraph]) -> ListPermissions
-    if not graph:
-        graph = GroupGraph()
-    graph.update_from_db(session)
-    repository_factory = RepositoryFactory(session, graph)
-    service_factory = ServiceFactory(session, repository_factory)
-    usecase_factory = UseCaseFactory(service_factory)
-    return usecase_factory.create_list_permissions_usecase(ui)
-
-
-def test_simple_list_permissions(session):  # noqa: F811
-    # type: (Session) -> None
-    permissions = create_test_data(session)
+def test_simple_list_permissions(setup):
+    # type: (SetupTest) -> None
+    permissions = create_test_data(setup)
     mock_ui = MockUI(sort=True)
-    usecase = create_list_permissions_usecase(session, mock_ui)
+    usecase = setup.usecase_factory.create_list_permissions_usecase(mock_ui)
     usecase.simple_list_permissions()
     assert not mock_ui.can_create
     expected = PaginatedList(values=sorted(permissions), total=3, offset=0)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 
-def test_list_permissions_pagination(session):  # noqa: F811
-    # type: (Session) -> None
-    permissions = create_test_data(session)
+def test_list_permissions_pagination(setup):
+    # type: (SetupTest) -> None
+    permissions = create_test_data(setup)
     mock_ui = MockUI()
-    usecase = create_list_permissions_usecase(session, mock_ui)
+    usecase = setup.usecase_factory.create_list_permissions_usecase(mock_ui)
 
     # Sorted by name, limited to 2.
     pagination = Pagination(
@@ -131,11 +105,11 @@ def test_list_permissions_pagination(session):  # noqa: F811
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 
-def test_list_permissions_audited_only(session):  # noqa: F811
-    # type: (Session) -> None
-    permissions = create_test_data(session)
+def test_list_permissions_audited_only(setup):
+    # type: (SetupTest) -> None
+    permissions = create_test_data(setup)
     mock_ui = MockUI()
-    usecase = create_list_permissions_usecase(session, mock_ui)
+    usecase = setup.usecase_factory.create_list_permissions_usecase(mock_ui)
     pagination = Pagination(
         sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=None
     )
@@ -145,16 +119,12 @@ def test_list_permissions_audited_only(session):  # noqa: F811
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 
-def test_list_permissions_can_create(session):  # noqa: F811
-    # type: (Session) -> None
-    user = User(username="gary@a.co")
-    user.add(session)
-    SQLPermission(name=PERMISSION_CREATE, description="").add(session)
-    Counter.incr(session, "updates")
-    session.commit()
-    graph = GroupGraph()
+def test_list_permissions_can_create(setup):
+    # type: (SetupTest) -> None
+    setup.create_permission(PERMISSION_CREATE)
+    create_test_data(setup)
     mock_ui = MockUI()
-    usecase = create_list_permissions_usecase(session, mock_ui, graph)
+    usecase = setup.usecase_factory.create_list_permissions_usecase(mock_ui)
 
     # User has no permissions.
     pagination = Pagination(
@@ -163,18 +133,9 @@ def test_list_permissions_can_create(session):  # noqa: F811
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     assert not mock_ui.can_create
 
-    # Create a group, grant the permission to the group, and add the user to the group.
-    permission = SQLPermission.get(session, name=PERMISSION_CREATE)
-    group = Group(groupname="creators")
-    group.add(session)
-    GroupEdge(
-        group_id=group.id, member_type=OBJ_TYPES["User"], member_pk=user.id, active=True
-    ).add(session)
-    PermissionMap(permission_id=permission.id, group_id=group.id, argument="*").add(session)
-    Counter.incr(session, "updates")
-    session.commit()
-    graph.update_from_db(session)
-
-    # Now the can_create flag should be set to true.
+    # If the user is added to a group with the right permission, can_create should be true.
+    setup.add_user_to_group("gary@a.co", "creators")
+    setup.grant_permission_to_group("creators", PERMISSION_CREATE, "*")
+    setup.commit()
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     assert mock_ui.can_create

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -135,7 +135,7 @@ def test_list_permissions_can_create(setup):
 
     # If the user is added to a group with the right permission, can_create should be true.
     setup.add_user_to_group("gary@a.co", "creators")
-    setup.grant_permission_to_group("creators", PERMISSION_CREATE, "*")
+    setup.grant_permission_to_group(PERMISSION_CREATE, "*", "creators")
     setup.commit()
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     assert mock_ui.can_create


### PR DESCRIPTION
Provide a new TestSetup class that handles creating the database
session and provides utility functions for setting up test data.
This is the replacement for fixtures that set up a complex data
model that most tests don't need and that somewhat obscure what
the test is doing.

This is the first iteration, which messes with the database
directly via SQLAlchemy objects.  A later revision will use the
same service and repository path that non-test code uses.