### PR TITLE
Vary Grouper HTML page titles

### DIFF
--- a/grouper/fe/templates/audit-create.html
+++ b/grouper/fe/templates/audit-create.html
@@ -4,6 +4,8 @@
     <a href="/audits">Audits</a>
 {% endblock %}
 
+{% block subtitle %} start global audit{% endblock %}
+
 {% block subheading %}
     Start Global Audit
 {% endblock %}

--- a/grouper/fe/templates/audits.html
+++ b/grouper/fe/templates/audits.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import log_entry_panel, account, paginator, dropdown with context %}
 
+{% block subtitle %} audits{% endblock %}
+
 {% block heading %}
     Audits
 {% endblock %}

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -2,7 +2,7 @@
 <html>
     <head>
 
-        <title>{% block title %}Grouper{% endblock %}</title>
+        <title>Grouper{% block subtitle %}{% endblock %}</title>
 
         <link href="{{cdnjs_prefix}}/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css"
               rel="stylesheet"

--- a/grouper/fe/templates/group-add.html
+++ b/grouper/fe/templates/group-add.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} add member to {{group.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-create.html
+++ b/grouper/fe/templates/group-create.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} create group{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-edit-member.html
+++ b/grouper/fe/templates/group-edit-member.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} edit member of {{group.groupname}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-edit.html
+++ b/grouper/fe/templates/group-edit.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} edit {{group.groupname}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -2,6 +2,8 @@
 
 {% from 'macros/ui.html' import form_field %}
 
+{% block subtitle %} join {{group.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-leave.html
+++ b/grouper/fe/templates/group-leave.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} leave {{group.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-permission-request.html
+++ b/grouper/fe/templates/group-permission-request.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} request permission for {{group.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-request-update.html
+++ b/grouper/fe/templates/group-request-update.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} update request for {{group.groupname}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import paginator, dropdown with context %}
 
+{% block subtitle %} requests for {{group.groupname}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -2,6 +2,8 @@
 {% from 'macros/ui.html' import group_panel, member_panel, permission_panel, log_entry_panel,
                                 help_for, account, service_account_panel %}
 
+{% block subtitle %} group {{group.groupname}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import account, paginator, dropdown with context %}
 
+{% block subtitle %} groups{% endblock %}
+
 {% block heading %}
     {% if audited_groups %}
       Audited

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import permission with context %}
 
+{% block subtitle %} help{% endblock %}
+
 {% block heading %}
     Help
 {% endblock %}

--- a/grouper/fe/templates/permission-create.html
+++ b/grouper/fe/templates/permission-create.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} create permission{% endblock %}
+
 {% block heading %}
     <a href="/permissions">Permissions</a>
 {% endblock %}

--- a/grouper/fe/templates/permission-grant-tag.html
+++ b/grouper/fe/templates/permission-grant-tag.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} grant permission to tag {{tag.name}}{% endblock %}
+
 {% block heading %}
     <a href="/permissions">Permissions</a>
 {% endblock %}

--- a/grouper/fe/templates/permission-grant.html
+++ b/grouper/fe/templates/permission-grant.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} grant permission to {{ group.name }}{% endblock %}
+
 {% block heading %}
     <a href="/permissions">Permissions</a>
 {% endblock %}

--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} act on requests for {{current_user.name}}{% endblock %}
+
 {% block heading %}
     Permission Requests
 {% endblock %}

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import paginator, dropdown with context %}
 
+{% block subtitle %} requests for {{ current_user.name }}{% endblock %}
+
 {% block heading %}
     Permission Requests
 {% endblock %}

--- a/grouper/fe/templates/permission-revoke-tag.html
+++ b/grouper/fe/templates/permission-revoke-tag.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import format_tag %}
 
+{% block subtitle %} revoke permission from tag{% endblock %}
 
 {% block heading %}
     <a href="/tags">Tags</a>

--- a/grouper/fe/templates/permission-revoke.html
+++ b/grouper/fe/templates/permission-revoke.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} revoke permission{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import log_entry_panel, paginator, dropdown with context %}
 
+{% block subtitle %} permission {{ permission.name }}{% endblock %}
+
 {% block heading %}
     Permissions
 {% endblock %}

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import permission, paginator, dropdown with context %}
 
+{% block subtitle %}
+    {% if audited_permissions %}
+      audited
+    {% endif %}
+    permissions
+{% endblock %}
+
 {% block heading %}
     {% if audited_permissions %}
       Audited

