### PR TITLE
Remove the TransactionService.commit() hack

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -298,9 +298,14 @@ The `setup` fixture provides a `SetupTest` object, which provides a test
 database session, methods to quickly assemble a test environment, and
 factories for various Merou objects.  With it, you can create users,
 groups, permissions, and assemble them.  Add more methods to that class if
-you have more common setup patterns to automate.  Call `setup.commit()`
-after building the test environment to commit those changes to the
-database.
+you have more common setup patterns to automate.  All test setup should be
+done inside a transaction using code like:
+
+.. code:: python
+
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+        # ...
 
 The `itests` directory contains integration tests that start a full API or
 frontend server.  The frontend integration tests use Selenium to interact

--- a/grouper/repositories/transaction.py
+++ b/grouper/repositories/transaction.py
@@ -33,11 +33,6 @@ class TransactionRepository(object):
         # type: (Session) -> None
         self.session = session
 
-    def commit(self):
-        # type: () -> None
-        """Provided for tests, do not use in use cases."""
-        self.session.commit()
-
     def transaction(self):
         # type: () -> SQLTransaction
         return SQLTransaction(self.session)

--- a/grouper/services/transaction.py
+++ b/grouper/services/transaction.py
@@ -17,12 +17,6 @@ class TransactionService(TransactionInterface):
         self.transaction_repository = transaction_repository
         self.checkpoint_repository = checkpoint_repository
 
-    def commit(self):
-        # type: () -> None
-        """Provided for tests, do not use in use cases."""
-        self.checkpoint_repository.update_checkpoint()
-        self.transaction_repository.commit()
-
     @contextmanager
     def transaction(self):
         # type: () -> Iterator[None]

--- a/itests/api/permissions_test.py
+++ b/itests/api/permissions_test.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
 
 def test_get_permissions(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
-    setup.create_permission("some-permission")
-    setup.create_permission("another-permission")
-    setup.commit()
+    with setup.transaction():
+        setup.create_permission("some-permission")
+        setup.create_permission("another-permission")
     with api_server(tmpdir) as api_url:
         api_client = Groupy(api_url)
         assert sorted(api_client.permissions) == ["another-permission", "some-permission"]
@@ -21,10 +21,10 @@ def test_get_permissions(tmpdir, setup):
 
 def test_get_permission(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
-    setup.grant_permission_to_group("ssh", "foo", "sad-team")
-    setup.grant_permission_to_group("ssh", "bar", "team-sre")
-    setup.grant_permission_to_group("ssh", "*", "tech-ops")
-    setup.commit()
+    with setup.transaction():
+        setup.grant_permission_to_group("ssh", "foo", "sad-team")
+        setup.grant_permission_to_group("ssh", "bar", "team-sre")
+        setup.grant_permission_to_group("ssh", "*", "tech-ops")
     with api_server(tmpdir) as api_url:
         api_client = Groupy(api_url)
         permission = api_client.permissions.get("ssh")

--- a/tests/ctl/permission_test.py
+++ b/tests/ctl/permission_test.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 
 def test_permission_disable(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
-    setup.add_user_to_group("gary@a.co", "admins")
-    setup.create_permission("some-permission")
-    setup.commit()
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_permission("some-permission")
 
     run_ctl(setup, "permission", "-a", "gary@a.co", "disable", "some-permission")
     permission = get_permission(setup.session, "some-permission")
@@ -25,7 +25,7 @@ def test_permission_disable(setup):
 
 def test_permission_disable_failed(setup):
     # type: (SetupTest) -> None
-    setup.create_user("gary@a.co")
-    setup.commit()
+    with setup.transaction():
+        setup.create_user("gary@a.co")
     with pytest.raises(SystemExit):
         run_ctl(setup, "permission", "-a", "gary@a.co", "disable", "some-permission")

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -11,10 +11,10 @@ if TYPE_CHECKING:
 
 def test_permission_disable(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
-    setup.add_user_to_group("gary@a.co", "admins")
-    setup.create_permission("some-permission")
-    setup.commit()
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_permission("some-permission")
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
 
@@ -32,9 +32,9 @@ def test_permission_disable(setup):
 
 def test_permission_disable_denied(setup):
     # type: (SetupTest) -> None
-    setup.create_user("zorkian@a.co")
-    setup.create_permission("some-permission")
-    setup.commit()
+    with setup.transaction():
+        setup.create_user("zorkian@a.co")
+        setup.create_permission("some-permission")
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("zorkian@a.co", mock_ui)
     usecase.disable_permission("some-permission")
@@ -46,10 +46,10 @@ def test_permission_disable_denied(setup):
 
 def test_permission_disable_system(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
-    setup.add_user_to_group("gary@a.co", "admins")
-    setup.create_permission(PERMISSION_CREATE)
-    setup.commit()
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_permission(PERMISSION_CREATE)
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission(PERMISSION_CREATE)
@@ -60,9 +60,9 @@ def test_permission_disable_system(setup):
 
 def test_permission_not_found(setup):
     # type: (SetupTest) -> None
-    setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
-    setup.add_user_to_group("gary@a.co", "admins")
-    setup.commit()
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission("nonexistent")


### PR DESCRIPTION
Expose a context manager from SetupTest for transactions and use it
for all test setup as well, so that tests follow the same general
coding style as the rest of the code.  Delete the commit() method on
TransactionService and TransactionRepository so that they aren't
lingering near production code as an attractive nuisance.