### PR TITLE
Add direct SQL user permission code

### DIFF
--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -15,7 +15,7 @@ from grouper.app import GrouperApplication
 from grouper.database import DbRefreshThread
 from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.graph import Graph
-from grouper.initialization import create_usecase_factory
+from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
@@ -70,7 +70,7 @@ def start_server(args, sentry_client):
     refresher.daemon = True
     refresher.start()
 
-    usecase_factory = create_usecase_factory(settings, graph=graph)
+    usecase_factory = create_graph_usecase_factory(settings, graph=graph)
     application = create_api_application(graph, settings, usecase_factory)
 
     address = args.address or settings.address

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -6,22 +6,21 @@ from typing import TYPE_CHECKING
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
 from grouper.ctl.factory import CtlCommandFactory
-from grouper.initialization import create_usecase_factory
+from grouper.initialization import create_sql_usecase_factory
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path, settings
 from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
-    from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
     from typing import List, Optional
 
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
-def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
-    # type: (List[str], bool, Optional[Session], Optional[GroupGraph]) -> None
+def main(sys_argv=sys.argv, start_config_thread=True, session=None):
+    # type: (List[str], bool, Optional[Session]) -> None
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
@@ -76,7 +75,7 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None, graph=None):
     if log_level < 0:
         sa_log.setLevel(logging.INFO)
 
-    usecase_factory = create_usecase_factory(settings, session, graph)
+    usecase_factory = create_sql_usecase_factory(settings, session)
     command_factory = CtlCommandFactory(usecase_factory)
 
     # Old-style subcommands store a func in callable when setting up their arguments.  New-style

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -18,7 +18,7 @@ from grouper.fe.routes import HANDLERS
 from grouper.fe.settings import settings
 from grouper.fe.template_util import get_template_env
 from grouper.graph import Graph
-from grouper.initialization import create_usecase_factory
+from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import get_plugin_proxy, initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
@@ -72,7 +72,7 @@ def start_server(args, sentry_client):
     database_url = args.database_url or get_database_url(settings)
     Session.configure(bind=get_db_engine(database_url))
 
-    usecase_factory = create_usecase_factory(settings, Session())
+    usecase_factory = create_graph_usecase_factory(settings, Session())
     application = create_fe_application(settings, usecase_factory, args.deployment_name)
 
     address = args.address or settings.address

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from grouper.repositories.factory import RepositoryFactory
+from grouper.repositories.factory import GraphRepositoryFactory, SQLRepositoryFactory
 from grouper.services.factory import ServiceFactory
 from grouper.usecases.factory import UseCaseFactory
 
@@ -13,13 +13,25 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-def create_usecase_factory(settings, session=None, graph=None):
+def create_graph_usecase_factory(settings, session=None, graph=None):
     # type: (Settings, Optional[Session], Optional[GroupGraph]) -> UseCaseFactory
-    """Create a UseCaseFactory, with optional injection of a Session and GroupGraph.
+    """Create a graph-backed UseCaseFactory, with optional injection of a Session and GroupGraph.
 
-    Session and GroupGraph injection are supported primarily for tests.  If not injected, they will
-    be created on demand.
+    Session and graph injection is supported primarily for tests.  If not injected, they will be
+    created on demand.
     """
-    repository_factory = RepositoryFactory(settings, session, graph)
+    repository_factory = GraphRepositoryFactory(settings, session, graph)
+    service_factory = ServiceFactory(repository_factory)
+    return UseCaseFactory(service_factory)
+
+
+def create_sql_usecase_factory(settings, session=None):
+    # type: (Settings, Optional[Session]) -> UseCaseFactory
+    """Create a SQL-backed UseCaseFactory, with optional injection of a Session.
+
+    Session injection is supported primarily for tests.  If not injected, it will be created on
+    demand.
+    """
+    repository_factory = SQLRepositoryFactory(settings, session)
     service_factory = ServiceFactory(repository_factory)
     return UseCaseFactory(service_factory)

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -5,6 +5,9 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import PermissionGrant
+    from grouper.repositories.audit_log import AuditLogRepository
+    from grouper.repositories.checkpoint import CheckpointRepository
+    from grouper.repositories.transaction import TransactionRepository
     from grouper.usecases.list_permissions import ListPermissionsSortKey
     from typing import List, Optional
 
@@ -36,11 +39,42 @@ class PermissionGrantRepository(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def permissions_for_user(self, user):
+    def permission_grants_for_user(self, user):
         # type: (str) -> List[PermissionGrant]
         pass
 
     @abstractmethod
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
+        pass
+
+
+class RepositoryFactory(object):
+    """Abstract base class for repository factories."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def create_audit_log_repository(self):
+        # type: () -> AuditLogRepository
+        pass
+
+    @abstractmethod
+    def create_checkpoint_repository(self):
+        # type: () -> CheckpointRepository
+        pass
+
+    @abstractmethod
+    def create_permission_repository(self):
+        # type: () -> PermissionRepository
+        pass
+
+    @abstractmethod
+    def create_permission_grant_repository(self):
+        # type: () -> PermissionGrantRepository
+        pass
+
+    @abstractmethod
+    def create_transaction_repository(self):
+        # type: () -> TransactionRepository
         pass

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -1,10 +1,20 @@
+from datetime import datetime
 from typing import TYPE_CHECKING
 
