### PR TITLE
Escape more template parameters

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -338,7 +338,12 @@ class PublicKeyAddTagForm(Form):
 
 class UserPasswordForm(Form):
     name = StringField(
-        "Password name", [validators.DataRequired(), validators.Length(min=1, max=16)]
+        "Password name",
+        [
+            validators.DataRequired(),
+            validators.Length(min=1, max=16),
+            ValidateRegex(constants.TOKEN_NAME_VALIDATION),
+        ],
     )
     password = PasswordField("Password", [validators.DataRequired()])
 

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -52,7 +52,7 @@
 
                     <form class="navbar-form navbar-right" role="search" action="/search" method="get">
                         <div class="input-group search-input">
-                            <input type="text" class="form-control" placeholder="Search" name="query" id="query" value="{{search_query}}">
+                            <input type="text" class="form-control" placeholder="Search" name="query" id="query" value="{{search_query|e}}">
                             <div class="input-group-btn">
                                 <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
                             </div>
@@ -68,9 +68,9 @@
                         {% for alert in alerts %}
                             <div class="row">
                                 <div class="col-md-12">
-                                    <div class="alert alert-{{alert.severity}} alert-dismissable">
+                                    <div class="alert alert-{{alert.severity|e}} alert-dismissable">
                                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                        <strong>{{alert.heading}}</strong> {{alert.message|e}}
+                                        <strong>{{alert.heading|e}}</strong> {{alert.message|e}}
                                     </div>
                                 </div>
                             </div>

--- a/grouper/fe/templates/errors/generic.html
+++ b/grouper/fe/templates/errors/generic.html
@@ -5,10 +5,10 @@
 {% endblock %}
 
 {% block subheading %}
-{{ status_code }}: {{ message }}
+{{ status_code }}: {{ message|e }}
 {% endblock %}
 
 {% block content %}
 <p class="lead">{{ status_code }}</p>
-    <p>{{ message }}</p>
+    <p>{{ message|e }}</p>
 {% endblock %}

--- a/grouper/fe/templates/group-request-update.html
+++ b/grouper/fe/templates/group-request-update.html
@@ -34,7 +34,7 @@
                 <tr>
                     <td colspan="5">
                         <span class="pad-left">
-                            <strong>Reason:</strong> <em>{{update.reason}}</em>
+                            <strong>Reason:</strong> <em>{{update.reason|e}}</em>
                         </span>
                     </td>
                 </tr>

--- a/grouper/fe/templates/group-requests.html
+++ b/grouper/fe/templates/group-requests.html
@@ -62,7 +62,7 @@
                                 <span class="request-role">{{ ROLES[request.role] }}</span>
                                 <br/>
                                 <strong>Reason:</strong>
-                                <em class="request-reason">{{ request.reason }}</em>
+                                <em class="request-reason">{{ request.reason|e }}</em>
                             </div>
                         </td>
                     </tr>

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -184,7 +184,7 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>{{ shell }}</td>
+                        <td>{{ shell|e }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -546,9 +546,9 @@ enabled. Membership in this group is regularly reviewed.
     <div class="btn-group">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             {% if current %}
-                {{key|title}}: {{current}}
+                {{key|title|e}}: {{current|e}}
             {% else %}
-                {{key|title}}
+                {{key|title|e}}
             {% endif %}
             <span class="caret"></span>
         </button>

--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -46,7 +46,7 @@
                                 </a>
                             </dd>
                             <dt>Argument:</dt><dd>{{ request.argument }}</dd>
-                            <dt>Reason:</dt><dd>{{ comment.comment }}</dd>
+                            <dt>Reason:</dt><dd>{{ comment.comment|e }}</dd>
                         </span>
                     </td>
                 </tr>


### PR DESCRIPTION
Grouper was vulnerable to reflected XSS via the search field when
showing search results.  Fix that by escaping the search query on
the results page, and escape various other parameters that might
conceivably be under user control.  (A more comprehensive audit in
the future is probably indicated.)

Names of user passwords were not previously restricted to exclude
various HTML metacharacters.  Do that as well.