### PR TITLE
Move checkpoint updates to the transaction service

### DIFF
--- a/grouper/entities/checkpoint.py
+++ b/grouper/entities/checkpoint.py
@@ -1,0 +1,3 @@
+from typing import NamedTuple
+
+Checkpoint = NamedTuple("Checkpoint", [("checkpoint", int), ("time", int)])

--- a/grouper/repositories/checkpoint.py
+++ b/grouper/repositories/checkpoint.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.checkpoint import Checkpoint
+from grouper.models.counter import Counter
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+
+
+class CheckpointRepository(object):
+    """Manage the checkpoint counter used for graph reloading.
+
+    On every change to any Grouper data, increment an updates counter stored in the database.  This
+    triggers a graph reload in any service that has a background graph refresh thread, is returned
+    by the API server in all requests, and is used by API clients to ensure that they do not use an
+    older version of the graph when talking to multiple API servers.
+    """
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def get_checkpoint(self):
+        # type: () -> Checkpoint
+        counter = self.session.query(Counter).filter_by(name="updates").scalar()
+        if counter:
+            return Checkpoint(counter.count, int(counter.last_modified.strftime("%s")))
+        else:
+            return Checkpoint(0, 0)
+
+    def update_checkpoint(self):
+        # type: () -> None
+        """Update the checkpoint counter.
+
+        We intentionally do not update the last_modified date of the counter because groupy had a
+        nonsensical test for whether the checkpoint timestamp was within 600 seconds of the time of
+        the API response and a bug that reversed the logic.  Therefore, if the update timestamp is
+        within 600s of the current time, groupy will fail.
+
+        This was fixed in groupy 0.3.0 in 2016, so it could probably now be re-enabled.
+        """
+        counter = self.session.query(Counter).filter_by(name="updates").with_for_update().scalar()
+        if counter:
+            counter.count += 1
+        else:
+            Counter(name="updates", count=1).add(self.session)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.repositories.audit_log import AuditLogRepository
+from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import GraphPermissionGrantRepository
 
@@ -21,6 +22,10 @@ class RepositoryFactory(object):
     def create_audit_log_repository(self):
         # type: () -> AuditLogRepository
         return AuditLogRepository(self.session)
+
+    def create_checkpoint_repository(self):
+        # type: () -> CheckpointRepository
+        return CheckpointRepository(self.session)
 
     def create_permission_repository(self):
         # type: () -> PermissionRepository

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from grouper.entities.pagination import PaginatedList
 from grouper.entities.permission import Permission, PermissionNotFoundException
-from grouper.models.counter import Counter
 from grouper.models.permission import Permission as SQLPermission
 from grouper.repositories.interfaces import PermissionRepository
 from grouper.usecases.list_permissions import ListPermissionsSortKey
@@ -85,7 +84,6 @@ class SQLPermissionRepository(PermissionRepository):
         if not permission:
             raise PermissionNotFoundException(name)
         permission.enabled = False
-        Counter.incr(self.session, "updates")
 
     def list_permissions(self, pagination, audited_only):
         # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -33,7 +33,8 @@ class ServiceFactory(ServiceFactoryInterface):
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface
-        return TransactionService(self.session)
+        checkpoint_repository = self.repository_factory.create_checkpoint_repository()
+        return TransactionService(self.session, checkpoint_repository)
 
     def create_user_service(self):
         # type: () -> UserInterface

--- a/tests/services/transaction_test.py
+++ b/tests/services/transaction_test.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_checkpoint_update(setup):
+    # type: (SetupTest) -> None
+    """Test that the updates counter is incremented on each transaction commit."""
+    checkpoint_repository = setup.repository_factory.create_checkpoint_repository()
+    checkpoint = checkpoint_repository.get_checkpoint()
+    assert checkpoint.checkpoint == 0
+
+    transaction_service = setup.service_factory.create_transaction_service()
+    with transaction_service.transaction():
+        pass
+    checkpoint = checkpoint_repository.get_checkpoint()
+    assert checkpoint.checkpoint == 1


### PR DESCRIPTION
Rather than independently updating the checkpoint counter in every
change, make the transaction service update it on every transaction
commit.  Add a checkpoint service to manage the checkpoint counter.

Use SELECT FOR UPDATE to lock the counter when updating it so that
we won't potentially race with other transactions.

Add a detailed comment about why updating the last_modified column
has been disabled.