### PR TITLE
A new request form, that accepts parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN /etc/init.d/mysql start && mysql -e "\
  "
 
 RUN /etc/init.d/mysql start && \
- TRAVIS_PYTHON_VERSION=2.7 ci/setup.sh \
+ TRAVIS_PYTHON_VERSION=2.7 ci/setup.sh && \
  pip3 install isort mypy
 
 COPY . /app
@@ -52,5 +52,6 @@ RUN ( \
 
 EXPOSE 8888
 
+ENV PYTHONDONTWRITEBYTECODE=PLEASE
 ENV TRAVIS_PYTHON_VERSION 2.7
 CMD ["/bin/bash", "-c", "/etc/init.d/mysql start && exec /bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get install -y libmysqlclient-dev mysql-client mysql-server
-RUN apt-get install -y python2.7-dev python-pip gcc
+RUN apt-get install -y python2.7-dev python-pip python3-pip gcc
 RUN apt-get install -y chromium-driver
 RUN apt-get install -y procps unzip wget
 
@@ -32,8 +32,9 @@ RUN /etc/init.d/mysql start && mysql -e "\
  GRANT ALL ON *.* TO travis@localhost; \
  "
 
-ENV TRAVIS_PYTHON_VERSION 2.7
-RUN /etc/init.d/mysql start && ci/setup.sh
+RUN /etc/init.d/mysql start && \
+ TRAVIS_PYTHON_VERSION=2.7 ci/setup.sh \
+ pip3 install isort mypy
 
 COPY . /app
 ENV PYTHONPATH /app
@@ -51,4 +52,5 @@ RUN ( \
 
 EXPOSE 8888
 
+ENV TRAVIS_PYTHON_VERSION 2.7
 CMD ["/bin/bash", "-c", "/etc/init.d/mysql start && exec /bin/bash"]

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -47,6 +47,7 @@ common:
       - plugins.group_ownership_policy
       - plugins.permission_aliases
       - plugins.ssh_key_policy
+      - plugins.sample_permission
 
     # Name of permissions for which we restrict ownership calculations to
     # exclude wildcard ownership if any non-wildcard owners are avaiable.

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -27,7 +27,7 @@ def sync_db_command(args):
     from grouper.models.perf_profile import PerfProfile  # noqa: F401
     from grouper.models.user_token import UserToken  # noqa: F401
 
-    db_engine = get_db_engine(get_database_url(settings))
+    db_engine = get_db_engine(get_database_url(settings()))
     Model.metadata.create_all(db_engine)
 
     # Add some basic database structures we know we will need if they don't exist.
@@ -68,7 +68,7 @@ def sync_db_command(args):
 
         session.commit()
 
-    auditors_group_name = get_auditors_group_name(settings)
+    auditors_group_name = get_auditors_group_name(settings())
     auditors_group = Group.get(session, name=auditors_group_name)
     if not auditors_group:
         auditors_group = Group(

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -70,7 +70,7 @@ def ensure_valid_service_account_name(f):
 
 def make_session():
     # type: () -> Session
-    db_engine = get_db_engine(get_database_url(settings))
+    db_engine = get_db_engine(get_database_url(settings()))
     Session.configure(bind=db_engine)
     return Session()
 

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -238,18 +238,18 @@ class GroupPermissionRequestTextForm(Form):
     argument_type = HiddenField(default="text")
 
 
-_argument_validators = [
-    validators.DataRequired(),
-    validators.Length(min=0, max=64),
-    ValidateRegex(constants.ARGUMENT_VALIDATION),
-]
-
-
 class PermissionRequestForm(Form):
     # Caller will add <select> field choices.
     group_name = SelectField("Group", [validators.DataRequired()])
     permission_name = SelectField("Permission", [validators.DataRequired()])
-    argument = StringField("Argument", _argument_validators)
+    argument = StringField(
+        "Argument",
+        [
+            validators.DataRequired(),
+            validators.Length(min=0, max=64),
+            ValidateRegex(constants.ARGUMENT_VALIDATION),
+        ],
+    )
     reason = TextAreaField("Reason", [validators.DataRequired()])
 
 

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -238,6 +238,21 @@ class GroupPermissionRequestTextForm(Form):
     argument_type = HiddenField(default="text")
 
 
+_argument_validators = [
+    validators.DataRequired(),
+    validators.Length(min=0, max=64),
+    ValidateRegex(constants.ARGUMENT_VALIDATION),
+]
+
+
+class PermissionRequestForm(Form):
+    # Caller will add <select> field choices.
+    group_name = SelectField("Group", [validators.DataRequired()])
+    permission_name = SelectField("Permission", [validators.DataRequired()])
+    argument = StringField("Argument", _argument_validators)
+    reason = TextAreaField("Reason", [validators.DataRequired()])
+
+
 class PermissionRequestsForm(Form):
     offset = IntegerField(default=0)
     limit = IntegerField(default=100, validators=[validators.NumberRange(min=100, max=9000)])

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -1,0 +1,129 @@
+import json
+
+from grouper import permissions
+from grouper.audit import UserNotAuditor
+from grouper.fe.forms import (
+    GroupPermissionRequestDropdownForm,
+    GroupPermissionRequestTextForm,
+    PermissionRequestForm,
+)
+from grouper.fe.settings import settings
+from grouper.fe.util import Alert, GrouperHandler
+from grouper.models.group import Group
+from grouper.permissions import get_grantable_permissions, get_permission
+from grouper.user_group import get_groups_by_user
+from tornado.web import HTTPError
+
+
+def _build_form(request, data):
+    session = request.session
+    current_user = request.current_user
+
+    group_names = {g.groupname for g, e in get_groups_by_user(session, current_user)}
+    args_by_perm = get_grantable_permissions(session, settings.restricted_ownership_permissions)
+    permission_names = {p for p in args_by_perm}
+
+    group_param = request.get_argument('group', None)
+    if group_param is not None:
+        if group_param not in group_names:
+            raise HTTPError(
+                status_code=404, reason='the group name in the URL is not one you belong to'
+            )
+        group_choices = [group_param]
+    else:
+        group_choices = [""] + sorted(group_names)
+
+    permission_param = request.get_argument('permission', None)
+    if permission_param is not None:
+        if permission_param not in permission_names:
+            raise HTTPError(
+                status_code=404, reason='an unrecognized permission is specified in the URL'
+            )
+        permission_choices = [permission_param]
+    else:
+        permission_choices = [""] + sorted(args_by_perm.keys())
+
+    form = PermissionRequestForm(data)
+    form.group_name.choices = [(c, c) for c in group_choices]
+    form.permission_name.choices = [(c, c) for c in permission_choices]
+    return form, args_by_perm
+
+
+class PermissionRequest(GrouperHandler):
+    def get(self):
+        form, args_by_perm = _build_form(self, None)
+        self.render(
+            "permission-request.html",
+            args_by_perm_json=json.dumps(args_by_perm),
+            form=form,
+            uri=self.request.uri,
+        )
+
+    def post(self):
+        form, args_by_perm = _build_form(self, self.request.arguments)
+
+        if not form.validate():
+            return self.render(
+                "permission-request.html",
+                args_by_perm_json=json.dumps(args_by_perm),
+                form=form,
+                alerts=self.get_form_alerts(form.errors),
+            )
+
+        group = self.session.query(Group).filter(Group.groupname == form.group_name.data)
+        assert group is not None, "our prefilled permission should exist or we have problems"
+
+        permission = get_permission(self.session, form.permission_name.data)
+        assert (permission is not None) and (
+            permission.name in args_by_perm
+        ), "our prefilled permission should be in the form or we have problems"
+
+        # save off request
+        try:
+            request = permissions.create_request(
+                self.session,
+                self.current_user,
+                group,
+                permission,
+                form.argument.data,
+                form.reason.data,
+            )
+        except permissions.RequestAlreadyGranted:
+            alerts = [Alert("danger", "This group already has this permission and argument.")]
+        except permissions.RequestAlreadyExists:
+            alerts = [
+                Alert(
+                    "danger",
+                    "Request for permission and argument already exists, please wait patiently.",
+                )
+            ]
+        except permissions.NoOwnersAvailable:
+            self.log_message(
+                "prefilled perm+arg have no owner",
+                group_name=group.name,
+                permission_name=permission.name,
+                argument=form.argument.data,
+            )
+            alerts = [
+                Alert(
+                    "danger",
+                    "No owners available for requested permission and argument."
+                    " If this error persists please contact an adminstrator.",
+                )
+            ]
+        except UserNotAuditor as e:
+            alerts = [Alert("danger", str(e))]
+        else:
+            alerts = None
+
+        if alerts:
+            return self.render(
+                "group-permission-request.html",
+                dropdown_form=dropdown_form,
+                text_form=text_form,
+                group=group,
+                args_by_perm_json=json.dumps(args_by_perm),
+                alerts=alerts,
+            )
+        else:
+            return self.redirect("/permissions/requests/{}".format(request.id))

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -119,7 +119,7 @@ class PermissionRequest(GrouperHandler):
 
         group_names = {g.groupname for g, e in get_groups_by_user(session, current_user)}
         args_by_perm = get_grantable_permissions(
-            session, settings.restricted_ownership_permissions
+            session, settings().restricted_ownership_permissions
         )
         permission_names = {p for p in args_by_perm}
 

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -1,18 +1,15 @@
 import json
 
+from tornado.web import HTTPError
+
 from grouper import permissions
 from grouper.audit import UserNotAuditor
-from grouper.fe.forms import (
-    GroupPermissionRequestDropdownForm,
-    GroupPermissionRequestTextForm,
-    PermissionRequestForm,
-)
+from grouper.fe.forms import PermissionRequestForm
 from grouper.fe.settings import settings
 from grouper.fe.util import Alert, GrouperHandler
 from grouper.models.group import Group
 from grouper.permissions import get_grantable_permissions, get_permission
 from grouper.user_group import get_groups_by_user
-from tornado.web import HTTPError
 
 
 def _build_form(request, data):
@@ -36,31 +33,31 @@ def _build_form(request, data):
     args_by_perm = get_grantable_permissions(session, settings.restricted_ownership_permissions)
     permission_names = {p for p in args_by_perm}
 
-    group_param = request.get_argument('group', None)
+    group_param = request.get_argument("group", None)
     if group_param is not None:
         if group_param not in group_names:
             raise HTTPError(
-                status_code=404, reason='the group name in the URL is not one you belong to'
+                status_code=404, reason="the group name in the URL is not one you belong to"
             )
         form.group_name.choices = pairs([group_param])
-        form.group_name.render_kw = {'readonly': 'readonly'}
+        form.group_name.render_kw = {"readonly": "readonly"}
     else:
         form.group_name.choices = pairs([""] + sorted(group_names))
 
-    permission_param = request.get_argument('permission', None)
+    permission_param = request.get_argument("permission", None)
     if permission_param is not None:
         if permission_param not in permission_names:
             raise HTTPError(
-                status_code=404, reason='an unrecognized permission is specified in the URL'
+                status_code=404, reason="an unrecognized permission is specified in the URL"
             )
         form.permission_name.choices = pairs([permission_param])
-        form.permission_name.render_kw = {'readonly': 'readonly'}
+        form.permission_name.render_kw = {"readonly": "readonly"}
     else:
         form.permission_name.choices = pairs([""] + sorted(permission_names))
 
-    argument_param = request.get_argument('argument', '')
+    argument_param = request.get_argument("argument", "")
     if argument_param:
-        form.argument.render_kw = {'readonly': 'readonly'}
+        form.argument.render_kw = {"readonly": "readonly"}
         form.argument.data = argument_param
 
     return form, args_by_perm

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -70,7 +70,7 @@ class PermissionRequest(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors),
             )
 
-        group = self.session.query(Group).filter(Group.groupname == form.group_name.data)
+        group = self.session.query(Group).filter(Group.groupname == form.group_name.data).first()
         assert group is not None, "our prefilled permission should exist or we have problems"
 
         permission = get_permission(self.session, form.permission_name.data)

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -37,6 +37,7 @@ from grouper.fe.handlers.perf_profile import PerfProfile
 from grouper.fe.handlers.permission_disable import PermissionDisable
 from grouper.fe.handlers.permission_disable_auditing import PermissionDisableAuditing
 from grouper.fe.handlers.permission_enable_auditing import PermissionEnableAuditing
+from grouper.fe.handlers.permission_request import PermissionRequest
 from grouper.fe.handlers.permission_view import PermissionView
 from grouper.fe.handlers.permissions_create import PermissionsCreate
 from grouper.fe.handlers.permissions_grant import PermissionsGrant
@@ -81,6 +82,7 @@ HANDLERS = [
     (r"/audits/create", AuditsCreate),
     (r"/groups", GroupsView),
     (r"/permissions/create", PermissionsCreate),
+    (r"/permissions/request", PermissionRequest),
     (r"/permissions/requests", PermissionsRequests),
     (r"/permissions/requests/(?P<request_id>[0-9]+)", PermissionsRequestUpdate),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), PermissionView),

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -187,6 +187,82 @@ $(function () {
         });
     }
 
+    $('#permission-request').each(function() {
+        $form = $(this);
+        var args_by_perm = $form.data('permission');
+        console.log(args_by_perm);
+
+        var $argument_div = $form.find('.form-group-argument');
+        var $reason_div = $form.find('.form-group-reason');
+
+        var $group_input = $form.find('#group_name');
+        var $permission_input = $form.find('#permission_name');
+        var $argument_input = $form.find('#argument');
+
+        // Supplement the standard <input> field with an adjacent
+        // dropdown that we can fill with permission-specific options.
+        // We use careful enabling and disabling, below, to make sure
+        // only one of the inputs is eligible to be included in the
+        // submitted form.
+        var $argument_select = $("<select>", {
+            "name": $argument_input.attr('name'),
+            "class": $argument_input.attr('class'),
+        }).insertAfter($argument_input);
+
+        // Helpfully gray out drop-downs that have arrived with only one
+        // option, meaning that they have been specified in the URL.
+        function disable_if_only_one_option($input) {
+            if ($input.find('option').size() == 1)
+                $input.prop('disabled', true);
+        }
+        disable_if_only_one_option($group_input);
+        disable_if_only_one_option($permission_input);
+
+        function update() {
+            $permission = $permission_input.val()
+
+            if ($permission === "") {
+                $argument_div.hide();
+                $reason_div.hide();
+                return
+            }
+
+            $argument_div.show();
+            $reason_div.show();
+
+            var args = args_by_perm[$permission];
+
+            if (args.length == 1 && args[0] == "*") {
+                $argument_input.show();
+                $argument_select.hide();
+
+                $argument_input.prop('disabled', false);
+                $argument_select.prop('disabled', true);
+            } else {
+                $argument_input.hide();
+                $argument_select.show();
+
+                $argument_input.prop('disabled', true);
+                $argument_select.prop('disabled', false);
+
+                $argument_select.empty();
+                $.each(args, function(index, arg) {
+                    var option = $("<option></option>").attr("value", arg).text(arg);
+                    $argument_select.append(option);
+                });
+            }
+        }
+
+        update();
+
+        $permission_input.on('change', update);
+
+        $form.on('submit', function() {
+            // Re-enable possibly disabled inputs, so they get transmitted.
+            $group_input.prop('disabled', false);
+            $permission_input.prop('disabled', false);
+        });
+    });
 
     $("#clickthruModal #agree-clickthru-btn").on("click", function(e) {
         $(".join-group-form .clickthru-checkbox").prop("checked", true);

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -190,7 +190,6 @@ $(function () {
     $('#permission-request').each(function() {
         $form = $(this);
         var args_by_perm = $form.data('permission');
-        console.log(args_by_perm);
 
         var $argument_div = $form.find('.form-group-argument');
         var $reason_div = $form.find('.form-group-reason');
@@ -199,24 +198,15 @@ $(function () {
         var $permission_input = $form.find('#permission_name');
         var $argument_input = $form.find('#argument');
 
-        // Supplement the standard <input> field with an adjacent
-        // dropdown that we can fill with permission-specific options.
-        // We use careful enabling and disabling, below, to make sure
-        // only one of the inputs is eligible to be included in the
-        // submitted form.
+        // Supplement the <input> "argument" field with an adjacent
+        // "argument" dropdown that we can fill with permission-specific
+        // options.  We use renaming, below, to make sure only one of
+        // the two inputs is actually named "argument" when the form
+        // submits.
         var $argument_select = $("<select>", {
             "name": $argument_input.attr('name'),
             "class": $argument_input.attr('class'),
         }).insertAfter($argument_input);
-
-        // Helpfully gray out drop-downs that have arrived with only one
-        // option, meaning that they have been specified in the URL.
-        function disable_if_only_one_option($input) {
-            if ($input.find('option').size() == 1)
-                $input.prop('disabled', true);
-        }
-        disable_if_only_one_option($group_input);
-        disable_if_only_one_option($permission_input);
 
         function update() {
             $permission = $permission_input.val()
@@ -234,16 +224,16 @@ $(function () {
 
             if (args.length == 1 && args[0] == "*") {
                 $argument_input.show();
-                $argument_select.hide();
+                $argument_input.prop('name', 'argument');
 
-                $argument_input.prop('disabled', false);
-                $argument_select.prop('disabled', true);
+                $argument_select.hide();
+                $argument_select.prop('name', 'ignore');
             } else {
                 $argument_input.hide();
-                $argument_select.show();
+                $argument_input.prop('name', 'ignore');
 
-                $argument_input.prop('disabled', true);
-                $argument_select.prop('disabled', false);
+                $argument_select.show();
+                $argument_select.prop('name', 'argument');
 
                 $argument_select.empty();
                 $.each(args, function(index, arg) {
@@ -256,12 +246,6 @@ $(function () {
         update();
 
         $permission_input.on('change', update);
-
-        $form.on('submit', function() {
-            // Re-enable possibly disabled inputs, so they get transmitted.
-            $group_input.prop('disabled', false);
-            $permission_input.prop('disabled', false);
-        });
     });
 
     $("#clickthruModal #agree-clickthru-btn").on("click", function(e) {

--- a/grouper/fe/templates/permission-request.html
+++ b/grouper/fe/templates/permission-request.html
@@ -25,7 +25,7 @@
                 {{ form_field(form.permission_name, 3, 8, class_="form-control") }}
                 {{ form_field(form.argument, 3, 8, class_="form-control") }}
                 {{ form_field(form.reason, 3, 8, class_="form-control") }}
-                {{ xsrf_form() }}
+                {{ xsrf_form() | safe }}
                 <div class="col-sm-offset-3 col-sm-4">
                     <button type="submit" class="btn btn-primary">Submit</button>
                 </div>

--- a/grouper/fe/templates/permission-request.html
+++ b/grouper/fe/templates/permission-request.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% from 'macros/ui.html' import form_field -%}
+
+{% block subtitle %} request permission{% endblock %}
+
+{% block heading %}
+    <a href="/permissions">Permissions</a>
+{% endblock %}
+
+{% block subheading %}
+    Request Permission
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Request Permission</h3>
+        </div>
+
+        <form id="permission-request" class="form-horizontal" role="form"
+              method="post" action="{{ uri }}"
+              {{ { "data-permission" : args_by_perm_json } | xmlattr }}>
+            {{ form_field(form.group_name, 3, 8, class_="form-control") }}
+            {{ form_field(form.permission_name, 3, 8, class_="form-control") }}
+            {{ form_field(form.argument, 3, 8, class_="form-control") }}
+            {{ form_field(form.reason, 3, 8, class_="form-control") }}
+            {{ xsrf_form() }}
+            <div class="col-sm-offset-3 col-sm-4">
+                <button type="submit" class="btn btn-primary">Submit</button>
+            </div>
+        </form>
+
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/permission-request.html
+++ b/grouper/fe/templates/permission-request.html
@@ -17,20 +17,29 @@
         <div class="panel-heading">
             <h3 class="panel-title">Request Permission</h3>
         </div>
-
-        <form id="permission-request" class="form-horizontal" role="form"
-              method="post" action="{{ uri }}"
-              {{ { "data-permission" : args_by_perm_json } | xmlattr }}>
-            {{ form_field(form.group_name, 3, 8, class_="form-control") }}
-            {{ form_field(form.permission_name, 3, 8, class_="form-control") }}
-            {{ form_field(form.argument, 3, 8, class_="form-control") }}
-            {{ form_field(form.reason, 3, 8, class_="form-control") }}
-            {{ xsrf_form() }}
-            <div class="col-sm-offset-3 col-sm-4">
-                <button type="submit" class="btn btn-primary">Submit</button>
-            </div>
-        </form>
-
+        <div class="panel-body">
+            <form id="permission-request" class="form-horizontal" role="form"
+                  method="post" action="{{ uri }}"
+                  {{ { "data-permission" : args_by_perm_json } | xmlattr }}>
+                {{ form_field(form.group_name, 3, 8, class_="form-control") }}
+                {{ form_field(form.permission_name, 3, 8, class_="form-control") }}
+                {{ form_field(form.argument, 3, 8, class_="form-control") }}
+                {{ form_field(form.reason, 3, 8, class_="form-control") }}
+                {{ xsrf_form() }}
+                <div class="col-sm-offset-3 col-sm-4">
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
+
+<p>
+    <b>Hint.</b>
+    You can create links to this form
+    that automatically fill in the values of Group, Permission, and Argument
+    by adding the query parameters “group=” “permission=” and “argument=”
+    to the URL.
+</p>
+
 {% endblock %}

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -28,6 +28,9 @@
             </button>
         {% endif %}
     {% endif %}
+    <a class="btn btn-warning" href="/permissions/request?permission={{ permission.name }}">
+        <i class="fa fa-plus"></i> Request this permission
+    </a>
 {% endblock %}
 
 {% block content %}

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -1,0 +1,51 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.permission import PermissionPage
+from itests.pages.permission_request import PermissionRequestPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_requesting_permission(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+
+    with setup.transaction():
+        setup.create_group("dev-infra")
+        setup.create_group("front-end")
+        setup.create_permission(name="git.repo.read")
+        setup.create_user("brhodes@a.co")
+
+        setup.add_user_to_group("brhodes@a.co", "front-end")
+        setup.grant_permission_to_group("grouper.permission.grant", "git.repo.read", "dev-infra")
+
+    with frontend_server(tmpdir, "brhodes@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/git.repo.read"))
+
+        page1 = PermissionPage(browser)
+        assert page1.heading == "Permissions"
+        assert page1.subheading == "git.repo.read"
+        page1.button_to_request_this_permission.click()
+
+        page2 = PermissionRequestPage(browser)
+        assert page2.heading == "Permissions"
+        assert page2.subheading == "Request Permission"
+        assert page2.get_option_values("group_name") == [u'', u'front-end']
+        assert page2.get_option_values("permission_name") == [u'git.repo.read']
+
+        page2.set_select_value("group_name", "front-end")
+        page2.fill_field('argument', 'server')
+        page2.fill_field('reason', 'So they can do development')
+        page2.submit_request()
+
+        text = ' '.join(browser.find_element_by_tag_name('body').text.split())
+        assert browser.current_url.endswith('/permissions/requests/1')
+        assert 'brhodes@a.co pending' in text
+        assert (
+            'Group: front-end Permission: git.repo.read Argument: server '
+            'Reason: So they can do development Waiting for approval' in text
+        )

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING
 
+from grouper.models.permission import Permission
+from grouper.models.permission_request import PermissionRequest
+from grouper.models.permission_request_status_change import PermissionRequestStatusChange
 from itests.pages.permission import PermissionPage
 from itests.pages.permission_request import PermissionRequestPage
 from itests.setup import frontend_server
@@ -49,3 +52,15 @@ def test_requesting_permission(tmpdir, setup, browser):
             'Group: front-end Permission: git.repo.read Argument: server '
             'Reason: So they can do development Waiting for approval' in text
         )
+
+    # TODO: the subsequent test "test_pending_inbound_requests" fails in
+    # the MySQL version of the test suite if the request is not deleted.
+    # Someone should at some point work out the test isolation story.
+    setup.session.commit()
+    p = Permission.get(setup.session, name='git.repo.read')
+    r = PermissionRequest.get(setup.session, permission=p)
+    h = PermissionRequestStatusChange.get(setup.session, request=r)
+    h.delete(setup.session)
+    r.delete(setup.session)
+    p.delete(setup.session)
+    setup.session.commit()

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -37,27 +37,27 @@ def test_requesting_permission(tmpdir, setup, browser):
         page2 = PermissionRequestPage(browser)
         assert page2.heading == "Permissions"
         assert page2.subheading == "Request Permission"
-        assert page2.get_option_values("group_name") == [u'', u'front-end']
-        assert page2.get_option_values("permission_name") == [u'git.repo.read']
+        assert page2.get_option_values("group_name") == [u"", u"front-end"]
+        assert page2.get_option_values("permission_name") == [u"git.repo.read"]
 
         page2.set_select_value("group_name", "front-end")
-        page2.fill_field('argument', 'server')
-        page2.fill_field('reason', 'So they can do development')
+        page2.fill_field("argument", "server")
+        page2.fill_field("reason", "So they can do development")
         page2.submit_request()
 
-        text = ' '.join(browser.find_element_by_tag_name('body').text.split())
-        assert browser.current_url.endswith('/permissions/requests/1')
-        assert 'brhodes@a.co pending' in text
+        text = " ".join(browser.find_element_by_tag_name("body").text.split())
+        assert browser.current_url.endswith("/permissions/requests/1")
+        assert "brhodes@a.co pending" in text
         assert (
-            'Group: front-end Permission: git.repo.read Argument: server '
-            'Reason: So they can do development Waiting for approval' in text
+            "Group: front-end Permission: git.repo.read Argument: server "
+            "Reason: So they can do development Waiting for approval" in text
         )
 
     # TODO: the subsequent test "test_pending_inbound_requests" fails in
     # the MySQL version of the test suite if the request is not deleted.
     # Someone should at some point work out the test isolation story.
     setup.session.commit()
-    p = Permission.get(setup.session, name='git.repo.read')
+    p = Permission.get(setup.session, name="git.repo.read")
     r = PermissionRequest.get(setup.session, permission=p)
     h = PermissionRequestStatusChange.get(setup.session, request=r)
     h.delete(setup.session)

--- a/itests/pages/permission.py
+++ b/itests/pages/permission.py
@@ -1,0 +1,8 @@
+from itests.pages.base import BaseElement, BasePage
+
+
+class PermissionPage(BasePage):
+    @property
+    def button_to_request_this_permission(self):
+        buttons = self.find_elements_by_class_name("btn")
+        return next(b for b in buttons if b.text == u'Request this permission')

--- a/itests/pages/permission.py
+++ b/itests/pages/permission.py
@@ -5,4 +5,4 @@ class PermissionPage(BasePage):
     @property
     def button_to_request_this_permission(self):
         buttons = self.find_elements_by_class_name("btn")
-        return next(b for b in buttons if b.text == u'Request this permission')
+        return next(b for b in buttons if b.text == u"Request this permission")

--- a/itests/pages/permission.py
+++ b/itests/pages/permission.py
@@ -1,4 +1,4 @@
-from itests.pages.base import BaseElement, BasePage
+from itests.pages.base import BasePage
 
 
 class PermissionPage(BasePage):

--- a/itests/pages/permission_request.py
+++ b/itests/pages/permission_request.py
@@ -12,7 +12,7 @@ class PermissionRequestPage(BasePage):
     def get_option_values(self, id):
         # type: (str) -> List[str]
         select = Select(self.find_element_by_id(id))
-        return [option.get_attribute('value') for option in select.options]
+        return [option.get_attribute("value") for option in select.options]
 
     def set_select_value(self, id, value):
         # type: (str, str) -> None
@@ -23,4 +23,4 @@ class PermissionRequestPage(BasePage):
         self.find_element_by_id(id).send_keys(value)
 
     def submit_request(self):
-        self.find_element_by_id('argument').send_keys(Keys.ENTER)
+        self.find_element_by_id("argument").send_keys(Keys.ENTER)

--- a/itests/pages/permission_request.py
+++ b/itests/pages/permission_request.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.base import BasePage
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.ui import Select
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+class PermissionRequestPage(BasePage):
+    def get_option_values(self, id):
+        # type: (str) -> List[str]
+        select = Select(self.find_element_by_id(id))
+        return [option.get_attribute('value') for option in select.options]
+
+    def set_select_value(self, id, value):
+        # type: (str, str) -> None
+        select = Select(self.find_element_by_id(id))
+        select.select_by_value(value)
+
+    def fill_field(self, id, value):
+        self.find_element_by_id(id).send_keys(value)
+
+    def submit_request(self):
+        self.find_element_by_id('argument').send_keys(Keys.ENTER)

--- a/itests/pages/permission_request.py
+++ b/itests/pages/permission_request.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 
-from itests.pages.base import BasePage
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
+
+from itests.pages.base import BasePage
 
 if TYPE_CHECKING:
     from typing import List

--- a/plugins/sample_permission.py
+++ b/plugins/sample_permission.py
@@ -1,17 +1,9 @@
 from __future__ import absolute_import, print_function
 
-import json
-import logging
-
-from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import yaml
-
 from grouper.models.group import Group
-from grouper.models.permission import Permission
 from grouper.plugin.base import BasePlugin
-
 
 if TYPE_CHECKING:
     from typing import Dict, List
@@ -22,9 +14,12 @@ class PermissionRequest(BasePlugin):
     def get_owner_by_arg_by_perm(self, session):
         # type: (Session) -> Dict[str, Dict[str, List[Group]]]
         """Return a map of permissions to owners based on external information."""
+        grouper_administrators = (
+            session.query(Group).filter(Group.name == "grouper-administrators").first()
+        )
         return {
-            'sample.permission': {
-                'Option A': ['grouper-administrators'],
-                'Option B': ['grouper-administrators'],
+            "sample.permission": {
+                "Option A": [grouper_administrators],
+                "Option B": [grouper_administrators],
             }
         }

--- a/plugins/sample_permission.py
+++ b/plugins/sample_permission.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, print_function
+
+import json
+import logging
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+import yaml
+
+from grouper.models.group import Group
+from grouper.models.permission import Permission
+from grouper.plugin.base import BasePlugin
+
+
+if TYPE_CHECKING:
+    from typing import Dict, List
+    from sqlalchemy.orm import Session
+
+
+class PermissionRequest(BasePlugin):
+    def get_owner_by_arg_by_perm(self, session):
+        # type: (Session) -> Dict[str, Dict[str, List[Group]]]
+        """Return a map of permissions to owners based on external information."""
+        return {
+            'sample.permission': {
+                'Option A': ['grouper-administrators'],
+                'Option B': ['grouper-administrators'],
+            }
+        }


### PR DESCRIPTION
This new form can be blank, or pre-populated with URLs like:
```
/permissions/request
/permissions/request?permission=sample.permission
/permissions/request?group=grouper-auditors
/permissions/request?group=grouper-auditors&permission=sample.permission
```
Once battle tested, this form can replace the grungy pair of forms implemented in
`group_permission_request.py` by having that old URL redirect to this one but
with `?group=` already specified.

Two directions will be possible once this lands:
1. Permissions can now gain an "Request" button, like groups already have.
2. We can additionally add an `argument=` field here, which will be of vast help
   to folks supporting things like repositories, since when someone says "how
   do I get access to this repository?" they can be given a URL that has not
   only the permission but the argument filled in. No more having to reject
   multiple requests until they finally spell the argument correctly! Joy!