### PR TITLE
Add support for converting a user to a service account

### DIFF
--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.permission import PermissionCommand
+from grouper.ctl.user import UserCommand
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
@@ -29,6 +30,8 @@ class CtlCommandFactory(object):
         """
         parser = subparsers.add_parser("permission", help="Manipulate permissions")
         PermissionCommand.add_arguments(parser)
+        parser = subparsers.add_parser("user", help="Manipulate users")
+        UserCommand.add_arguments(parser)
 
     def __init__(self, usecase_factory):
         # type: (UseCaseFactory) -> None
@@ -38,9 +41,15 @@ class CtlCommandFactory(object):
         # type: (str) -> CtlCommand
         if command == "permission":
             return self.construct_permission_command()
+        elif command == "user":
+            return self.construct_user_command()
         else:
             raise UnknownCommand("unknown command {}".format(command))
 
     def construct_permission_command(self):
         # type: () -> PermissionCommand
         return PermissionCommand(self.usecase_factory)
+
+    def construct_user_command(self):
+        # type: () -> UserCommand
+        return UserCommand(self.usecase_factory)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from grouper import __version__
-from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user, user_proxy
+from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user_proxy
 from grouper.ctl.factory import CtlCommandFactory
 from grouper.initialization import create_sql_usecase_factory
 from grouper.plugin import initialize_plugins
@@ -52,7 +52,6 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
         service_account,
         shell,
         sync_db,
-        user,
         user_proxy,
     ]:
         subcommand_module.add_parser(subparsers)  # type: ignore

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -1,0 +1,7 @@
+class GroupNotFoundException(Exception):
+    """Attempt to operate on a group not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Group {} not found".format(name)
+        super(GroupNotFoundException, self).__init__(msg)

--- a/grouper/entities/group_request.py
+++ b/grouper/entities/group_request.py
@@ -1,0 +1,29 @@
+from enum import Enum
+from typing import NamedTuple
+
+
+class GroupRequestStatus(Enum):
+    PENDING = "pending"
+    ACTIONED = "actioned"
+    CANCELLED = "cancelled"
+
+
+UserGroupRequest = NamedTuple(
+    "GroupRequest",
+    [
+        ("id", int),
+        ("user", str),
+        ("group", str),
+        ("requester", str),
+        ("status", GroupRequestStatus),
+    ],
+)
+
+
+class UserGroupRequestNotFoundException(Exception):
+    """Attempt to operate on a UserGroupRequest not found in the storage layer."""
+
+    def __init__(self, request):
+        # type: (UserGroupRequest) -> None
+        msg = "Group membership request {} not found".format(request.id)
+        super(UserGroupRequestNotFoundException, self).__init__(msg)

--- a/grouper/entities/permission.py
+++ b/grouper/entities/permission.py
@@ -4,3 +4,12 @@ from typing import NamedTuple
 Permission = NamedTuple(
     "Permission", [("name", str), ("description", str), ("created_on", datetime)]
 )
+
+
+class PermissionNotFoundException(Exception):
+    """Attempt to operate on a permission not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Permission {} not found".format(name)
+        super(PermissionNotFoundException, self).__init__(msg)

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,0 +1,7 @@
+class ServiceAccountNotFoundException(Exception):
+    """Attempt to operate on a service account not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Service account {} not found".format(name)
+        super(ServiceAccountNotFoundException, self).__init__(msg)

--- a/grouper/entities/user.py
+++ b/grouper/entities/user.py
@@ -1,0 +1,34 @@
+class UserNotFoundException(Exception):
+    """Attempt to operate on a user not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} not found".format(name)
+        super(UserNotFoundException, self).__init__(msg)
+
+
+class UserIsEnabledException(Exception):
+    """Operation failed because user is a member of groups."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} is enabled".format(name)
+        super(UserIsEnabledException, self).__init__(msg)
+
+
+class UserIsMemberOfGroupsException(Exception):
+    """Operation failed because user is a member of groups."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} is a member of one or more groups".format(name)
+        super(UserIsMemberOfGroupsException, self).__init__(msg)
+
+
+class UserHasPendingRequestsException(Exception):
+    """Operation failed because user has pending requests."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} has one or more pending requests".format(name)
+        super(UserHasPendingRequestsException, self).__init__(msg)

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 from sqlalchemy import desc
 
 from grouper.entities.audit_log_entry import AuditLogEntry
+from grouper.entities.group import GroupNotFoundException
+from grouper.entities.permission import PermissionNotFoundException
+from grouper.entities.user import UserNotFoundException
 from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.models.group import Group
 from grouper.models.permission import Permission
