### PR TITLE
Move factories into handler base classes

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -81,6 +81,10 @@ class GraphHandler(RequestHandler):
         self.graph = self.application.my_settings.get("graph")
         self.session = self.application.my_settings.get("db_session")()
 
+        repository_factory = RepositoryFactory(self.session, self.graph)
+        service_factory = ServiceFactory(self.session, repository_factory)
+        self.usecase_factory = UseCaseFactory(service_factory)
+
         self._request_start_time = datetime.utcnow()
 
         stats.log_rate("requests", 1)
@@ -270,10 +274,7 @@ class Permissions(GraphHandler, ListPermissionsUI):
 
     def get(self, name=None):
         if not name:
-            repository_factory = RepositoryFactory(self.session, self.graph)
-            service_factory = ServiceFactory(self.session, repository_factory)
-            usecase_factory = UseCaseFactory(service_factory)
-            usecase = usecase_factory.create_list_permissions_usecase(self)
+            usecase = self.usecase_factory.create_list_permissions_usecase(self)
             usecase.simple_list_permissions()
             return
 

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -1,9 +1,6 @@
 from grouper.entities.pagination import PaginatedList, Pagination
 from grouper.entities.permission import Permission
 from grouper.fe.util import GrouperHandler
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.usecases.factory import UseCaseFactory
 from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
 
 
@@ -42,8 +39,5 @@ class PermissionsView(GrouperHandler, ListPermissionsUI):
             sort_key=sort_key, reverse_sort=(sort_dir == "desc"), offset=offset, limit=limit
         )
 
-        repository_factory = RepositoryFactory(self.session, self.graph)
-        service_factory = ServiceFactory(self.session, repository_factory)
-        usecase_factory = UseCaseFactory(service_factory)
-        usecase = usecase_factory.create_list_permissions_usecase(self)
+        usecase = self.usecase_factory.create_list_permissions_usecase(self)
         usecase.list_permissions(self.current_user.name, pagination, audited_only)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -20,6 +20,9 @@ from grouper.fe.settings import settings
 from grouper.graph import Graph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.models.user import User
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.usecases.factory import UseCaseFactory
 from grouper.user_permissions import user_permissions
 from grouper.util import get_database_url
 
@@ -62,6 +65,10 @@ class GrouperHandler(RequestHandler):
     def initialize(self):
         self.session = self.application.my_settings.get("db_session")()
         self.graph = Graph()
+
+        repository_factory = RepositoryFactory(self.session, self.graph)
+        service_factory = ServiceFactory(self.session, repository_factory)
+        self.usecase_factory = UseCaseFactory(service_factory)
 
         if self.get_argument("_profile", False):
             self.perf_collector = Collector()


### PR DESCRIPTION
Create a use case factory in the initialize method of the API and
frontend handler base classes so that all handlers can use it
without creating it.