### PR TITLE
Rewrite grouper-ctl user_proxy

### DIFF
--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from grouper.ctl.permission import PermissionCommand
 from grouper.ctl.user import UserCommand
+from grouper.ctl.user_proxy import UserProxyCommand
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
@@ -32,6 +33,8 @@ class CtlCommandFactory(object):
         PermissionCommand.add_arguments(parser)
         parser = subparsers.add_parser("user", help="Manipulate users")
         UserCommand.add_arguments(parser)
+        parser = subparsers.add_parser("user_proxy", help="Start a development reverse proxy")
+        UserProxyCommand.add_arguments(parser)
 
     def __init__(self, usecase_factory):
         # type: (UseCaseFactory) -> None
@@ -43,6 +46,8 @@ class CtlCommandFactory(object):
             return self.construct_permission_command()
         elif command == "user":
             return self.construct_user_command()
+        elif command == "user_proxy":
+            return self.construct_user_proxy_command()
         else:
             raise UnknownCommand("unknown command {}".format(command))
 
@@ -53,3 +58,7 @@ class CtlCommandFactory(object):
     def construct_user_command(self):
         # type: () -> UserCommand
         return UserCommand(self.usecase_factory)
+
+    def construct_user_proxy_command(self):
+        # type: () -> UserProxyCommand
+        return UserProxyCommand()

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -45,14 +45,7 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
     CtlCommandFactory.add_all_parsers(subparsers)
 
     # Add parsers for legacy commands that have not been refactored.
-    for subcommand_module in [
-        dump_sql,
-        group,
-        oneoff,
-        service_account,
-        shell,
-        sync_db,
-    ]:
+    for subcommand_module in [dump_sql, group, oneoff, service_account, shell, sync_db]:
         subcommand_module.add_parser(subparsers)  # type: ignore
 
     args = parser.parse_args(sys_argv[1:])

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from grouper import __version__
-from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db, user_proxy
+from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db
 from grouper.ctl.factory import CtlCommandFactory
 from grouper.initialization import create_sql_usecase_factory
 from grouper.plugin import initialize_plugins
@@ -52,7 +52,6 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
         service_account,
         shell,
         sync_db,
-        user_proxy,
     ]:
         subcommand_module.add_parser(subparsers)  # type: ignore
 

--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -1,79 +1,157 @@
 from __future__ import print_function
 
-import BaseHTTPServer
 import getpass
 import logging
-import urllib2
+from typing import cast, TYPE_CHECKING
 
-from mrproxy import UserProxyHandler
+from six import PY2
+
+from grouper.ctl.base import CtlCommand
+
+try:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from urllib.error import HTTPError, URLError
+    from urllib.request import build_opener, HTTPErrorProcessor, Request
+except ImportError:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer  # type: ignore
+    from urllib2 import (  # type: ignore
+        build_opener,
+        HTTPError,
+        HTTPErrorProcessor,
+        Request,
+        URLError,
+    )
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
+    from urllib.request import _HTTPResponse, _UrlopenRet
+    from typing import Dict, Tuple, Type
 
 
-# Workaround for https://github.com/gmjosack/mrproxy/issues/2
-class ProxyHandler(UserProxyHandler):
+class NoRedirectHandler(HTTPErrorProcessor):
+    """Redirect handler that returns the redirect to the client.
+
+    We don't want the proxy to follow redirects itself since the client's concept of the current
+    URL will then desynchronize from the page that was retured.  We want to be transparent and
+    return each intermediate response.
+    """
+
+    def http_response(self, request, response):
+        # type: (Request, _HTTPResponse) -> _UrlopenRet
+        return response
+
+
+class ProxyServer(HTTPServer, object):
+    """Very simple proxy that adds the X-Grouper-User header.
+
+    This is not intended for production use and should not be exposed to hostile requests.  It's
+    based on the implementation in mrproxy.
+    """
+
+    def __init__(self, address, handler, backend_port, username):
+        # type: (Tuple[str, int], Type[BaseHTTPRequestHandler], int, str) -> None
+        self.backend_port = backend_port
+        self.username = username
+        self.opener = build_opener(NoRedirectHandler)
+        super(ProxyServer, self).__init__(address, handler)
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    """Handler for the proxy server."""
+
+    @property
+    def dest_url(self):
+        # type: () -> str
+        backend_port = cast(ProxyServer, self.server).backend_port
+        return "http://localhost:{}{}".format(backend_port, self.path)
+
     def do_request(self, request):
+        # type: (Request) -> None
         try:
-            url = urllib2.urlopen(request)
+            url = cast(ProxyServer, self.server).opener.open(request)
             code = url.getcode()
-            headers = str(url.info())
+            msg = getattr(url, "msg", "")
+            headers = str(url.info()).rstrip()
             data = url.read()
-        except urllib2.HTTPError as err:
+        except HTTPError as err:
             code = err.getcode()
-            headers = str(err.info())
+            msg = getattr(url, "msg", "")
+            headers = str(err.info()).rstrip()
             data = err.read()
-        except urllib2.URLError as err:
+        except URLError as err:
             code = 503
+            msg = "Service Unavailable"
             headers = str(err)
-            data = "503 Service Unavailable: %s\n" % err
+            data = "503 Service Unavailable: {}\n".format(headers).encode()
 
-        self.send_response(code)
-        self.wfile.write(headers)
+        self.send_response(code, msg)
+        for line in headers.splitlines():
+            header, value = line.split(": ", 1)
+            self.send_header(header, value)
         self.end_headers()
         self.wfile.write(data)
 