@@ -14,24 +17,6 @@ if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.usecases.authorization import Authorization
     from typing import List, Optional
-
-
-class UnknownGroupException(Exception):
-    """Group involved in a logged action does not exist."""
-
-    pass
-
-
-class UnknownPermissionException(Exception):
-    """Permission involved in a logged action does not exist."""
-
-    pass
-
-
-class UnknownUserException(Exception):
-    """User involved in a logged action does not exist."""
-
-    pass
 
 
 class AuditLogRepository(object):
@@ -99,21 +84,21 @@ class AuditLogRepository(object):
         # type: (str) -> int
         group_obj = Group.get(self.session, name=group)
         if not group_obj:
-            raise UnknownGroupException("unknown group {}".format(group))
+            raise GroupNotFoundException(group)
         return group_obj.id
 
     def _id_for_permission(self, permission):
         # type: (str) -> int
         permission_obj = Permission.get(self.session, name=permission)
         if not permission_obj:
-            raise UnknownUserException("unknown permission {}".format(permission))
+            raise PermissionNotFoundException(permission)
         return permission_obj.id
 
     def _id_for_user(self, user):
         # type: (str) -> int
         user_obj = User.get(self.session, name=user)
         if not user_obj:
-            raise UnknownUserException("unknown user {}".format(user))
+            raise UserNotFoundException(user)
         return user_obj.id
 
     def _to_audit_log_entry(self, entry):

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -4,18 +4,26 @@ from grouper.graph import Graph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
+from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
+from grouper.repositories.group_request import GroupRequestRepository
 from grouper.repositories.interfaces import RepositoryFactory
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import (
     GraphPermissionGrantRepository,
     SQLPermissionGrantRepository,
 )
+from grouper.repositories.service_account import ServiceAccountRepository
 from grouper.repositories.transaction import TransactionRepository
+from grouper.repositories.user import UserRepository
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
-    from grouper.repositories.interfaces import PermissionRepository, PermissionGrantRepository
+    from grouper.repositories.interfaces import (
+        GroupEdgeRepository,
+        PermissionRepository,
+        PermissionGrantRepository,
+    )
     from grouper.settings import Settings
     from typing import Optional
 
@@ -66,6 +74,14 @@ class GraphRepositoryFactory(RepositoryFactory):
         # type: () -> CheckpointRepository
         return CheckpointRepository(self.session)
 
+    def create_group_edge_repository(self):
+        # type: () -> GroupEdgeRepository
+        return GraphGroupEdgeRepository(self.graph)
+
+    def create_group_request_repository(self):
+        # type: () -> GroupRequestRepository
+        return GroupRequestRepository(self.session)
+
     def create_permission_repository(self):
         # type: () -> PermissionRepository
         sql_permission_repository = SQLPermissionRepository(self.session)
@@ -75,9 +91,17 @@ class GraphRepositoryFactory(RepositoryFactory):
         # type: () -> PermissionGrantRepository
         return GraphPermissionGrantRepository(self.graph)
 
+    def create_service_account_repository(self):
+        # type: () -> ServiceAccountRepository
+        return ServiceAccountRepository(self.session)
+
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
         return TransactionRepository(self.session)
+
+    def create_user_repository(self):
+        # type: () -> UserRepository
+        return UserRepository(self.session)
 
 
 class SQLRepositoryFactory(RepositoryFactory):
@@ -116,6 +140,14 @@ class SQLRepositoryFactory(RepositoryFactory):
         # type: () -> CheckpointRepository
         return CheckpointRepository(self.session)
 
+    def create_group_edge_repository(self):
+        # type: () -> GroupEdgeRepository
+        return SQLGroupEdgeRepository(self.session)
+
+    def create_group_request_repository(self):
+        # type: () -> GroupRequestRepository
+        return GroupRequestRepository(self.session)
+
     def create_permission_repository(self):
         # type: () -> PermissionRepository
         return SQLPermissionRepository(self.session)
@@ -124,6 +156,14 @@ class SQLRepositoryFactory(RepositoryFactory):
         # type: () -> PermissionGrantRepository
         return SQLPermissionGrantRepository(self.session)
 
+    def create_service_account_repository(self):
+        # type: () -> ServiceAccountRepository
+        return ServiceAccountRepository(self.session)
+
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
         return TransactionRepository(self.session)
+
+    def create_user_repository(self):
+        # type: () -> UserRepository
+        return UserRepository(self.session)

