### PR TITLE
Include permissions in Grouper searches

### DIFF
--- a/grouper/fe/templates/search.html
+++ b/grouper/fe/templates/search.html
@@ -32,6 +32,8 @@
                     <td>
                         {% if result.type == "Group" %}
                             <a href="/groups/{{result.name}}">{{result.name}}</a>
+                        {% elif result.type == "Permission" %}
+                            <a href="/permissions/{{result.name}}">{{result.name}}</a>
                         {% elif result.type == "User" %}
                             <a href="/users/{{result.name}}">{{result.name}}</a>
                         {% else %}


### PR DESCRIPTION
Given how many repository permissions I used to manage,
and the difficultly of scrolling through pages of permissions to
finally find them, having them available in search will be a big
time savings.