### PR TITLE
Rewrite grouper-ctl permission test to use new framework

### DIFF
--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -12,14 +12,15 @@ from grouper.settings import default_settings_path, settings
 from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
     from typing import List, Optional
 
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
-def main(sys_argv=sys.argv, start_config_thread=True, session=None):
-    # type: (List[str], bool, Optional[Session]) -> None
+def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
+    # type: (List[str], bool, Optional[Session], Optional[GroupGraph]) -> None
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
@@ -40,7 +41,7 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
         help="Display version information.",
     )
 
-    command_factory = CtlCommandFactory(session)
+    command_factory = CtlCommandFactory(session, graph)
 
     subparsers = parser.add_subparsers(dest="command")
     command_factory.add_all_parsers(subparsers)

--- a/tests/ctl_util.py
+++ b/tests/ctl_util.py
@@ -1,26 +1,19 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.main import main
-from tests.fixtures import session  # noqa: F401
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from tests.setup import SetupTest
 
 
-def call_main(session, *args):  # noqa: F811
+def call_main(session, *args):
+    # type: (Session, *str) -> None
     argv = ["grouper-ctl"] + list(args)
-    return main(sys_argv=argv, start_config_thread=False, session=session)
+    main(sys_argv=argv, start_config_thread=False, session=session)
 
 
-class CtlTestRunner(object):
-    """Runs a grouper-ctl command with a mocked session and database."""
-
-    def __init__(self, session):  # noqa: F811
-        # type: (Session) -> None
-        self.session = session  # noqa: F811
-
-    def run(self, *args):
-        # type: (*str) -> None
-        """Run grouper-ctl with a given set of arguments."""
-        argv = ["grouper-ctl"] + list(args)
-        main(sys_argv=argv, start_config_thread=False, session=self.session)
+def run_ctl(setup, *args):
+    # type: (SetupTest, *str) -> None
+    argv = ["grouper-ctl"] + list(args)
+    main(sys_argv=argv, start_config_thread=False, session=setup.session, graph=setup.graph)


### PR DESCRIPTION
With the new SetupTest class, the CtlTestRunner class is no longer
needed, and a simple wrapper around main that takes the SetupTest
object is sufficient.  Plumb the test graph through to the command
factory.

Add a test for exiting when disabling a permission fails.