--- a/grouper/repositories/group_edge.py
+++ b/grouper/repositories/group_edge.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import or_
+
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.group import Group
+from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.user import User
+from grouper.repositories.interfaces import GroupEdgeRepository
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
+    from typing import List
+
+
+class GraphGroupEdgeRepository(GroupEdgeRepository):
+    """Graph-aware storage layer for group edges."""
+
+    def __init__(self, graph):
+        # type: (GroupGraph) -> None
+        self.graph = graph
+
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        user_details = self.graph.get_user_details(username)
+        return [group for group in user_details["groups"]]
+
+
+class SQLGroupEdgeRepository(GroupEdgeRepository):
+    """Pure SQL storage layer for group edges."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        now = datetime.utcnow()
+        user = User.get(self.session, name=username)
+        if not user or user.role_user or user.is_service_account or not user.enabled:
+            return []
+        groups = (
+            self.session.query(Group.groupname)
+            .join(GroupEdge, Group.id == GroupEdge.group_id)
+            .join(User, User.id == GroupEdge.member_pk)
+            .filter(
+                Group.enabled == True,
+                User.id == user.id,
+                GroupEdge.active == True,
+                GroupEdge.member_type == OBJ_TYPES["User"],
+                GroupEdge._role != GROUP_EDGE_ROLES.index("np-owner"),
+                or_(GroupEdge.expiration > now, GroupEdge.expiration == None),
+            )
+            .distinct()
+        )
+        return [g.groupname for g in groups]

--- a/grouper/repositories/group_request.py
+++ b/grouper/repositories/group_request.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql import label
+
+from grouper.entities.group_request import UserGroupRequest, UserGroupRequestNotFoundException
+from grouper.entities.user import UserNotFoundException
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.comment import Comment
+from grouper.models.group import Group
+from grouper.models.request import Request
+from grouper.models.request_status_change import RequestStatusChange
+from grouper.models.user import User
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.usecases.authorization import Authorization
+    from typing import List
+
+
+class GroupRequestRepository(object):
+    """SQL storage layer for requests to join groups."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def cancel_user_request(self, user_request, reason, authorization):
+        # type: (UserGroupRequest, str, Authorization) -> None
+        now = datetime.utcnow()
+        request = Request.get(self.session, id=user_request.id)
+        if not request:
+            raise UserGroupRequestNotFoundException(request)
+        actor = User.get(self.session, name=authorization.actor)
+        if not actor:
+            raise UserNotFoundException(authorization.actor)
+
+        request_status_change = RequestStatusChange(
+            request=request,
+            user_id=actor.id,
+            from_status=request.status,
+            to_status="cancelled",
+            change_at=now,
+        ).add(self.session)
+
+        request.status = "cancelled"
+        self.session.flush()
+
+        Comment(
+            obj_type=OBJ_TYPES["RequestStatusChange"],
+            obj_pk=request_status_change.id,
+            user_id=actor.id,
+            comment=reason,
+            created_on=now,
+        ).add(self.session)
+
+    def pending_requests_for_user(self, user):
+        # type: (str) -> List[UserGroupRequest]
+        requester = aliased(User)
+        on_behalf_of = aliased(User)
+        sql_requests = self.session.query(
+            Request.id,
+            Request.status,
+            label("requester", requester.username),
+            Group.groupname,
+            label("on_behalf_of", on_behalf_of.username),
+        ).filter(
+            Request.on_behalf_obj_type == OBJ_TYPES["User"],
+            Request.on_behalf_obj_pk == on_behalf_of.id,
+            Request.requester_id == requester.id,
+            Request.requesting_id == Group.id,
+            Request.status == "pending",
+        )
+
+        requests = []
+        for sql_request in sql_requests:
+            request = UserGroupRequest(
+                id=sql_request.id,
+                user=sql_request.on_behalf_of,
+                group=sql_request.groupname,
+                requester=sql_request.requester,
+                status=sql_request.status,
+            )
+            requests.append(request)
+        return requests

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -7,9 +7,23 @@ if TYPE_CHECKING:
     from grouper.entities.permission_grant import PermissionGrant
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.repositories.checkpoint import CheckpointRepository
+    from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.service_account import ServiceAccountRepository
     from grouper.repositories.transaction import TransactionRepository
+    from grouper.repositories.user import UserRepository
     from grouper.usecases.list_permissions import ListPermissionsSortKey
     from typing import List, Optional
