### PR TITLE
Refactor use case factory creation

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -16,15 +16,14 @@ from grouper.models.base.session import Session
 from grouper.models.public_key import PublicKey
 from grouper.models.user import User
 from grouper.models.user_token import UserToken
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.usecases.factory import UseCaseFactory
 from grouper.usecases.list_permissions import ListPermissionsUI
 from grouper.util import try_update
 
 if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList
     from grouper.entities.permission import Permission
+    from grouper.graph import GroupGraph
+    from grouper.usecases.factory import UseCaseFactory
     from typing import Any, Dict, Optional
 
 # if raven library around, pull in SentryMixin
@@ -77,14 +76,10 @@ def get_individual_user_info(handler, name, cutoff, service_account):
 
 
 class GraphHandler(RequestHandler):
-    def initialize(self):
-        # type: () -> None
-        self.graph = self.application.my_settings.get("graph")
-        self.session = self.application.my_settings.get("db_session")()
-
-        repository_factory = RepositoryFactory(self.session, self.graph)
-        service_factory = ServiceFactory(repository_factory)
-        self.usecase_factory = UseCaseFactory(service_factory)
+    def initialize(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        self.graph = kwargs["graph"]  # type: GroupGraph
+        self.usecase_factory = kwargs["usecase_factory"]  # type: UseCaseFactory
 
         self._request_start_time = datetime.utcnow()
 

--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -1,3 +1,10 @@
+"""Routes and handlers for the Grouper API server.
+
+Provides the variable HANDLERS, which contains tuples of route regexes and handlers.  Do not
+provide additional handler arguments as a third argument of the tuple.  A standard set of
+additional arguments will be injected when the Tornado Application object is created.
+"""
+
 from grouper.api.handlers import (
     Groups,
     MultiUsers,

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -1,19 +1,11 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.permission import PermissionCommand
-from grouper.graph import Graph
-from grouper.models.base.session import get_db_engine, Session
-from grouper.repositories.factory import RepositoryFactory
-from grouper.services.factory import ServiceFactory
-from grouper.settings import settings
-from grouper.usecases.factory import UseCaseFactory
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
     from grouper.ctl.base import CtlCommand
-    from grouper.graph import GroupGraph
-    from typing import Optional
+    from grouper.usecases.factory import UseCaseFactory
 
 
 class UnknownCommand(Exception):
@@ -23,49 +15,24 @@ class UnknownCommand(Exception):
 
 
 class CtlCommandFactory(object):
-    """Construct and add parsers for grouper-ctl commands.
+    """Construct and add parsers for grouper-ctl commands."""
 
-    Some grouper-ctl commands do not want a Session or GroupGraph (and in some cases cannot have a
-    meaningful Session before they run, such as the command to set up the database).  The property
-    methods in this factory lazily create those objects on demand so that the code doesn't run when
-    those commands are instantiated.
-    """
-
-    def __init__(self, session=None, graph=None):
-        # type: (Session, GroupGraph) -> None
-        self._session = session
-        self._graph = graph
-        self._usecase_factory = None  # type: Optional[UseCaseFactory]
-
-    @property
-    def graph(self):
-        # type: () -> GroupGraph
-        if not self._graph:
-            self._graph = Graph()
-        return self._graph
-
-    @property
-    def session(self):
-        # type: () -> Session
-        if not self._session:
-            db_engine = get_db_engine(get_database_url(settings))
-            Session.configure(bind=db_engine)
-            self._session = Session()
-        return self._session
-
-    @property
-    def usecase_factory(self):
-        # type: () -> UseCaseFactory
-        if not self._usecase_factory:
-            repository_factory = RepositoryFactory(self.session, self.graph)
-            service_factory = ServiceFactory(repository_factory)
-            self._usecase_factory = UseCaseFactory(service_factory)
-        return self._usecase_factory
-
-    def add_all_parsers(self, subparsers):
+    @staticmethod
+    def add_all_parsers(subparsers):
         # type: (_SubParsersAction) -> None
+        """Initialize parsers for all grouper-ctl commands.
+
+        This is a static method since it has to be called before command-line parsing, but
+        constructing a CtlCommandFactory requires a UseCaseFactory, which in turn requires
+        information such as the database URL that may be overridden on the command line and thus
+        cannot be created until after command-line parsing.
+        """
         parser = subparsers.add_parser("permission", help="Manipulate permissions")
         PermissionCommand.add_arguments(parser)
+
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
 
     def construct_command(self, command):
         # type: (str) -> CtlCommand

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
 from grouper.ctl.factory import CtlCommandFactory
+from grouper.initialization import create_usecase_factory
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings
@@ -41,10 +42,8 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
         help="Display version information.",
     )
 
-    command_factory = CtlCommandFactory(session, graph)
-
     subparsers = parser.add_subparsers(dest="command")
-    command_factory.add_all_parsers(subparsers)
+    CtlCommandFactory.add_all_parsers(subparsers)
 
     # Add parsers for legacy commands that have not been refactored.
     for subcommand_module in [
@@ -76,6 +75,9 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
 
     if log_level < 0:
         sa_log.setLevel(logging.INFO)
+
+    usecase_factory = create_usecase_factory(settings, session, graph)
+    command_factory = CtlCommandFactory(usecase_factory)
 
     # Old-style subcommands store a func in callable when setting up their arguments.  New-style
     # subcommands are handled via a factory that constructs and calls the correct object.

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -1,3 +1,10 @@
+"""Routes and handlers for the Grouper frontend.
+
+Provides the variable HANDLERS, which contains tuples of route regexes and handlers.  Do not
+provide additional handler arguments as a third argument of the tuple.  A standard set of
+additional arguments will be injected when the Tornado Application object is created.
+"""
+
 from typing import TYPE_CHECKING
 
 from grouper.constants import (

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -1,0 +1,25 @@
+"""Setup functions common to all Grouper UIs."""
+
+from typing import TYPE_CHECKING
+
+from grouper.repositories.factory import RepositoryFactory
+from grouper.services.factory import ServiceFactory
+from grouper.usecases.factory import UseCaseFactory
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
+    from grouper.settings import Settings
+    from typing import Optional
+
+
+def create_usecase_factory(settings, session=None, graph=None):
+    # type: (Settings, Optional[Session], Optional[GroupGraph]) -> UseCaseFactory
+    """Create a UseCaseFactory, with optional injection of a Session and GroupGraph.
+
+    Session and GroupGraph injection are supported primarily for tests.  If not injected, they will
+    be created on demand.
+    """
+    repository_factory = RepositoryFactory(settings, session, graph)
+    service_factory = ServiceFactory(repository_factory)
+    return UseCaseFactory(service_factory)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -30,6 +30,7 @@ from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
 from grouper.repositories.factory import RepositoryFactory
 from grouper.services.factory import ServiceFactory
+from grouper.settings import Settings
 from grouper.usecases.factory import UseCaseFactory
 from tests.path_util import db_url
 
@@ -53,7 +54,8 @@ class SetupTest(object):
         # type: (LocalPath) -> None
         self.session = self.create_session(tmpdir)
         self.graph = GroupGraph()
-        self.repository_factory = RepositoryFactory(self.session, self.graph)
+        self.settings = Settings({"database": db_url(tmpdir)})
+        self.repository_factory = RepositoryFactory(self.settings, self.session, self.graph)
         self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)
 


### PR DESCRIPTION
Stop requiring a session and graph be injected into RepositoryFactory
and let it create them lazily when needed, since they're both
artifacts of the repository layer.  This requires passing Settings
to the RepositoryFactory (to get the database URL information).

Rather than repeating the same three lines to create a UseCaseFactory,
factor that out into a create_usecase_factory() function in a new
grouper.initialization module, with optional injection of a Session
and GroupGraph (which is somewhat widely used right now, until the API
and FE servers are further refactored).

Refactor Tornado application creation to avoid overriding the
constructor and creating new object attributes, and instead injecting
the global application settings as additional arguments to every
handler's initialize method.  Use this to simplify application creation
and plumb the new usecase_factory through to the handlers.  Stop
plumbing the SentryProxy through, since we aren't using it anywhere.