### PR TITLE
Fix permission pagination limit on last page

### DIFF
--- a/grouper/entities/pagination.py
+++ b/grouper/entities/pagination.py
@@ -39,10 +39,12 @@ class PaginatedList(Generic[T]):
         values: The members of the list
         total: Total number of list members were no pagination done
         offset: Offset from start of sorted list
+        limit: Requested limit on total number of items to return (actual items may be fewer)
     """
 
-    def __init__(self, values, total, offset):
-        # type: (List[T], int, int) -> None
+    def __init__(self, values, total, offset, limit):
+        # type: (List[T], int, int, Optional[int]) -> None
         self.values = values
         self.total = total
         self.offset = offset
+        self.limit = limit

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -19,7 +19,7 @@ class PermissionsView(GrouperHandler, ListPermissionsUI):
             "permissions.html",
             permissions=permissions.values,
             offset=permissions.offset,
-            limit=len(permissions.values),
+            limit=permissions.limit,
             total=permissions.total,
             can_create=can_create,
             audited_permissions=audited_only,

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -57,7 +57,9 @@ class GraphPermissionRepository(PermissionRepository):
             Permission(name=p.name, description=p.description, created_on=p.created_on)
             for p in perm_tuples
         ]
-        return PaginatedList[Permission](values=permissions, total=total, offset=pagination.offset)
+        return PaginatedList[Permission](
+            values=permissions, total=total, offset=pagination.offset, limit=pagination.limit
+        )
 
 
 class SQLPermissionRepository(PermissionRepository):

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -58,6 +58,7 @@ def test_list(tmpdir, setup, browser):
         assert seen_permissions == sorted(expected_permissions)
         assert page.heading == "Permissions"
         assert page.subheading == "{} permission(s)".format(len(expected_permissions))
+        assert page.limit_label == "Limit: 100"
 
         # Switch to only audited permissions.
         page.click_show_audited_button()
@@ -97,6 +98,15 @@ def test_list_pagination(tmpdir, setup, browser):
         page = PermissionsPage(browser)
         seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
         assert seen_permissions == sorted(expected_permissions)[1:2]
+        assert page.limit_label == "Limit: 1"
+
+        # Retrieve the last permission but with a larger limit to test that the limit isn't capped
+        # to the number of returned items.
+        browser.get(url(frontend_url, "/permissions?limit=10&offset=2"))
+        page = PermissionsPage(browser)
+        seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
+        assert seen_permissions == sorted(expected_permissions)[2:]
+        assert page.limit_label == "Limit: 10"
 
 
 def test_create_button(tmpdir, setup, browser):

--- a/itests/pages/permissions.py
+++ b/itests/pages/permissions.py
@@ -18,6 +18,11 @@ class PermissionsPage(BasePage):
         all_permission_rows = self.find_elements_by_class_name("permission-row")
         return [PermissionRow(row) for row in all_permission_rows]
 
+    @property
+    def limit_label(self):
+        # type: () -> str
+        return self.find_element_by_class_name("dropdown-toggle").text.strip()
+
     def click_show_all_button(self):
         # type: () -> None
         button = self.find_element_by_class_name("show-all")

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -68,7 +68,7 @@ def test_simple_list_permissions(setup):
     usecase = setup.usecase_factory.create_list_permissions_usecase(mock_ui)
     usecase.simple_list_permissions()
     assert not mock_ui.can_create
-    expected = PaginatedList(values=sorted(permissions), total=3, offset=0)
+    expected = PaginatedList(values=sorted(permissions), total=3, offset=0, limit=None)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 
@@ -83,7 +83,7 @@ def test_list_permissions_pagination(setup):
         sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=2
     )
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
-    expected = PaginatedList(values=sorted(permissions)[:2], total=3, offset=0)
+    expected = PaginatedList(values=sorted(permissions)[:2], total=3, offset=0, limit=2)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
     # Sorted by date, using offset, limit longer than remaining items.
@@ -92,7 +92,7 @@ def test_list_permissions_pagination(setup):
     )
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     expected_values = sorted(permissions, key=lambda p: p.created_on)[2:]
-    expected = PaginatedList(values=expected_values, total=3, offset=2)
+    expected = PaginatedList(values=expected_values, total=3, offset=2, limit=10)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
     # Sorted by name, reversed, limit of one 1 and offset of 1.
@@ -101,7 +101,7 @@ def test_list_permissions_pagination(setup):
     )
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     expected_values = sorted(permissions, reverse=True)[1:2]
-    expected = PaginatedList(values=expected_values, total=3, offset=1)
+    expected = PaginatedList(values=expected_values, total=3, offset=1, limit=1)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 
@@ -115,7 +115,7 @@ def test_list_permissions_audited_only(setup):
     )
     usecase.list_permissions("gary@a.co", pagination, audited_only=True)
     expected_values = [p for p in permissions if p.name == "audited-permission"]
-    expected = PaginatedList(values=expected_values, total=1, offset=0)
+    expected = PaginatedList(values=expected_values, total=1, offset=0, limit=None)
     assert_paginated_list_equal(mock_ui.permissions, expected)
 
 


### PR DESCRIPTION
The frontend UI was using the number of returned items as the
requested limit on the number of items, which is wrong for the
last page of a paginated list.  Return the requested limit as part
of the paginated list data structure so that the actual limit isn't
lost when there are fewer than that number of remaining items.