+
+
+class GroupEdgeRepository(object):
+    """Abstract base class for group edge repositories."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        pass
 
 
 class PermissionRepository(object):
@@ -34,7 +48,7 @@ class PermissionRepository(object):
 
 
 class PermissionGrantRepository(object):
-    """Abstract base class for permission grants."""
+    """Abstract base class for permission grant repositories."""
 
     __metaclass__ = ABCMeta
 
@@ -65,6 +79,16 @@ class RepositoryFactory(object):
         pass
 
     @abstractmethod
+    def create_group_edge_repository(self):
+        # type: () -> GroupEdgeRepository
+        pass
+
+    @abstractmethod
+    def create_group_request_repository(self):
+        # type: () -> GroupRequestRepository
+        pass
+
+    @abstractmethod
     def create_permission_repository(self):
         # type: () -> PermissionRepository
         pass
@@ -75,6 +99,16 @@ class RepositoryFactory(object):
         pass
 
     @abstractmethod
+    def create_service_account_repository(self):
+        # type: () -> ServiceAccountRepository
+        pass
+
+    @abstractmethod
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
+        pass
+
+    @abstractmethod
+    def create_user_repository(self):
+        # type: () -> UserRepository
         pass

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.entities.pagination import PaginatedList
-from grouper.entities.permission import Permission
+from grouper.entities.permission import Permission, PermissionNotFoundException
 from grouper.models.permission import Permission as SQLPermission
 from grouper.repositories.interfaces import PermissionRepository
 from grouper.usecases.list_permissions import ListPermissionsSortKey
@@ -11,15 +11,6 @@ if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
     from typing import Optional
-
-
-class PermissionNotFoundException(Exception):
-    """Attempt to operate on a permission not found in the storage layer."""
-
-    def __init__(self, name):
-        # type: (str) -> None
-        msg = "Permission {} not found".format(name)
-        super(PermissionNotFoundException, self).__init__(msg)
 
 
 class GraphPermissionRepository(PermissionRepository):

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -1,0 +1,69 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.group import GroupNotFoundException
+from grouper.entities.service_account import ServiceAccountNotFoundException
+from grouper.entities.user import UserNotFoundException
+from grouper.models.group import Group
+from grouper.models.group_service_accounts import GroupServiceAccount
+from grouper.models.service_account import ServiceAccount as SQLServiceAccount
+from grouper.models.user import User as SQLUser
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+
+
+class ServiceAccountRepository(object):
+    """Storage layer for service accounts."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def assign_service_account_to_group(self, name, groupname):
+        # type: (str, str) -> None
+        service_account = SQLServiceAccount.get(self.session, name=name)
+        if not service_account:
+            raise ServiceAccountNotFoundException(name)
+
+        group = Group.get(self.session, name=groupname)
+        if not group:
+            raise GroupNotFoundException(groupname)
+
+        existing_relationship = GroupServiceAccount.get(
+            self.session, service_account_id=service_account.id
+        )
+        if existing_relationship:
+            existing_relationship.group_id = group.id
+        else:
+            group_service_account = GroupServiceAccount(
+                group_id=group.id, service_account_id=service_account.id
+            )
+            group_service_account.add(self.session)
+
+    def enable_service_account(self, name):
+        # type: (str) -> None
+        service_account = SQLServiceAccount.get(self.session, name=name)
+        if not service_account:
+            raise ServiceAccountNotFoundException(name)
+
+        service_account.user.enabled = True
+
+    def mark_disabled_user_as_service_account(self, name, description="", mdbset=""):
+        # type: (str, str, str) -> None
+        """Transform a disabled user into a disabled, ownerless service account.
+
+        WARNING: This function encodes the fact that the user and service account repos
+        are in fact the same thing, as it assumes that a service account is just a user
+        that is marked in a special way. This is a temporary breaking of the abstractions
+        and will have to be cleaned up once the repositories are properly separate.
+        """
+        user = SQLUser.get(self.session, name=name)
+        if not user:
+            raise UserNotFoundException(name)
+
+        service_account = SQLServiceAccount(
+            user_id=user.id, description=description, machine_set=mdbset
+        )
+        service_account.add(self.session)
+
+        user.is_service_account = True

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.user import UserNotFoundException
+from grouper.models.user import User
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+
+
+class UserRepository(object):
+    """Storage layer for users."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def disable_user(self, name):
+        # type: (str) -> None
+        user = User.get(self.session, name=name)
+        if not user:
+            raise UserNotFoundException(name)
+        user.enabled = False
+
+    def user_is_enabled(self, name):
+        # type: (str) -> bool
+        user = User.get(self.session, name=name)
+        if not user:
+            raise UserNotFoundException(name)
+        return user.enabled

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.usecases.authorization import Authorization
 
@@ -12,6 +13,15 @@ class AuditLogService(object):
         # type: (AuditLogRepository) -> None
         self.audit_log_repository = audit_log_repository
 
+    def log_create_service_account_from_disabled_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="create_service_account_from_disabled_user",
+            description="Convert a disabled user into a disabled service account",
+            on_user=user,
+        )
+
     def log_disable_permission(self, permission, authorization):
         # type: (str, Authorization) -> None
         self.audit_log_repository.log(
@@ -19,4 +29,33 @@ class AuditLogService(object):
             action="disable_permission",
             description="Disabled permission",
             on_permission=permission,
+        )
+
+    def log_disable_user(self, username, authorization):
+        # type: (str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="disable_user",
+            description="Disabled user",
+            on_user=username,
+        )
+
+    def log_enable_service_account(self, user, owner, authorization):
+        # type: (str, str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="enable_service_account",
+            description="Enabled service account",
+            on_user=user,
+            on_group=owner,
+        )
+
+    def log_user_group_request_status_change(self, request, status, authorization):
+        # type: (UserGroupRequest, GroupRequestStatus, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="update_request",
+            description="Updated request to status: {}".format(status.value),
+            on_group=request.group,
+            on_user=request.requester,
         )

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -1,26 +1,36 @@
 from typing import TYPE_CHECKING
 
 from grouper.services.audit_log import AuditLogService
+from grouper.services.group_request import GroupRequestService
 from grouper.services.permission import PermissionService
+from grouper.services.service_account import ServiceAccountService
 from grouper.services.transaction import TransactionService
 from grouper.services.user import UserService
-from grouper.usecases.interfaces import ServiceFactoryInterface
 
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import RepositoryFactory
     from grouper.usecases.interfaces import (
+        GroupRequestInterface,
         PermissionInterface,
+        ServiceAccountInterface,
         TransactionInterface,
         UserInterface,
     )
 
 
-class ServiceFactory(ServiceFactoryInterface):
+class ServiceFactory(object):
     """Construct backend services."""
 
     def __init__(self, repository_factory):
         # type: (RepositoryFactory) -> None
         self.repository_factory = repository_factory
+
+    def create_group_request_service(self):
+        # type: () -> GroupRequestInterface
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
+        group_request_repository = self.repository_factory.create_group_request_repository()
+        return GroupRequestService(group_request_repository, audit_log_service)
 
     def create_permission_service(self):
         # type: () -> PermissionInterface
@@ -28,6 +38,22 @@ class ServiceFactory(ServiceFactoryInterface):
         audit_log_service = AuditLogService(audit_log_repository)
         permission_repository = self.repository_factory.create_permission_repository()
         return PermissionService(audit_log_service, permission_repository)
+
+    def create_service_account_service(self):
+        # type: () -> ServiceAccountInterface
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
+        user_repository = self.repository_factory.create_user_repository()
+        service_account_repository = self.repository_factory.create_service_account_repository()
+        group_edge_repository = self.repository_factory.create_group_edge_repository()
+        group_request_repository = self.repository_factory.create_group_request_repository()
+        return ServiceAccountService(
+            user_repository,
+            service_account_repository,
+            group_edge_repository,
+            group_request_repository,
+            audit_log_service,
+        )
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface
@@ -37,5 +63,11 @@ class ServiceFactory(ServiceFactoryInterface):
 
     def create_user_service(self):
         # type: () -> UserInterface
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
+        user_repository = self.repository_factory.create_user_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
-        return UserService(permission_grant_repository)
+        group_edge_repository = self.repository_factory.create_group_edge_repository()
+        return UserService(
+            user_repository, permission_grant_repository, group_edge_repository, audit_log_service
+        )

--- a/grouper/services/group_request.py
+++ b/grouper/services/group_request.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.group_request import GroupRequestStatus
+from grouper.usecases.interfaces import GroupRequestInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.services.audit_log import AuditLogService
+    from grouper.usecases.authorization import Authorization
+
+
+class GroupRequestService(GroupRequestInterface):
+    """High-level logic to manipulate requests to join groups."""
+
+    def __init__(self, group_request_repository, audit_log_service):
+        # type: (GroupRequestRepository, AuditLogService) -> None
+        self.group_request_repository = group_request_repository
+        self.audit_log_service = audit_log_service
+
+    def cancel_all_requests_for_user(self, user, reason, authorization):
+        # type: (str, str, Authorization) -> None
+        pending_requests = self.group_request_repository.pending_requests_for_user(user)
+        for request in pending_requests:
+            self.group_request_repository.cancel_user_request(request, reason, authorization)
+            self.audit_log_service.log_user_group_request_status_change(
+                request, GroupRequestStatus.CANCELLED, authorization
+            )

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -1,0 +1,59 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.user import (
+    UserHasPendingRequestsException,
+    UserIsEnabledException,
+    UserIsMemberOfGroupsException,
+)
+from grouper.usecases.interfaces import ServiceAccountInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.group_edge import GroupEdgeRepository
+    from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.service_account import ServiceAccountRepository
+    from grouper.repositories.user import UserRepository
+    from grouper.services.audit_log import AuditLogService
+    from grouper.usecases.authorization import Authorization
+
+
+class ServiceAccountService(ServiceAccountInterface):
+    """High-level logic to manipulate service accounts."""
+
+    def __init__(
+        self,
+        user_repository,  # type: UserRepository
+        service_account_repository,  # type: ServiceAccountRepository
+        group_edge_repository,  # type: GroupEdgeRepository
+        group_request_repository,  # type: GroupRequestRepository
+        audit_log_service,  # type: AuditLogService
+    ):
+        # type: (...) -> None
+        self.user_repository = user_repository
+        self.service_account_repository = service_account_repository
+        self.group_edge_repository = group_edge_repository
+        self.group_request_repository = group_request_repository
+        self.audit_log = audit_log_service
+
+    def create_service_account_from_disabled_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        if self.user_repository.user_is_enabled(user):
+            raise UserIsEnabledException(user)
+        if self.group_edge_repository.groups_of_user(user) != []:
+            raise UserIsMemberOfGroupsException(user)
+        if self.group_request_repository.pending_requests_for_user(user) != []:
+            raise UserHasPendingRequestsException(user)
+
+        # WARNING: This logic relies on the fact that the user and service account repos
+        # are in fact the same thing, as it never explicitly removes the user from the
+        # user repo. This is a temporary breaking of the abstractions and will have to be
+        # cleaned up once the repositories are properly separate.
+        self.service_account_repository.mark_disabled_user_as_service_account(user)
+
+        self.audit_log.log_create_service_account_from_disabled_user(user, authorization)
+
+    def enable_service_account(self, user, owner, authorization):
+        # type: (str, str, Authorization) -> None
+        self.service_account_repository.assign_service_account_to_group(user, owner)
+        self.service_account_repository.enable_service_account(user)
+
+        self.audit_log.log_enable_service_account(user, owner, authorization)

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -1,20 +1,42 @@
 from typing import TYPE_CHECKING
 
-from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE
+from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE, USER_ADMIN
 from grouper.usecases.interfaces import UserInterface
 
 if TYPE_CHECKING:
     from grouper.entities.permission_grant import PermissionGrant
+    from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
+    from grouper.repositories.user import UserRepository
+    from grouper.services.audit_log import AuditLogService
+    from grouper.usecases.authorization import Authorization
     from typing import List
 
 
 class UserService(UserInterface):
     """High-level logic to manipulate users."""
 
-    def __init__(self, permission_grant_repository):
-        # type: (PermissionGrantRepository) -> None
+    def __init__(
+        self,
+        user_repository,  # type: UserRepository
+        permission_grant_repository,  # type: PermissionGrantRepository
+        group_edge_repository,  # type: GroupEdgeRepository
+        audit_log_service,  # type: AuditLogService
+    ):
+        # type: (...) -> None
+        self.user_repository = user_repository
         self.permission_grant_repository = permission_grant_repository
+        self.group_edge_repository = group_edge_repository
+        self.audit_log = audit_log_service
+
+    def disable_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        self.user_repository.disable_user(user)
+        self.audit_log.log_disable_user(user, authorization)
+
+    def groups_of_user(self, user):
+        # type: (str) -> List[str]
+        return self.group_edge_repository.groups_of_user(user)
 
     def permission_grants_for_user(self, user):
         # type: (str) -> List[PermissionGrant]
@@ -23,6 +45,10 @@ class UserService(UserInterface):
     def user_is_permission_admin(self, user):
         # type: (str) -> bool
         return self.permission_grant_repository.user_has_permission(user, PERMISSION_ADMIN)
+
+    def user_is_user_admin(self, user):
+        # type: (str) -> bool
+        return self.permission_grant_repository.user_has_permission(user, USER_ADMIN)
 
     def user_can_create_permissions(self, user):
         # type: (str) -> bool

--- a/grouper/usecases/convert_user_to_service_account.py
+++ b/grouper/usecases/convert_user_to_service_account.py
@@ -1,0 +1,76 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from grouper.usecases.authorization import Authorization
+
+if TYPE_CHECKING:
+    from grouper.usecases.interfaces import (
+        GroupRequestInterface,
+        ServiceAccountInterface,
+        TransactionInterface,
+        UserInterface,
+    )
+
+
+class ConvertUserToServiceAccountUI(object):
+    """Abstract base class for UI for ConvertUserToServiceAccount."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def convert_user_to_service_account_failed_permission_denied(self, user):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def convert_user_to_service_account_failed_user_is_in_groups(self, user):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def converted_user_to_service_account(self, user, owner):
+        # type: (str, str) -> None
+        pass
+
+
+class ConvertUserToServiceAccount(object):
+    """Delete a user and create a service account with the same name.
+
+    The use case doesn't exactly do that now due to limitations of the data model, but semantically
+    that should be the effect.
+    """
+
+    def __init__(
+        self,
+        actor,  # type: str
+        ui,  # type: ConvertUserToServiceAccountUI
+        user_service,  # type: UserInterface
+        service_account_service,  # type: ServiceAccountInterface
+        group_request_service,  # type: GroupRequestInterface
+        transaction_service,  # type: TransactionInterface
+    ):
+        self.actor = actor
+        self.ui = ui
+        self.user_service = user_service
+        self.service_account_service = service_account_service
+        self.group_request_service = group_request_service
+        self.transaction_service = transaction_service
+
+    def convert_user_to_service_account(self, user, owner):
+        # type: (str, str) -> None
+        if not self.user_service.user_is_user_admin(self.actor):
+            self.ui.convert_user_to_service_account_failed_permission_denied(user)
+        elif self.user_service.groups_of_user(user) != []:
+            self.ui.convert_user_to_service_account_failed_user_is_in_groups(user)
+        else:
+            authorization = Authorization(self.actor)
+            with self.transaction_service.transaction():
+                self.group_request_service.cancel_all_requests_for_user(
+                    user, "User converted to service account", authorization
+                )
+                self.user_service.disable_user(user, authorization)
+                self.service_account_service.create_service_account_from_disabled_user(
+                    user, authorization
+                )
+                self.service_account_service.enable_service_account(user, owner, authorization)
+            self.ui.converted_user_to_service_account(user, owner)

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -1,10 +1,12 @@
 from typing import TYPE_CHECKING
 