+from sqlalchemy import or_
+
 from grouper.entities.permission_grant import PermissionGrant
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.group import Group
+from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.permission import Permission
+from grouper.models.permission_map import PermissionMap
+from grouper.models.user import User
 from grouper.repositories.interfaces import PermissionGrantRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
     from typing import List
 
 
@@ -15,7 +25,7 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         # type: (GroupGraph) -> None
         self.graph = graph
 
-    def permissions_for_user(self, user):
+    def permission_grants_for_user(self, user):
         # type: (str) -> List[PermissionGrant]
         user_details = self.graph.get_user_details(user)
         permissions = []
@@ -28,7 +38,78 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
-        for user_permission in self.permissions_for_user(user):
+        for user_permission in self.permission_grants_for_user(user):
+            if permission == user_permission.name:
+                return True
+        return False
+
+
+class SQLPermissionGrantRepository(PermissionGrantRepository):
+    """SQL storage layer for permission grants."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def permission_grants_for_user(self, username):
+        # type: (str) -> List[PermissionGrant]
+        now = datetime.utcnow()
+        user = User.get(self.session, name=username)
+        if not user or user.role_user or user.is_service_account or not user.enabled:
+            return []
+
+        # Get the groups of which this user is a direct member.
+        groups = (
+            self.session.query(Group.id)
+            .join(GroupEdge, Group.id == GroupEdge.group_id)
+            .join(User, User.id == GroupEdge.member_pk)
+            .filter(
+                Group.enabled == True,
+                User.id == user.id,
+                GroupEdge.active == True,
+                GroupEdge.member_type == OBJ_TYPES["User"],
+                GroupEdge._role != GROUP_EDGE_ROLES.index("np-owner"),
+                or_(GroupEdge.expiration > now, GroupEdge.expiration == None),
+            )
+            .distinct()
+        )
+        group_ids = [g.id for g in groups]
+
+        # Now, get the parent groups of those groups and so forth until we run out of levels of the
+        # tree.  Use a set of seen group_ids to avoid querying the same group twice if a user is a
+        # member of it via multiple paths.
+        seen_group_ids = set(group_ids)
+        while group_ids:
+            parent_groups = (
+                self.session.query(Group.id)
+                .join(GroupEdge, Group.id == GroupEdge.group_id)
+                .filter(
+                    GroupEdge.member_pk.in_(group_ids),
+                    Group.enabled == True,
+                    GroupEdge.active == True,
+                    GroupEdge.member_type == OBJ_TYPES["Group"],
+                    GroupEdge._role != GROUP_EDGE_ROLES.index("np-owner"),
+                    or_(GroupEdge.expiration > now, GroupEdge.expiration == None),
+                )
+                .distinct()
+            )
+            group_ids = [g.id for g in parent_groups if g.id not in seen_group_ids]
+            seen_group_ids.update(group_ids)
+
+        # Return the permission grants.
+        group_permission_grants = (
+            self.session.query(Permission.name, PermissionMap.argument)
+            .filter(
+                Permission.id == PermissionMap.permission_id,
+                PermissionMap.group_id.in_(seen_group_ids),
+            )
+            .all()
+        )
+        return [PermissionGrant(g.name, g.argument) for g in group_permission_grants]
+
+    def user_has_permission(self, user, permission):
+        # type: (str, str) -> bool
+        for user_permission in self.permission_grants_for_user(user):
             if permission == user_permission.name:
                 return True
         return False

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -7,7 +7,7 @@ from grouper.services.user import UserService
 from grouper.usecases.interfaces import ServiceFactoryInterface
 
 if TYPE_CHECKING:
-    from grouper.repositories.factory import RepositoryFactory
+    from grouper.repositories.interfaces import RepositoryFactory
     from grouper.usecases.interfaces import (
         PermissionInterface,
         TransactionInterface,

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -4,7 +4,9 @@ from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE
 from grouper.usecases.interfaces import UserInterface
 
 if TYPE_CHECKING:
+    from grouper.entities.permission_grant import PermissionGrant
     from grouper.repositories.interfaces import PermissionGrantRepository
+    from typing import List
 
 
 class UserService(UserInterface):
@@ -13,6 +15,10 @@ class UserService(UserInterface):
     def __init__(self, permission_grant_repository):
         # type: (PermissionGrantRepository) -> None
         self.permission_grant_repository = permission_grant_repository
+
+    def permission_grants_for_user(self, user):
+        # type: (str) -> List[PermissionGrant]
+        return self.permission_grant_repository.permission_grants_for_user(user)
 
     def user_is_permission_admin(self, user):
         # type: (str) -> bool

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -17,9 +17,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
+    from grouper.entities.permission_grant import PermissionGrant
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
-    from typing import ContextManager
+    from typing import ContextManager, List
 
 
 class PermissionInterface(object):
@@ -74,6 +75,11 @@ class UserInterface(object):
     """Abstract base class for user operations and queries."""
 
     __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def permission_grants_for_user(self, user):
+        # type: (str) -> List[PermissionGrant]
+        pass
 
     @abstractmethod
     def user_can_create_permissions(self, user):

--- a/tests/ctl_util.py
+++ b/tests/ctl_util.py
@@ -16,4 +16,4 @@ def call_main(session, *args):
 def run_ctl(setup, *args):
     # type: (SetupTest, *str) -> None
     argv = ["grouper-ctl"] + list(args)
-    main(sys_argv=argv, start_config_thread=False, session=setup.session, graph=setup.graph)
+    main(sys_argv=argv, start_config_thread=False, session=setup.session)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,7 +17,7 @@ from grouper.constants import (
 )
 from grouper.fe.main import create_fe_application
 from grouper.graph import Graph
-from grouper.initialization import create_usecase_factory
+from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine, Session
 from grouper.models.group import Group
@@ -299,7 +299,7 @@ def permissions(session, users):
 def api_app(session, standard_graph):
     # type: (Session, GroupGraph) -> GrouperApplication
     settings = Settings({"debug": False})
-    usecase_factory = create_usecase_factory(settings, session, standard_graph)
+    usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
     return create_api_application(standard_graph, settings, usecase_factory)
 
 
@@ -307,7 +307,7 @@ def api_app(session, standard_graph):
 def fe_app(session, standard_graph, tmpdir):
     # type: (Session, GroupGraph, LocalPath) -> GrouperApplication
     settings = Settings({"debug": False})
-    usecase_factory = create_usecase_factory(settings, session, standard_graph)
+    usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
     return create_fe_application(
         settings, usecase_factory, "", xsrf_cookies=False, session=lambda: session
     )

--- a/tests/repositories/permission_grant_test.py
+++ b/tests/repositories/permission_grant_test.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+from grouper.repositories.permission_grant import SQLPermissionGrantRepository
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_permission_grants_for_user(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+    permission_grant_repository = SQLPermissionGrantRepository(setup.session)
+    assert permission_grant_repository.permission_grants_for_user("gary@a.co") == []
+
+    # Build a bit of a group hierarchy with some nested inheritance.
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "one-group")
+        setup.grant_permission_to_group("perm", "one", "one-group")
+        setup.add_user_to_group("gary@a.co", "two-group", "owner")
+        setup.grant_permission_to_group("perm", "two", "two-group")
+        setup.add_user_to_group("gary@a.co", "three-group", "np-owner")
+        setup.grant_permission_to_group("perm", "three", "three-group")
+        setup.add_group_to_group("one-group", "parent")
+        setup.grant_permission_to_group("other-perm", "arg", "parent")
+        setup.add_group_to_group("parent", "grandparent")
+        setup.grant_permission_to_group("other-perm", "arg", "grandparent")
+        setup.grant_permission_to_group("other-perm", "*", "grandparent")
+        setup.add_group_to_group("two-group", "grandparent")
+        setup.add_group_to_group("three-group", "np-group")
+        setup.grant_permission_to_group("another-perm", "foo", "np-group")
+
+    # Check the returned permissions.
+    permission_grants = permission_grant_repository.permission_grants_for_user("gary@a.co")
+    assert sorted([(p.name, p.argument) for p in permission_grants]) == [
+        ("other-perm", "*"),
+        ("other-perm", "arg"),
+        ("other-perm", "arg"),
+        ("perm", "one"),
+        ("perm", "two"),
+    ]


### PR DESCRIPTION
Add a pure SQL implementation of the permission grant repository
that retrieves all permissions for a user directly from the
database (takes about 150ms with current Dropbox production
configurations).

Separate the repository factory into a Graph and a SQL variation,
use the Graph variation for the frontend and API server, and use
the SQL variation for grouper-ctl.  The SQL variation will never
instantiate a graph or use any of the graph functions, thus avoiding
the graph construction overhead.