### PR TITLE
[constants] Allow @ in arguments

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -26,7 +26,7 @@ TOKEN_FORMAT = r"^{}/{}:{}$".format(
 # Regexes for validating permission/argument names
 PERMISSION_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+)"
 PERMISSION_WILDCARD_VALIDATION = r"(?P<name>(?:[a-z0-9]+[_\-\.])*[a-z0-9]+(?:\.\*)?)"
-ARGUMENT_VALIDATION = r"(?P<argument>|[\^\*\w\[\]\$=+/.: -]+)"
+ARGUMENT_VALIDATION = r"(?P<argument>|[\^\*\w\[\]\$=@+/.: -]+)"
 
 # Global permission names to prevent stringly typed things
 PERMISSION_GRANT = "grouper.permission.grant"

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -190,6 +190,7 @@ class PermissionTests(unittest.TestCase):
         self.assertIsNone(eval_argument("caret^"))
         self.assertIsNone(eval_argument("underscore_equals=plus+slash/dot.color:hyphen-ok"))
         self.assertIsNone(eval_argument("whitespace allowed"))
+        self.assertIsNone(eval_argument("foo@bar"))
         self.assertRaises(ValidationError, eval_argument, "question?mark")
         self.assertRaises(ValidationError, eval_argument, "exclaimation!point")
 


### PR DESCRIPTION
Allowing an @ in argument strings lets us represent namespaces in a
natural way. One use case for this is granting a group the ability
to assume a role in some AWS account i.e "billing@finance".