+from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
 from grouper.usecases.list_permissions import ListPermissions
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.list_permissions import ListPermissionsUI
 
@@ -15,6 +17,21 @@ class UseCaseFactory(object):
     def __init__(self, service_factory):
         # type: (Session) -> None
         self.service_factory = service_factory
+
+    def create_convert_user_to_service_account_usecase(self, actor, ui):
+        # type: (str, ConvertUserToServiceAccountUI) -> ConvertUserToServiceAccount
+        user_service = self.service_factory.create_user_service()
+        service_account_service = self.service_factory.create_service_account_service()
+        group_request_service = self.service_factory.create_group_request_service()
+        transaction_service = self.service_factory.create_transaction_service()
+        return ConvertUserToServiceAccount(
+            actor,
+            ui,
+            user_service,
+            service_account_service,
+            group_request_service,
+            transaction_service,
+        )
 
     def create_disable_permission_usecase(self, actor, ui):
         # type: (str, DisablePermissionUI) -> DisablePermission

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -23,6 +23,17 @@ if TYPE_CHECKING:
     from typing import ContextManager, List
 
 
+class GroupRequestInterface(object):
+    """Abstract base class for requests for group membership."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def cancel_all_requests_for_user(self, user, reason, authorization):
+        # type: (str, str, Authorization) -> None
+        pass
+
+
 class PermissionInterface(object):
     """Abstract base class for permission operations and queries."""
 
@@ -49,25 +60,29 @@ class PermissionInterface(object):
         pass
 
 
+class ServiceAccountInterface(object):
+    """Abstract base class for service account operations and queries."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def create_service_account_from_disabled_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        pass
+
+    @abstractmethod
+    def enable_service_account(self, user, owner, authorization):
+        # type: (str, str, Authorization) -> None
+        pass
+
+
 class TransactionInterface(object):
     """Abstract base class for starting and committing transactions."""
 
     __metaclass__ = ABCMeta
 
