### PR TITLE
Some minor cleanup of disable permission

### DIFF
--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -39,17 +39,17 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
         # type: (str) -> None
         logging.info("disabled permission %s", name)
 
-    def disable_permission_failed_because_not_found(self, name):
+    def disable_permission_failed_not_found(self, name):
         # type: (str) -> None
         logging.critical("permission %s not found", name)
         sys.exit(1)
 
-    def disable_permission_failed_because_permission_denied(self, name):
+    def disable_permission_failed_permission_denied(self, name):
         # type: (str) -> None
         logging.critical("not permitted to disable permission %s", name)
         sys.exit(1)
 
-    def disable_permission_failed_because_system_permission(self, name):
+    def disable_permission_failed_system_permission(self, name):
         # type: (str) -> None
         logging.critical("cannot disable system permission %s", name)
         sys.exit(1)

--- a/grouper/entities/permission.py
+++ b/grouper/entities/permission.py
@@ -4,12 +4,3 @@ from typing import NamedTuple
 Permission = NamedTuple(
     "Permission", [("name", str), ("description", str), ("created_on", datetime)]
 )
-
-
-class PermissionNotFoundException(Exception):
-    """Attempt to operate on a permission not found in the storage layer."""
-
-    def __init__(self, name):
-        # type: (str) -> None
-        msg = "Permission {} not found".format(name)
-        super(PermissionNotFoundException, self).__init__(msg)

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -9,15 +9,15 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         # type: (str) -> None
         self.redirect("/permissions/{}".format(name))
 
-    def disable_permission_failed_because_not_found(self, name):
+    def disable_permission_failed_not_found(self, name):
         # type: (str) -> None
         return self.notfound()
 
-    def disable_permission_failed_because_permission_denied(self, name):
+    def disable_permission_failed_permission_denied(self, name):
         # type: (str) -> None
         return self.forbidden()
 
-    def disable_permission_failed_because_system_permission(self, name):
+    def disable_permission_failed_system_permission(self, name):
         # type: (str) -> None
         return self.forbidden()
 

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.entities.pagination import PaginatedList
-from grouper.entities.permission import Permission, PermissionNotFoundException
+from grouper.entities.permission import Permission
 from grouper.models.permission import Permission as SQLPermission
 from grouper.repositories.interfaces import PermissionRepository
 from grouper.usecases.list_permissions import ListPermissionsSortKey
@@ -11,6 +11,15 @@ if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
     from typing import Optional
+
+
+class PermissionNotFoundException(Exception):
+    """Attempt to operate on a permission not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Permission {} not found".format(name)
+        super(PermissionNotFoundException, self).__init__(msg)
 
 
 class GraphPermissionRepository(PermissionRepository):

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -25,10 +25,14 @@ class PermissionService(PermissionInterface):
         self.permission_repository.disable_permission(name)
         self.audit_log.log_disable_permission(name, authorization)
 
+    def is_system_permission(self, name):
+        # type: (str) -> bool
+        return name in (entry[0] for entry in SYSTEM_PERMISSIONS)
+
     def list_permissions(self, pagination, audited_only):
         # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]
         return self.permission_repository.list_permissions(pagination, audited_only)
 
-    def is_system_permission(self, name):
+    def permission_exists(self, name):
         # type: (str) -> bool
-        return name in (entry[0] for entry in SYSTEM_PERMISSIONS)
+        return True if self.permission_repository.get_permission(name) else False

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -33,6 +33,11 @@ class PermissionInterface(object):
         pass
 
     @abstractmethod
+    def permission_exists(self, name):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
     def is_system_permission(self, name):
         # type: (str) -> bool
         pass

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -39,7 +39,7 @@ def test_permission_disable_denied(setup):
     usecase = setup.usecase_factory.create_disable_permission_usecase("zorkian@a.co", mock_ui)
     usecase.disable_permission("some-permission")
     assert mock_ui.mock_calls == [
-        call.disable_permission_failed_because_permission_denied("some-permission")
+        call.disable_permission_failed_permission_denied("some-permission")
     ]
     assert Permission.get(setup.session, name="some-permission").enabled
 
@@ -54,7 +54,7 @@ def test_permission_disable_system(setup):
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission(PERMISSION_CREATE)
     assert mock_ui.mock_calls == [
-        call.disable_permission_failed_because_system_permission(PERMISSION_CREATE)
+        call.disable_permission_failed_system_permission(PERMISSION_CREATE)
     ]
 
 
@@ -66,4 +66,4 @@ def test_permission_not_found(setup):
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission("nonexistent")
-    assert mock_ui.mock_calls == [call.disable_permission_failed_because_not_found("nonexistent")]
+    assert mock_ui.mock_calls == [call.disable_permission_failed_not_found("nonexistent")]


### PR DESCRIPTION
While discussing a new use case, we decided that the "because"
in UI methods for failure just makes the method name longer without
adding clarity.  Without because, it still reads as English if you
see the underscore after "failed" as a colon.

We also decided to do all checks in the use case, rather than catching
exceptions thrown by the repository.  There is some possibility of
failure later with an exception because of a race, but the cost in
complexity of catching those race condition exceptions everywhere is
high and the value unclear, particularly for objects where deletion is
not currently supported.  Rewrite the disable permission use case to
see if the permission exists first before trying to disable it, and
then don't catch exceptions in the event of a race with deleting the
permission (particularly since deleting a permission entirely is not
currently a supported operation).