### PR TITLE
Refactor TransactionService to use a repository

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -78,11 +78,12 @@ def get_individual_user_info(handler, name, cutoff, service_account):
 
 class GraphHandler(RequestHandler):
     def initialize(self):
+        # type: () -> None
         self.graph = self.application.my_settings.get("graph")
         self.session = self.application.my_settings.get("db_session")()
 
         repository_factory = RepositoryFactory(self.session, self.graph)
-        service_factory = ServiceFactory(self.session, repository_factory)
+        service_factory = ServiceFactory(repository_factory)
         self.usecase_factory = UseCaseFactory(service_factory)
 
         self._request_start_time = datetime.utcnow()

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -58,7 +58,7 @@ class CtlCommandFactory(object):
         # type: () -> UseCaseFactory
         if not self._usecase_factory:
             repository_factory = RepositoryFactory(self.session, self.graph)
-            service_factory = ServiceFactory(self.session, repository_factory)
+            service_factory = ServiceFactory(repository_factory)
             self._usecase_factory = UseCaseFactory(service_factory)
         return self._usecase_factory
 

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -1,8 +1,5 @@
 from grouper.fe.util import GrouperHandler
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
 from grouper.usecases.disable_permission import DisablePermissionUI
-from grouper.usecases.factory import UseCaseFactory
 
 
 class PermissionDisable(GrouperHandler, DisablePermissionUI):
@@ -24,11 +21,10 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         # type: (str) -> None
         return self.forbidden()
 