-    @abstractmethod
     def transaction(self):
         # type: () -> ContextManager[None]
-        pass
-
-
-class ServiceFactoryInterface(object):
-    """Abstract base class for creating services."""
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def create_permission_service(self):
-        # type: () -> PermissionInterface
         pass
 
 
@@ -75,6 +90,16 @@ class UserInterface(object):
     """Abstract base class for user operations and queries."""
 
     __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def disable_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        pass
+
+    @abstractmethod
+    def groups_of_user(self, user):
+        # type: (str) -> List[str]
+        pass
 
     @abstractmethod
     def permission_grants_for_user(self, user):
@@ -88,5 +113,10 @@ class UserInterface(object):
 
     @abstractmethod
     def user_is_permission_admin(self, user):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def user_is_user_admin(self, user):
         # type: (str) -> bool
         pass

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -173,3 +173,19 @@ class SetupTest(object):
             permission_id=permission_obj.id, group_id=group_obj.id, argument=argument
         )
         grant.add(self.session)
+
+    def create_group_request(self, user, group, role="member"):
+        # type: (str, str, str) -> None
+        self.create_user(user)
+        self.create_group(group)
+
+        user_obj = User.get(self.session, name=user)
+        assert user_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+
+        # Note: despite the function name, this only creates the request. The flow here is
+        # convoluted enough that it seems best to preserve exact behavior for testing.
+        group_obj.add_member(
+            requester=user_obj, user_or_group=user_obj, reason="", status="pending", role=role
+        )

