### PR TITLE
Bump PyYAML version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annex==0.5.0
 Jinja2==2.7.3
 MarkupSafe==0.23
-PyYAML==3.12
+PyYAML==5.1
 SQLAlchemy==1.3.2
 WTForms==2.1
 backports.ssl-match-hostname==3.5.0.1


### PR DESCRIPTION
This truly doesn't matter for this code, since literally the only
thing we call is safe_load and then check for an exception, but it
will make the GitHub warning about security vulnerabilities in
dependencies go away.