### PR TITLE
Add an audit log repository

### DIFF
--- a/grouper/entities/audit_log_entry.py
+++ b/grouper/entities/audit_log_entry.py
@@ -1,0 +1,13 @@
+from typing import NamedTuple, Optional
+
+AuditLogEntry = NamedTuple(
+    "AuditLogEntry",
+    [
+        ("actor", str),
+        ("action", str),
+        ("description", str),
+        ("on_user", Optional[str]),
+        ("on_group", Optional[str]),
+        ("on_permission", Optional[str]),
+    ],
+)

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import desc
+
+from grouper.entities.audit_log_entry import AuditLogEntry
+from grouper.models.audit_log import AuditLog, AuditLogCategory
+from grouper.models.group import Group
+from grouper.models.permission import Permission
+from grouper.models.user import User
+from grouper.plugin import get_plugin_proxy
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.usecases.authorization import Authorization
+    from typing import List, Optional
+
+
+class UnknownGroupException(Exception):
+    """Group involved in a logged action does not exist."""
+
+    pass
+
+
+class UnknownPermissionException(Exception):
+    """Permission involved in a logged action does not exist."""
+
+    pass
+
+
+class UnknownUserException(Exception):
+    """User involved in a logged action does not exist."""
+
+    pass
+
+
+class AuditLogRepository(object):
+    """SQL storage layer for audit log entries."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def get_entries_affecting_permission(self, permission):
+        # type: (str) -> List[AuditLogEntry]
+        permission_obj = Permission.get(self.session, name=permission)
+        if not permission_obj:
+            return []
+        results = (
+            self.session.query(AuditLog)
+            .filter(AuditLog.on_permission_id == permission_obj.id)
+            .order_by(desc(AuditLog.log_time))
+        )
+        return [self._to_audit_log_entry(e) for e in results]
+
+    def log(
+        self,
+        authorization,  # type: Authorization
+        action,  # type: str
+        description,  # type: str
+        on_user=None,  # type: Optional[str]
+        on_group=None,  # type: Optional[str]
+        on_permission=None,  # type: Optional[str]
+        category=AuditLogCategory.general,  # type: AuditLogCategory
+    ):
+        # type: (...) -> None
+        """Log an action to the audit log.
+
+        Arguments don't cover all use cases yet.  This method will be expanded as further use cases
+        are ported to this service.
+        """
+        actor = self._id_for_user(authorization.actor)
+
+        # We currently have no way to log audit log entries for objects that no longer exist.  This
+        # should eventually be fixed via a schema change to use strings for all fields of the audit
+        # log.  For now, we'll die with an exception.
+        user = self._id_for_user(on_user) if on_user else None
+        group = self._id_for_group(on_group) if on_group else None
+        permission = self._id_for_permission(on_permission) if on_permission else None
+
+        entry = AuditLog(
+            actor_id=actor,
+            log_time=datetime.utcnow(),
+            action=action,
+            description=description,
+            on_user_id=user,
+            on_group_id=group,
+            on_permission_id=permission,
+            category=int(category),
+        )
+        entry.add(self.session)
+
+        # This should happen at the service layer, not the repository layer, but the API for the
+        # plugin currently takes a SQL object.  This can move to the service layer once a data
+        # transfer object is defined instead.
+        get_plugin_proxy().log_auditlog_entry(entry)
+
+    def _id_for_group(self, group):
+        # type: (str) -> int
+        group_obj = Group.get(self.session, name=group)
+        if not group_obj:
+            raise UnknownGroupException("unknown group {}".format(group))
+        return group_obj.id
+
+    def _id_for_permission(self, permission):
+        # type: (str) -> int
+        permission_obj = Permission.get(self.session, name=permission)
+        if not permission_obj:
+            raise UnknownUserException("unknown permission {}".format(permission))
+        return permission_obj.id
+
+    def _id_for_user(self, user):
+        # type: (str) -> int
+        user_obj = User.get(self.session, name=user)
+        if not user_obj:
+            raise UnknownUserException("unknown user {}".format(user))
+        return user_obj.id
+
+    def _to_audit_log_entry(self, entry):
+        # type: (AuditLog) -> AuditLogEntry
+        return AuditLogEntry(
+            actor=entry.actor.username,
+            action=entry.action,
+            description=entry.description,
+            on_user=entry.on_user.username if entry.on_user else None,
+            on_group=entry.on_group.groupname if entry.on_group else None,
+            on_permission=entry.on_permission.name if entry.on_permission else None,
+        )

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import GraphPermissionGrantRepository
 
@@ -16,6 +17,10 @@ class RepositoryFactory(object):
         # type: (Session, GroupGraph) -> None
         self.session = session
         self.graph = graph
+
+    def create_audit_log_repository(self):
+        # type: () -> AuditLogRepository
+        return AuditLogRepository(self.session)
 
     def create_permission_repository(self):
         # type: () -> PermissionRepository

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -1,73 +1,22 @@
-from datetime import datetime
-from enum import Enum
 from typing import TYPE_CHECKING
 
-from grouper.models.audit_log import AuditLog, AuditLogCategory
-from grouper.models.permission import Permission
-from grouper.models.user import User
-from grouper.plugin import get_plugin_proxy
-
 if TYPE_CHECKING:
-    from grouper.models.base.session import Session
+    from grouper.repositories.audit_log import AuditLogRepository
     from grouper.usecases.authorization import Authorization
-
-
-class UnknownUserException(Exception):
-    """User involved in a logged action does not exist."""
-
-    pass
-
-
-class AuditLogAction(Enum):
-    """Possible actions and descriptions for the audit log.
-
-    The logged action will be the lowercase form of the enum name, and the enum value will be used
-    as the description.
-    """
-
-    DISABLE_PERMISSION = "Disabled permission"
 
 
 class AuditLogService(object):
     """Updates the audit log when changes are made."""
 
-    def __init__(self, session):
-        # type: (Session) -> None
-        self.session = session
+    def __init__(self, audit_log_repository):
+        # type: (AuditLogRepository) -> None
+        self.audit_log_repository = audit_log_repository
 
     def log_disable_permission(self, permission, authorization):
         # type: (str, Authorization) -> None
-        permission_obj = Permission.get(self.session, name=permission)
-        self._log(authorization, AuditLogAction.DISABLE_PERMISSION, on_permission=permission_obj)
-
-    def _log(
-        self,
-        authorization,  # type: Authorization
-        action,  # type: AuditLogAction
-        on_permission,  # type: Permission
-        category=AuditLogCategory.general,  # type: AuditLogCategory
-    ):
-        # type: (...) -> None
-        """Internal method to log an action to the audit log.
-
-        All uses of AuditLog.log should be replaced with more specific entry points like the above,
-        which in turn dispatch to this private method to make the database change.  Arguments don't
-        cover all use cases yet.  This method will be expanded as further use cases are ported to
-        this service.
-        """
-        actor = User.get(self.session, name=authorization.actor)
-        if not actor:
-            raise UnknownUserException("unknown actor {}".format(authorization.actor))
-        entry = AuditLog(
-            actor_id=actor.id,
-            log_time=datetime.utcnow(),
-            action=action.name.lower(),
-            description=action.value,
-            on_user_id=None,
-            on_group_id=None,
-            on_permission_id=on_permission.id,
-            on_tag_id=None,
-            category=int(category),
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="disable_permission",
+            description="Disabled permission",
+            on_permission=permission,
         )
-        entry.add(self.session)
-        get_plugin_proxy().log_auditlog_entry(entry)

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -26,9 +26,10 @@ class ServiceFactory(ServiceFactoryInterface):
 
     def create_permission_service(self):
         # type: () -> PermissionInterface
-        audit_log = AuditLogService(self.session)
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
         permission_repository = self.repository_factory.create_permission_repository()
-        return PermissionService(audit_log, permission_repository)
+        return PermissionService(audit_log_service, permission_repository)
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface


### PR DESCRIPTION
Refactor the AuditLogService to use an AuditLogRepository.  Add a
repository method (not yet plumbed through to a service or use
case) to search for log entries about a specific permission, and
add a test that disabling a permission makes an audit log entry.