### PR TITLE
Update development and groupy dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-coverage==3.7.1
-flake8-import-order==0.18
-flake8==3.7.5
-groupy
+coverage==4.5.3
+flake8-import-order==0.18.1
+flake8==3.7.7
+groupy>=0.5.0
 mock==2.0.0
 mrproxy==0.3.4
 py==1.5.2
@@ -9,4 +9,4 @@ pytest-mock==1.10.0
 pytest-tornado==0.5.0
 pytest-xdist==1.10
 pytest==3.5.0
-selenium==3.6.0
+selenium==3.141.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,4 +1,4 @@
-black==18.9b0
-flake8-import-order==0.18
-flake8==3.7.5
-mypy==0.660
+black==19.3b0
+flake8-import-order==0.18.1
+flake8==3.7.7
+mypy==0.700


### PR DESCRIPTION
Bump versions on dependencies that are only used for development.
Depend on groupy 0.5.0 or later for tests since it adds Python 3
support.