### PR TITLE
Refactor grouper-ctl initialization

### DIFF
--- a/grouper/ctl/base.py
+++ b/grouper/ctl/base.py
@@ -1,17 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
-from grouper.graph import Graph
-from grouper.models.base.session import get_db_engine, Session
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.settings import settings
-from grouper.usecases.factory import UseCaseFactory
-from grouper.util import get_database_url
-
 if TYPE_CHECKING:
-    from argparse import _SubParsersAction, Namespace
-    from typing import Optional
+    from argparse import ArgumentParser, Namespace
 
 
 class CtlCommand(object):
@@ -21,20 +12,10 @@ class CtlCommand(object):
 
     @staticmethod
     @abstractmethod
-    def add_parser(subparsers):
-        # type: (_SubParsersAction) -> str
-        """Add the parser for this subcommand and return the subcommand name."""
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        """Add the arguments for this command to the provided parser."""
         pass
-
-    def __init__(self, session):
-        # type: (Optional[Session]) -> None
-        if not session:
-            db_engine = get_db_engine(get_database_url(settings))
-            Session.configure(bind=db_engine)
-            session = Session()
-        repository_factory = RepositoryFactory(session, Graph())
-        service_factory = ServiceFactory(session, repository_factory)
-        self.usecase_factory = UseCaseFactory(service_factory)
 
     @abstractmethod
     def run(self, args):

--- a/grouper/ctl/base.py
+++ b/grouper/ctl/base.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
 
 
 class CtlCommand(object):
-    """Implements a subcommand of grouper-ctl that needs a session and a graph."""
+    """Implements a subcommand of grouper-ctl."""
 
     __metaclass__ = ABCMeta
 
@@ -20,5 +20,5 @@ class CtlCommand(object):
     @abstractmethod
     def run(self, args):
         # type: (Namespace) -> None
-        """Run a command and return the exit status."""
+        """Run a command with some arguments."""
         pass

--- a/grouper/ctl/base.py
+++ b/grouper/ctl/base.py
@@ -1,29 +1,43 @@
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
+from grouper.graph import Graph
+from grouper.models.base.session import get_db_engine, Session
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.settings import settings
+from grouper.usecases.factory import UseCaseFactory
+from grouper.util import get_database_url
+
 if TYPE_CHECKING:
     from argparse import _SubParsersAction, Namespace
-    from grouper.models.base.session import Session
+    from typing import Optional
 
 
 class CtlCommand(object):
-    """Implements a subcommand of grouper-ctl."""
+    """Implements a subcommand of grouper-ctl that needs a session and a graph."""
 
     __metaclass__ = ABCMeta
 
+    @staticmethod
     @abstractmethod
-    def add_parser(self, subparsers):
-        # type: (_SubParsersAction) -> None
-        """Add the parser for this subcommand."""
+    def add_parser(subparsers):
+        # type: (_SubParsersAction) -> str
+        """Add the parser for this subcommand and return the subcommand name."""
         pass
+
+    def __init__(self, session):
+        # type: (Optional[Session]) -> None
+        if not session:
+            db_engine = get_db_engine(get_database_url(settings))
+            Session.configure(bind=db_engine)
+            session = Session()
+        repository_factory = RepositoryFactory(session, Graph())
+        service_factory = ServiceFactory(session, repository_factory)
+        self.usecase_factory = UseCaseFactory(service_factory)
 
     @abstractmethod
     def run(self, args):
         # type: (Namespace) -> None
         """Run a command and return the exit status."""
         pass
-
-    def set_session(self, session):
-        # type: (Session) -> None
-        """Set the database session for the command."""
-        self.session = session

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -40,14 +40,9 @@ class CtlCommandFactory(object):
     @property
     def graph(self):
         # type: () -> GroupGraph
