### PR TITLE
Fix health check routes, add tests

### DIFF
--- a/grouper/handlers/health_check.py
+++ b/grouper/handlers/health_check.py
@@ -1,13 +1,21 @@
 from contextlib import closing
+from typing import TYPE_CHECKING
 
 from tornado.web import RequestHandler
 
 from grouper.models.base.session import Session
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class HealthCheck(RequestHandler):
-    def get(self):
+    def initialize(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        pass
+
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         with closing(Session()) as session:
             session.execute("SELECT 1")
-
-        return self.write("")
+        self.write("")

--- a/tests/api/handlers_test.py
+++ b/tests/api/handlers_test.py
@@ -30,6 +30,13 @@ from tests.url_util import url
 
 
 @pytest.mark.gen_test
+def test_health(session, http_client, base_url):  # noqa: F811
+    health_url = url(base_url, "/debug/health")
+    resp = yield http_client.fetch(health_url)
+    assert resp.code == 200
+
+
+@pytest.mark.gen_test
 def test_users(users, http_client, base_url):  # noqa: F811
     all_users = sorted(users.keys() + ["service@a.co"])
     users_wo_role = sorted([u for u in users if u != u"role@a.co"])

--- a/tests/fe/handlers_test.py
+++ b/tests/fe/handlers_test.py
@@ -44,6 +44,13 @@ def _get_unsent_and_mark_as_sent_emails_with_username(session, username):  # noq
 
 
 @pytest.mark.gen_test
+def test_health(session, http_client, base_url):  # noqa: F811
+    health_url = url(base_url, "/debug/health")
+    resp = yield http_client.fetch(health_url)
+    assert resp.code == 200
+
+
+@pytest.mark.gen_test
 def test_auth(users, http_client, base_url):  # noqa: F811
     # no 'auth' present
     with pytest.raises(HTTPError):


### PR DESCRIPTION
The refactoring of the way parameters were passed into the Tornado
handlers broke the shared HealthCheck handler since it didn't
override initialize.  Add an empty initialize method (since it
doesn't care about any of the parameters in its current design),
and add tests that exercise the health check handler.

Rename an API test file that had a typo in the name.