### PR TITLE
Add docstring for permission_aliases.py plugin

### DIFF
--- a/plugins/permission_aliases.py
+++ b/plugins/permission_aliases.py
@@ -1,3 +1,10 @@
+"""Sample plugin that defines a permission alias.
+
+This plugin makes the "owner" permission equivalent to having the "ssh" permission with argument
+"owner=<argument>" and the "sudo" permission with argument <argument>, where <argument> is the
+argument to the "owner" permission.
+"""
+
 from grouper.plugin.base import BasePlugin
 
 


### PR DESCRIPTION
What this plugin does is a little opaque, so add a docstring
explaining what's going on.