-    def post(self, user_id=None, name=None):
-        repository_factory = RepositoryFactory(self.session, self.graph)
-        service_factory = ServiceFactory(self.session, repository_factory)
-        usecase_factory = UseCaseFactory(service_factory)
-        usecase = usecase_factory.create_disable_permission_usecase(
+    def post(self, *args, **kwargs):
+        # type: (*str, **str) -> None
+        name = kwargs["name"]
+        usecase = self.usecase_factory.create_disable_permission_usecase(
             self.current_user.username, self
         )
         usecase.disable_permission(name)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -27,7 +27,7 @@ from grouper.user_permissions import user_permissions
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
-    from typing import Dict, List
+    from typing import Dict, List, Optional
 
 
 class Alert(object):
@@ -63,16 +63,17 @@ else:
 
 class GrouperHandler(RequestHandler):
     def initialize(self):
+        # type: () -> None
         self.session = self.application.my_settings.get("db_session")()
         self.graph = Graph()
 
         repository_factory = RepositoryFactory(self.session, self.graph)
-        service_factory = ServiceFactory(self.session, repository_factory)
+        service_factory = ServiceFactory(repository_factory)
         self.usecase_factory = UseCaseFactory(service_factory)
 
         if self.get_argument("_profile", False):
             self.perf_collector = Collector()
-            self.perf_trace_uuid = str(uuid4())
+            self.perf_trace_uuid = str(uuid4())  # type: Optional[str]
             self.perf_collector.start()
         else:
             self.perf_collector = None

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -4,6 +4,7 @@ from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import GraphPermissionGrantRepository
+from grouper.repositories.transaction import TransactionRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
@@ -35,3 +36,7 @@ class RepositoryFactory(object):
     def create_permission_grant_repository(self):
         # type: () -> PermissionGrantRepository
         return GraphPermissionGrantRepository(self.graph)
+
+    def create_transaction_repository(self):
+        # type: () -> TransactionRepository
+        return TransactionRepository(self.session)

--- a/grouper/repositories/transaction.py
+++ b/grouper/repositories/transaction.py
@@ -1,0 +1,43 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from types import TracebackType
+    from typing import Optional
+
+
+class SQLTransaction(object):
+    """Returned by a TransactionRepository as a context manager."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def __enter__(self):
+        # type: () -> None
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # type: (Optional[type], Optional[Exception], Optional[TracebackType]) -> bool
+        if exc_type:
+            self.session.rollback()
+        else:
+            self.session.commit()
+        return False
+
+
+class TransactionRepository(object):
+    """Manage storage layer transactions."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def commit(self):
+        # type: () -> None
+        """Provided for tests, do not use in use cases."""
+        self.session.commit()
+
+    def transaction(self):
+        # type: () -> SQLTransaction
+        return SQLTransaction(self.session)

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -7,7 +7,6 @@ from grouper.services.user import UserService
 from grouper.usecases.interfaces import ServiceFactoryInterface
 
 if TYPE_CHECKING:
-    from grouper.models.base.session import Session
     from grouper.repositories.factory import RepositoryFactory
     from grouper.usecases.interfaces import (
         PermissionInterface,
@@ -19,9 +18,8 @@ if TYPE_CHECKING:
 class ServiceFactory(ServiceFactoryInterface):
     """Construct backend services."""
 
-    def __init__(self, session, repository_factory):
-        # type: (Session, RepositoryFactory) -> None
-        self.session = session
+    def __init__(self, repository_factory):
+        # type: (RepositoryFactory) -> None
         self.repository_factory = repository_factory
 
     def create_permission_service(self):
@@ -33,8 +31,9 @@ class ServiceFactory(ServiceFactoryInterface):
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface
+        transaction_repository = self.repository_factory.create_transaction_repository()
         checkpoint_repository = self.repository_factory.create_checkpoint_repository()
-        return TransactionService(self.session, checkpoint_repository)
+        return TransactionService(transaction_repository, checkpoint_repository)
 
     def create_user_service(self):
         # type: () -> UserInterface

--- a/grouper/services/transaction.py
+++ b/grouper/services/transaction.py
@@ -1,54 +1,31 @@
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from grouper.usecases.interfaces import Transaction, TransactionInterface
+from grouper.repositories.transaction import TransactionRepository
+from grouper.usecases.interfaces import TransactionInterface
 
 if TYPE_CHECKING:
-    from grouper.models.base.session import Session
     from grouper.repositories.checkpoint import CheckpointRepository
-    from types import TracebackType
-    from typing import Optional
-
-
-class SQLTransaction(Transaction):
-    """Returned by the TransactionService context manager."""
-
-    def __init__(self, session, checkpoint_repository):
-        # type: (Session, CheckpointRepository) -> None
-        self.session = session
-        self.checkpoint_repository = checkpoint_repository
-
-    def __enter__(self):
-        # type: () -> None
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # type: (Optional[type], Optional[Exception], Optional[TracebackType]) -> bool
-        if exc_type:
-            self.session.rollback()
-        else:
-            try:
-                self.checkpoint_repository.update_checkpoint()
-                self.session.commit()
-            except Exception:
-                self.session.rollback()
-                raise
-        return False
+    from typing import Iterator
 
 
 class TransactionService(TransactionInterface):
     """Manage storage layer transactions encompassing multiple service actions."""
 
-    def __init__(self, session, checkpoint_repository):
-        # type: (Session, CheckpointRepository) -> None
-        self.session = session
+    def __init__(self, transaction_repository, checkpoint_repository):
+        # type: (TransactionRepository, CheckpointRepository) -> None
+        self.transaction_repository = transaction_repository
         self.checkpoint_repository = checkpoint_repository
 
     def commit(self):
         # type: () -> None
         """Provided for tests, do not use in use cases."""
         self.checkpoint_repository.update_checkpoint()
-        self.session.commit()
+        self.transaction_repository.commit()
 
+    @contextmanager
     def transaction(self):
-        # type: () -> Transaction
-        return SQLTransaction(self.session, self.checkpoint_repository)
+        # type: () -> Iterator[None]
+        with self.transaction_repository.transaction():
+            yield
+            self.checkpoint_repository.update_checkpoint()

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -19,8 +19,7 @@ if TYPE_CHECKING:
     from grouper.entities.permission import Permission
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
-    from types import TracebackType
-    from typing import Optional
+    from typing import ContextManager
 
 
 class PermissionInterface(object):
@@ -44,22 +43,6 @@ class PermissionInterface(object):
         pass
 
 
-class Transaction(object):
-    """Abstract base class for transaction objects."""
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def __enter__(self):
-        # type: () -> None
-        pass
-
-    @abstractmethod
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # type: (Optional[type], Optional[Exception], Optional[TracebackType]) -> bool
-        pass
-
-
 class TransactionInterface(object):
     """Abstract base class for starting and committing transactions."""
 
@@ -67,7 +50,7 @@ class TransactionInterface(object):
 
     @abstractmethod
     def transaction(self):
-        # type: () -> Transaction
+        # type: () -> ContextManager[None]
         pass
 
 

--- a/tests/services/transaction_test.py
+++ b/tests/services/transaction_test.py
@@ -6,13 +6,15 @@ if TYPE_CHECKING:
 
 def test_checkpoint_update(setup):
     # type: (SetupTest) -> None
-    """Test that the updates counter is incremented on each transaction commit."""
+    """Test that the updates counter is incremented at the end of each transaction commit."""
     checkpoint_repository = setup.repository_factory.create_checkpoint_repository()
     checkpoint = checkpoint_repository.get_checkpoint()
     assert checkpoint.checkpoint == 0
 
     transaction_service = setup.service_factory.create_transaction_service()
     with transaction_service.transaction():
-        pass
+        checkpoint = checkpoint_repository.get_checkpoint()
+        assert checkpoint.checkpoint == 0
+
     checkpoint = checkpoint_repository.get_checkpoint()
     assert checkpoint.checkpoint == 1

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -54,7 +54,7 @@ class SetupTest(object):
         self.session = self.create_session(tmpdir)
         self.graph = GroupGraph()
         self.repository_factory = RepositoryFactory(self.session, self.graph)
-        self.service_factory = ServiceFactory(self.session, self.repository_factory)
+        self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)
 
     def create_session(self, tmpdir):


### PR DESCRIPTION
Move the bits that call into SQLAlchemy into a TransactionRepository,
eliminating the last dependency of a ServiceFactory on a Session.
The TransactionService is now only responsible for ensuring a
checkpoint update, so it uses a simpler @contextmanager.  Adjust the
type of the expected interface in the use case to just any context
manager.

Add type annotations to every place a ServiceFactory was being
created so that mypy would catch the argument changes, and update
callers.  This includes removing now-duplicate work from the
PermissionDisable handler and reusing the UseCaseFactory stored in
the handler object.

Add a type signature to the post() method in the PermissionDisable
handler, which requires changing the method signature because mypy
isn't very happy with the flexibility of Tornado's handler methods.