### PR TITLE
improve group remove error message

### DIFF
--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from grouper.fe.forms import GroupRemoveForm
 from grouper.fe.util import Alert, GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -7,9 +9,15 @@ from grouper.role_user import get_role_user, is_role_user
 from grouper.user import get_user_or_group
 from grouper.user_group import user_can_manage_group
 
+if TYPE_CHECKING:
+    from typing import Any, Optional
+
 
 class GroupRemove(GrouperHandler):
-    def post(self, group_id=None, name=None):
+    def post(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        group_id = kwargs.get("group_id", None)  # type: Optional[int]
+        name = kwargs.get("name", None)  # type: Optional[str]
         group = Group.get(self.session, group_id, name)
         if not group:
             return self.notfound()

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -25,7 +25,12 @@ class GroupRemove(GrouperHandler):
 
         members = group.my_members()
         if not members.get((member_type.capitalize(), member_name), None):
-            return self.notfound()
+            return self.send_error(
+                status_code=400,
+                reason="Invalid remove request: {} is not a member of {}.".format(
+                    member_name, group.name
+                ),
+            )
 
         removed_member = get_user_or_group(self.session, member_name, user_or_group=member_type)
 


### PR DESCRIPTION
When a user has already been removed, state that they are not a member of a group instead of 404ing. This improves UX when a user makes multiple post requests to perform a remove.