### PR TITLE
Convert transactions to a context manager

### DIFF
--- a/grouper/usecases/disable_permission.py
+++ b/grouper/usecases/disable_permission.py
@@ -65,9 +65,8 @@ class DisablePermission(object):
         else:
             authorization = Authorization(self.actor)
             try:
-                self.transaction_service.start_transaction()
-                self.permission_service.disable_permission(name, authorization)
-                self.transaction_service.commit()
+                with self.transaction_service.transaction():
+                    self.permission_service.disable_permission(name, authorization)
             except PermissionNotFoundException:
                 self.ui.disable_permission_failed_because_not_found(name)
             else:

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     from grouper.entities.permission import Permission
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
+    from types import TracebackType
+    from typing import Optional
 
 
 class PermissionInterface(object):
@@ -42,19 +44,30 @@ class PermissionInterface(object):
         pass
 
 
+class Transaction(object):
+    """Abstract base class for transaction objects."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def __enter__(self):
+        # type: () -> None
+        pass
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # type: (Optional[type], Optional[Exception], Optional[TracebackType]) -> bool
+        pass
+
+
 class TransactionInterface(object):
     """Abstract base class for starting and committing transactions."""
 
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def start_transaction(self):
-        # type: () -> None
-        pass
-
-    @abstractmethod
-    def commit(self):
-        # type: () -> None
+    def transaction(self):
+        # type: () -> Transaction
         pass
 
 


### PR DESCRIPTION
Change the API of TransactionService to create a Transaction object
that implements the context manager API, and update callers to use
it instead of start_transaction and commit pairs.  Add a Transaction
interface and a SQLTransaction implementation.  Retain the commit
method for tests, which may not want to bother with the context
manager, but hide it from use cases.