--- a/grouper/fe/templates/public-key-add-tag.html
+++ b/grouper/fe/templates/public-key-add-tag.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} tag public key{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/public-key-add.html
+++ b/grouper/fe/templates/public-key-add.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} add public key{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/public-key-delete.html
+++ b/grouper/fe/templates/public-key-delete.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} delete public key{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/search.html
+++ b/grouper/fe/templates/search.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import paginator, dropdown with context %}
 
+{% block subtitle %} search{% endblock %}
+
 {% block heading %}
     Search
 {% endblock %}

--- a/grouper/fe/templates/service-account-create.html
+++ b/grouper/fe/templates/service-account-create.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} create service account for {{group.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/service-account-edit.html
+++ b/grouper/fe/templates/service-account-edit.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} edit {{service_account.user.username}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/service-account-enable.html
+++ b/grouper/fe/templates/service-account-enable.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} enable {{ user.username }}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/service-account-permission-grant.html
+++ b/grouper/fe/templates/service-account-permission-grant.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} grant permission to {{user.username}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -59,6 +59,8 @@
     </div>
 {%- endmacro %}
 
+{% block subtitle %} service account {{user.username}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}

--- a/grouper/fe/templates/service.html
+++ b/grouper/fe/templates/service.html
@@ -6,6 +6,8 @@
 
 {% from 'macros/ui.html' import public_key_modal with context %}
 
+{% block subtitle %} service accounts{% endblock %}
+
 {% block heading %}
     <a href="/service">Service Accounts</a>
 {% endblock %}

--- a/grouper/fe/templates/tag-edit.html
+++ b/grouper/fe/templates/tag-edit.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} edit {{tag.name}}{% endblock %}
+
 {% block heading %}
     <a href="/groups">Tags</a>
 {% endblock %}

--- a/grouper/fe/templates/tag.html
+++ b/grouper/fe/templates/tag.html
@@ -2,6 +2,8 @@
 {% from 'macros/ui.html' import group_panel, member_panel, tag_permission_panel, log_entry_panel,
                                 help_for, account %}
 
+{% block subtitle %} tag {{tag.name}}{% endblock %}
+
 {% block heading %}
     <a href="/tags">Tags</a>
 {% endblock %}

--- a/grouper/fe/templates/tags.html
+++ b/grouper/fe/templates/tags.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import account, paginator, format_tag, dropdown with context %}
 
+{% block subtitle %} tags{% endblock %}
+
 {% block heading %}
     Tags
 {% endblock %}

--- a/grouper/fe/templates/user-password-add.html
+++ b/grouper/fe/templates/user-password-add.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} add password{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-password-delete.html
+++ b/grouper/fe/templates/user-password-delete.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} delete password{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-requests.html
+++ b/grouper/fe/templates/user-requests.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import paginator, dropdown with context %}
 
+{% block subtitle %} pending user requests{% endblock %}
+
 {% block heading %}
     <a href="/Users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-shell.html
+++ b/grouper/fe/templates/user-shell.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} change shell for {{user.name}}{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-token-add.html
+++ b/grouper/fe/templates/user-token-add.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} add token{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-token-created.html
+++ b/grouper/fe/templates/user-token-created.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} new token{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-token-disable.html
+++ b/grouper/fe/templates/user-token-disable.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} disable token{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user-token-disabled.html
+++ b/grouper/fe/templates/user-token-disabled.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block subtitle %} token disabled{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -4,6 +4,8 @@
                                 shell_panel, passwords_panel %}
 {% from 'macros/ui.html' import public_key_panel with context %}
 
+{% block subtitle %} user {{user.username}}{% endblock %}
+
 {% block heading %}
     <a href="/users">Users</a>
 {% endblock %}

--- a/grouper/fe/templates/users-publickey.html
+++ b/grouper/fe/templates/users-publickey.html
@@ -3,6 +3,8 @@
 {% from 'macros/ui.html' import account, one_public_key_row %}
 {% from 'macros/ui.html' import dropdown, paginator, public_key_modal with context %}
 
+{% block subtitle %} public keys{% endblock %}
+
 {% block heading %}
     {% if not form.enabled.data %}
       Disabled

--- a/grouper/fe/templates/users-usertokens.html
+++ b/grouper/fe/templates/users-usertokens.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import account, paginator, one_user_token_row, dropdown with context %}
 
+{% block subtitle %} user tokens{% endblock %}
+
 {% block heading %}
     {% if not form.enabled.data %}
       Disabled

--- a/grouper/fe/templates/users.html
+++ b/grouper/fe/templates/users.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import account, paginator, dropdown with context %}
 
+{% block subtitle %} users{% endblock %}
+
 {% block heading %}
     {% if not enabled %}
       Disabled


### PR DESCRIPTION
Browser history (as well as any list of open tabs) is fairly useless if
every page ever visited is simply named “Grouper”, so add real titles.