### PR TITLE
Run tests under the running interpreter

### DIFF
--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import errno
 import socket
 import subprocess
+import sys
 import time
 from contextlib import closing
 from typing import TYPE_CHECKING
@@ -32,6 +33,7 @@ def async_server(standard_graph, tmpdir):
 
     cmds = [
         [
+            sys.executable,
             src_path("bin", "grouper-ctl"),
             "-vvc",
             src_path("config", "dev.yaml"),
@@ -43,6 +45,7 @@ def async_server(standard_graph, tmpdir):
             "cbguder@a.co",
         ],
         [
+            sys.executable,
             src_path("bin", "grouper-fe"),
             "-c",
             src_path("config", "dev.yaml"),
@@ -75,6 +78,7 @@ def async_api_server(standard_graph, tmpdir):
     api_port = _get_unused_port()
 
     cmd = [
+        sys.executable,
         src_path("bin", "grouper-api"),
         "-c",
         src_path("config", "dev.yaml"),

--- a/itests/setup.py
+++ b/itests/setup.py
@@ -8,6 +8,7 @@ import errno
 import logging
 import socket
 import subprocess
+import sys
 import time
 from contextlib import closing, contextmanager
 from typing import TYPE_CHECKING
@@ -62,6 +63,7 @@ def api_server(tmpdir):
     api_port = _get_unused_port()
 
     cmd = [
+        sys.executable,
         src_path("bin", "grouper-api"),
         "-c",
         src_path("config", "dev.yaml"),
@@ -91,6 +93,7 @@ def frontend_server(tmpdir, user):
 
     cmds = [
         [
+            sys.executable,
             src_path("bin", "grouper-ctl"),
             "-vvc",
             src_path("config", "dev.yaml"),
@@ -102,6 +105,7 @@ def frontend_server(tmpdir, user):
             user,
         ],
         [
+            sys.executable,
             src_path("bin", "grouper-fe"),
             "-vvc",
             src_path("config", "dev.yaml"),

--- a/tests/bin_test.py
+++ b/tests/bin_test.py
@@ -1,4 +1,12 @@
+"""Check that the bin wrappers load properly.
+
+TODO(rra): These wrappers all start with /usr/bin/env python2 right now, so will not run properly
+in a Python 3 environment.  If we are running under Python 3, run them explicitly under the Python
+binary we're running under.
+"""
+
 import subprocess
+import sys
 
 from tests.path_util import bin_env, src_path
 
@@ -6,26 +14,26 @@ from tests.path_util import bin_env, src_path
 def test_api():
     # type: () -> None
     bin_path = src_path("bin", "grouper-api")
-    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
-    assert out.startswith("usage: grouper-api")
+    out = subprocess.check_output([sys.executable, bin_path, "--help"], env=bin_env())
+    assert out.decode().startswith("usage: grouper-api")
 
 
 def test_background():
     # type: () -> None
     bin_path = src_path("bin", "grouper-background")
-    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
-    assert out.startswith("usage: grouper-background")
+    out = subprocess.check_output([sys.executable, bin_path, "--help"], env=bin_env())
+    assert out.decode().startswith("usage: grouper-background")
 
 
 def test_ctl():
     # type: () -> None
     bin_path = src_path("bin", "grouper-ctl")
-    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
-    assert out.startswith("usage: grouper-ctl")
+    out = subprocess.check_output([sys.executable, bin_path, "--help"], env=bin_env())
+    assert out.decode().startswith("usage: grouper-ctl")
 
 
 def test_fe():
     # type: () -> None
     bin_path = src_path("bin", "grouper-fe")
-    out = subprocess.check_output([bin_path, "--help"], env=bin_env())
-    assert out.startswith("usage: grouper-fe")
+    out = subprocess.check_output([sys.executable, bin_path, "--help"], env=bin_env())
+    assert out.decode().startswith("usage: grouper-fe")

--- a/tools/run-dev
+++ b/tools/run-dev
@@ -4,6 +4,7 @@ import optparse
 import subprocess
 import os
 import signal
+import sys
 
 parser = optparse.OptionParser(r"""
 
@@ -46,6 +47,7 @@ os.setpgrp()
 settings = os.environ.get("GROUPER_SETTINGS", "config/dev.yaml")
 cmds = [
     [
+        sys.executable,
         "bin/grouper-ctl",
         "-vvc",
         settings,
@@ -56,9 +58,9 @@ cmds = [
         options.listen_port,
         options.user,
     ],
-    ["bin/grouper-fe", "--config={}".format(settings)],
-    ["bin/grouper-api", "--config={}".format(settings)],
-    ["bin/grouper-background", "--config={}".format(settings)],
+    [sys.executable, "bin/grouper-fe", "--config={}".format(settings)],
+    [sys.executable, "bin/grouper-api", "--config={}".format(settings)],
+    [sys.executable, "bin/grouper-background", "--config={}".format(settings)],
 ]
 for cmd in cmds:
     subprocess.Popen(cmd)
@@ -67,7 +69,7 @@ for cmd in cmds:
 try:
     signal.pause()
 except KeyboardInterrupt:
-    print "Terminating development environment"
+    print("Terminating development environment")
 finally:
     # Kill everything in our process group.
     os.killpg(0, signal.SIGTERM)


### PR DESCRIPTION
Integration tests, the bin_test test, and tools/run-dev spawn
various commands using the wrappers in bin.  However, those
wrappers indicate they should be run with /usr/bin/env python2.
This interferes with Python 3 support.

Always run these external programs using the current interpreter,
which ensures that the test suite and the development environment
stays consistent.