+    def updated_headers(self):
+        # type: () -> Dict[str, str]
+        headers = {h: str(v) for h, v in self.headers.items()}
+        headers["X-Grouper-User"] = cast(ProxyServer, self.server).username
+        return headers
 
-def build_user_proxy_server(username, backend_port, listen_host, listen_port):
-    class ServerArgs(object):
-        def __init__(self, backend_port, username):
-            self.backend_port = backend_port
-            self.header = ["X-Grouper-User: %s" % username]
+    def do_GET(self, method="GET"):
+        # type: (str) -> None
+        headers = self.updated_headers()
+        if PY2:
+            request = Request(self.dest_url, headers=headers)
+            request.get_method = lambda: method
+        else:
+            request = Request(self.dest_url, method=method, headers=headers)
+        self.do_request(request)
 
-    server = BaseHTTPServer.HTTPServer((listen_host, listen_port), ProxyHandler)
-    server.args = ServerArgs(backend_port, username)
+    def do_POST(self, method="POST"):
+        # type: (str) -> None
+        content_len = int(str(self.headers["Content-Length"]))
+        data = self.rfile.read(content_len)
+        headers = self.updated_headers()
+        if PY2:
+            request = Request(self.dest_url, headers=headers, data=data)
+            request.get_method = lambda: method
+        else:
+            request = Request(self.dest_url, method=method, headers=headers, data=data)
+        self.do_request(request)
 
-    return server
 
+class UserProxyCommand(CtlCommand):
+    """Command to start a user proxy."""
 
-def user_proxy_command(args):
-    username = args.username
-    if username is None:
-        username = getpass.getuser()
-        logging.debug("No username provided, using (%s)", username)
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument("--listen-host", default="localhost", help="Host to listen on.")
+        parser.add_argument(
+            "-p", "--listen-port", default=8888, type=int, help="Port to listen on."
+        )
+        parser.add_argument(
+            "-P", "--backend-port", default=8989, type=int, help="Port to proxy to."
+        )
+        parser.add_argument("username", nargs="?", default=None)
 
-    server = build_user_proxy_server(
-        args.username, args.backend_port, args.listen_host, args.listen_port
-    )
-    try:
+    def run(self, args):
+        # type: (Namespace) -> None
+        username = args.username
+        if username is None:
+            username = getpass.getuser()
+            logging.debug("No username provided, using (%s)", username)
+
+        listen_address = (args.listen_host, args.listen_port)
+        server = ProxyServer(listen_address, ProxyHandler, args.backend_port, args.username)
+
         logging.info(
-            "Starting user_proxy on host (%s) and port (%s) with user (%s)",
+            "Starting user_proxy on %s:%d with user %s",
             args.listen_host,
             args.listen_port,
             username,
         )
-        server.serve_forever()
-    except KeyboardInterrupt:
-        print("Bye!")
-
-
-def add_parser(subparsers):
-    user_proxy_parser = subparsers.add_parser(
-        "user_proxy", help="Start a development reverse proxy."
-    )
-    user_proxy_parser.set_defaults(func=user_proxy_command)
-    user_proxy_parser.add_argument("--listen-host", default="localhost", help="Host to listen on.")
-    user_proxy_parser.add_argument(
-        "-p", "--listen-port", default=8888, type=int, help="Port to listen on."
-    )
-    user_proxy_parser.add_argument(
-        "-P", "--backend-port", default=8989, type=int, help="Port to proxy to."
-    )
-    user_proxy_parser.add_argument("username", nargs="?", default=None)
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("Bye!")

--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -4,8 +4,6 @@ import getpass
 import logging
 from typing import cast, TYPE_CHECKING
 
-from six import PY2
-
 from grouper.ctl.base import CtlCommand
 
 try:
@@ -97,26 +95,18 @@ class ProxyHandler(BaseHTTPRequestHandler):
         headers["X-Grouper-User"] = cast(ProxyServer, self.server).username
         return headers
 
-    def do_GET(self, method="GET"):
-        # type: (str) -> None
+    def do_GET(self):
+        # type: () -> None
         headers = self.updated_headers()
-        if PY2:
-            request = Request(self.dest_url, headers=headers)
-            request.get_method = lambda: method
-        else:
-            request = Request(self.dest_url, method=method, headers=headers)
+        request = Request(self.dest_url, headers=headers)
         self.do_request(request)
 
-    def do_POST(self, method="POST"):
-        # type: (str) -> None
+    def do_POST(self):
+        # type: () -> None
         content_len = int(str(self.headers["Content-Length"]))
         data = self.rfile.read(content_len)
         headers = self.updated_headers()
-        if PY2:
-            request = Request(self.dest_url, headers=headers, data=data)
-            request.get_method = lambda: method
-        else:
-            request = Request(self.dest_url, method=method, headers=headers, data=data)
+        request = Request(self.dest_url, headers=headers, data=data)
         self.do_request(request)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ flake8-import-order==0.18.1
 flake8==3.7.7
 groupy>=0.5.0
 mock==2.0.0
-mrproxy==0.3.4
 py==1.5.2
 pytest-mock==1.10.3
 pytest-tornado==0.7.0


### PR DESCRIPTION
mrproxy doesn't support Python 3.  It is small enough, the changes
for porting are significant enough, and we were already overriding
enough of its logic that it made sense to replace it entirely.

Rewrite using http.server and urllib.request directly, in a way
that is compatible with both Python 2 and Python 3.  Covert it to
the new grouper-ctl class structure.