-        if self._graph:
-            return self._graph
-
-        # This is written in an odd way to unconfuse mypy, which insists self._graph has type
-        # Optional[GroupGraph] and is incompatible with the return type.  Graph() is a singleton,
-        # so it shouldn't matter that we call it twice.
-        self._graph = Graph()
-        return Graph()
+        if not self._graph:
+            self._graph = Graph()
+        return self._graph
 
     @property
     def session(self):

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING
+
+from grouper.ctl.permission import PermissionCommand
+from grouper.graph import Graph
+from grouper.models.base.session import get_db_engine, Session
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.settings import settings
+from grouper.usecases.factory import UseCaseFactory
+from grouper.util import get_database_url
+
+if TYPE_CHECKING:
+    from argparse import _SubParsersAction
+    from grouper.ctl.base import CtlCommand
+    from grouper.graph import GroupGraph
+    from typing import Optional
+
+
+class UnknownCommand(Exception):
+    """Attempted to run a command with no known class."""
+
+    pass
+
+
+class CtlCommandFactory(object):
+    """Construct and add parsers for grouper-ctl commands.
+
+    Some grouper-ctl commands do not want a Session or GroupGraph (and in some cases cannot have a
+    meaningful Session before they run, such as the command to set up the database).  The property
+    methods in this factory lazily create those objects on demand so that the code doesn't run when
+    those commands are instantiated.
+    """
+
+    def __init__(self, session=None, graph=None):
+        # type: (Session, GroupGraph) -> None
+        self._session = session
+        self._graph = graph
+        self._usecase_factory = None  # type: Optional[UseCaseFactory]
+
+    @property
+    def graph(self):
+        # type: () -> GroupGraph
+        if self._graph:
+            return self._graph
+
+        # This is written in an odd way to unconfuse mypy, which insists self._graph has type
+        # Optional[GroupGraph] and is incompatible with the return type.  Graph() is a singleton,
+        # so it shouldn't matter that we call it twice.
+        self._graph = Graph()
+        return Graph()
+
+    @property
+    def session(self):
+        # type: () -> Session
+        if not self._session:
+            db_engine = get_db_engine(get_database_url(settings))
+            Session.configure(bind=db_engine)
+            self._session = Session()
+        return self._session
+
+    @property
+    def usecase_factory(self):
+        # type: () -> UseCaseFactory
+        if not self._usecase_factory:
+            repository_factory = RepositoryFactory(self.session, self.graph)
+            service_factory = ServiceFactory(self.session, repository_factory)
+            self._usecase_factory = UseCaseFactory(service_factory)
+        return self._usecase_factory
+
+    def add_all_parsers(self, subparsers):
+        # type: (_SubParsersAction) -> None
+        parser = subparsers.add_parser("permission", help="Manipulate permissions")
+        PermissionCommand.add_arguments(parser)
+
+    def construct_command(self, command):
+        # type: (str) -> CtlCommand
+        if command == "permission":
+            return self.construct_permission_command()
+        else:
+            raise UnknownCommand("unknown command {}".format(command))
+
+    def construct_permission_command(self):
+        # type: () -> PermissionCommand
+        return PermissionCommand(self.usecase_factory)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
-from grouper.ctl.permission import PermissionCommand
-from grouper.ctl.util import make_session
+from grouper.ctl.base import CtlCommand
+from grouper.ctl.permission import PermissionCommand  # noqa: F401
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings
@@ -14,7 +14,7 @@ from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import List, Optional
+    from typing import Dict, List, Optional, Type
 
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
@@ -55,24 +55,17 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
     ]:
         subcommand_module.add_parser(subparsers)  # type: ignore
 
-    subcommands = []
-    for subcommand_class in [PermissionCommand]:
-        command = subcommand_class()
-        command.add_parser(subparsers)
-        subcommands.append(command)
+    subcommand = {}  # type: Dict[str, Type[CtlCommand]]
+    for subcommand_class in CtlCommand.__subclasses__():
+        subcommand_name = subcommand_class.add_parser(subparsers)
+        # https://github.com/python/mypy/issues/4717
+        subcommand[subcommand_name] = subcommand_class  # type: ignore
 
     args = parser.parse_args(sys_argv[1:])
 
     if start_config_thread:
         settings.update_from_config(args.config)
         settings.start_config_thread(args.config)
-
-    # TODO(rra): This is a hack that we can remove, along with the set_session() implementation,
-    # once we have proper factories.
-    if not session:
-        session = make_session()
-    for subcommand in subcommands:
-        subcommand.set_session(session)
 
     log_level = get_loglevel(args, base=logging.INFO)
     logging.basicConfig(level=log_level, format=settings.log_format)
@@ -86,4 +79,9 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
     if log_level < 0:
         sa_log.setLevel(logging.INFO)
 
-    args.func(args)
+    # Old-style subcommands store a func in callable when setting up their arguments.  New-style
+    # subcommands initialized their arguments above and map a subcommand name to a class.
+    if getattr(args, "func", None):
+        args.func(args)
+    else:
+        subcommand[args.command](session).run(args)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
 from grouper.ctl.factory import CtlCommandFactory
-from grouper.ctl.permission import PermissionCommand  # noqa: F401
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings

--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -6,17 +6,16 @@ from grouper.ctl.base import CtlCommand
 from grouper.usecases.disable_permission import DisablePermissionUI
 
 if TYPE_CHECKING:
-    from argparse import _SubParsersAction, Namespace
+    from argparse import ArgumentParser, Namespace
+    from grouper.usecases.factory import UseCaseFactory
 
 
 class PermissionCommand(CtlCommand, DisablePermissionUI):
     """Commands to modify permissions."""
 
     @staticmethod
-    def add_parser(subparsers):
-        # type: (_SubParsersAction) -> str
-        parser = subparsers.add_parser("permission", help="Manipulate permissions")
-
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
         parser.add_argument(
             "-a",
             "--actor",
@@ -32,7 +31,9 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
         disable_parser = subparser.add_parser("disable", help="Disable a permission")
         disable_parser.add_argument("name", help="Name of permission to disable")
 
-        return "permission"
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
 
     def disabled_permission(self, name):
         # type: (str) -> None


### PR DESCRIPTION
Move argument setup to a static method so that it can be called
without a session, and change the way that the right class is
determined to look at args.command if args.func is not set.
Automatically initialize all discovered subclasses, so all that's
required to add a new command to ctl/main.py is to import the
relevant class.

Move the factory setup into the CtlCommand base class.

Add sys.exit calls in the failure handlers in PermissionCommand
so that the exit status is correct.