### PR TITLE
Show description on each permission’s page

### DIFF
--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -29,6 +29,12 @@
 {% endblock %}
 
 {% block content %}
+{% if permission.description %}
+    <p>
+        <b>Description:</b> “{{ permission.description | escape }}”
+    </p>
+{% endif %}
+
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
         {% if not permission.enabled %}


### PR DESCRIPTION
I often want to double-check the permission’s description when reviewing
who holds the permission, but right now it’s only in the big table.