### PR TITLE
[WIP] Fix creation of UserToken table at startup

### DIFF
--- a/grouper/models/user.py
+++ b/grouper/models/user.py
@@ -2,11 +2,13 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.model_base import Model
 from grouper.models.comment import CommentObjectMixin
 from grouper.models.counter import Counter
+from grouper.models.user_token import UserToken
 from grouper.plugin import get_plugin_proxy
 
 if TYPE_CHECKING:
@@ -23,6 +25,7 @@ class User(Model, CommentObjectMixin):
     enabled = Column(Boolean, default=True, nullable=False)
     role_user = Column(Boolean, default=False, nullable=False)
     is_service_account = Column(Boolean, default=False, nullable=False)
+    tokens = relationship("UserToken", backref="user")
 
     @hybrid_property
     def name(self):

--- a/grouper/models/user_token.py
+++ b/grouper/models/user_token.py
@@ -4,10 +4,8 @@ import os
 from datetime import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
-from sqlalchemy.orm import relationship
 
 from grouper.models.base.model_base import Model
-from grouper.models.user import User
 
 
 def _make_secret():
@@ -28,8 +26,6 @@ class UserToken(Model):
     disabled_at = Column(DateTime, default=None, nullable=True)
 
     hashed_secret = Column(String(length=64), unique=True, nullable=False)
-
-    user = relationship("User", backref="tokens")
 
     __table_args__ = (UniqueConstraint("user_id", "name"),)
 


### PR DESCRIPTION
On a clean pull of Grouper, if you run `grouper-ctl sync_db` and then try to view any user on the fe, it errors out with the UserToken table not existing. Best I can tell, it's since the file defining that table isn't imported anywhere prior to the `create_all` call.

The best fix I could think of was to define the User<->UserToken relationship within User, which then must import UserToken. Note that per the semantics of backref ([doc](https://docs.sqlalchemy.org/en/latest/orm/backref.html)), the change should be a logic no-op.

Anyone know if there's a more correct solution I'm missing? (@rra since you were the last to muck with this table relationship)