### PR TITLE
Run futurize stage one

### DIFF
--- a/grouper/error_reporting.py
+++ b/grouper/error_reporting.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import logging
 import signal
 import sys

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import errno
 import socket
 import subprocess

--- a/tests/audit_test.py
+++ b/tests/audit_test.py
@@ -175,7 +175,7 @@ def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):
     open_audits = [
         Audit(
             x.id,
-            x.group.my_owners().iterkeys().next(),
+            next(x.group.my_owners().iterkeys()),
             x.group.name,
             [AuditMember(am.id, am.edge.member_type, am.edge_id) for am in x.my_members()],
         )
@@ -214,7 +214,7 @@ def test_audit_end_to_end(session, users, groups, http_client, base_url, graph):
             # approve
             body_dict["audit_{}".format(am.id)] = "approved"
 
-    owner_name = one_audit.group.my_owners().iterkeys().next()
+    owner_name = next(one_audit.group.my_owners().iterkeys())
     fe_url = url(base_url, "/audits/{}/complete".format(one_audit.id))
     resp = yield http_client.fetch(
         fe_url, method="POST", body=urlencode(body_dict), headers={"X-Grouper-User": owner_name}


### PR DESCRIPTION
Do all Python-2-compatible fixes in futurize stage one, which do
not introduce any dependency on the future module.