--- a/tests/usecases/convert_user_to_service_account_test.py
+++ b/tests/usecases/convert_user_to_service_account_test.py
@@ -1,0 +1,142 @@
+from typing import TYPE_CHECKING
+
+import pytest
+from mock import call, MagicMock
+
+from grouper.constants import USER_ADMIN
+from grouper.entities.group import GroupNotFoundException
+from grouper.graph import NoSuchUser
+from grouper.group_requests import count_requests_by_group
+from grouper.models.group import Group
+from grouper.models.group_service_accounts import GroupServiceAccount
+from grouper.models.service_account import ServiceAccount
+from grouper.models.user import User
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_success(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_user("service@a.co")
+        setup.create_group("some-group")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.converted_user_to_service_account("service@a.co", "some-group")
+    ]
+
+    # Check the User after the conversion
+    service_account_user = User.get(setup.session, name="service@a.co")
+    assert service_account_user
+    assert service_account_user.is_service_account
+    assert service_account_user.enabled
+
+    # Check the ServiceAccount that should have been created
+    service_account = ServiceAccount.get(setup.session, name="service@a.co")
+    assert service_account
+    assert service_account.description == ""
+    assert service_account.machine_set == ""
+    assert service_account.user_id == service_account_user.id
+
+    # Check that the ServiceAccount is owned by the correct Group
+    group = Group.get(setup.session, name="some-group")
+    group_service_account = GroupServiceAccount.get(
+        setup.session, service_account_id=service_account.id
+    )
+    assert group
+    assert group_service_account
+    assert group_service_account.group_id == group.id
+
+
+def test_failed_access_denied(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_user("service@a.co")
+        setup.create_group("some-group")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.convert_user_to_service_account_failed_permission_denied("service@a.co")
+    ]
+
+
+def test_failed_member_of_group(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_user("service@a.co")
+        setup.add_user_to_group("service@a.co", "admins")
+        setup.create_group("some-group")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.convert_user_to_service_account_failed_user_is_in_groups("service@a.co")
+    ]
+
+
+def test_cancels_group_requests(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_user("service@a.co")
+        setup.create_group("some-group")
+        setup.create_group_request("service@a.co", "some-group")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.converted_user_to_service_account("service@a.co", "some-group")
+    ]
+
+    # Confirm that the request to the group is now cancelled and there are no pending requests
+    group = Group.get(setup.session, name="some-group")
+    assert group
+    assert count_requests_by_group(setup.session, group, status="cancelled") == 1
+    assert count_requests_by_group(setup.session, group, status="pending") == 0
+
+
+def test_failed_user_does_not_exist(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_group("some-group")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    with pytest.raises(NoSuchUser):
+        usecase.convert_user_to_service_account("dne@a.co", "some-group")
+
+
+def test_failed_group_does_not_exist(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.create_user("service@a.co")
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    with pytest.raises(GroupNotFoundException):
+        usecase.convert_user_to_service_account("service@a.co", "some-group")


### PR DESCRIPTION
Add a use case and a grouper-ctl command that converts a user to
a service account by first disabling it and then wrapping it in a
service account and enabling the service account.

Move the user subcommand of grouper-ctl to the new framework so
that it can run use cases, although the existing subcommands are
still implemented the old way.

Move the exceptions for unknown database entities to the
grouper.entities.* modules so that they can be shared across
repositories, services, and use cases (the latter two may need to
catch the exceptions in some situations).