### PR TITLE
Turn request users, groups, permissions into links

### DIFF
--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -25,7 +25,11 @@
         <tbody>
             {% for change_status, comment in change_comment_list %}
                 <tr>
-                    <td>{{ change_status.user.name }}</td>
+                    <td>
+                        <a href="/users/{{ change_status.user.name }}">
+                            {{ change_status.user.name }}
+                        </a>
+                    </td>
                     <td>{{ change_status.from_status|default("", True) }}</td>
                     <td>{{ change_status.to_status }}</td>
                     <td>{{ change_status.change_at|print_date }}</td>

--- a/grouper/fe/templates/permission-requests.html
+++ b/grouper/fe/templates/permission-requests.html
@@ -46,10 +46,15 @@
                         </a>
                     </td>
                     <td class="request-requested">
-                        {{ request.permission.name }}, {{ request.argument }}
+                        <a href="/permissions/{{ request.permission.name }}">{{ request.permission.name }}</a>,
+                        {{ request.argument }}
                     </td>
 		    <td class="request-approvers">
-		        {{ ", ".join(granters[request.permission.name][request.argument]) }}
+                        {% for granter in granters[request.permission.name][request.argument] %}
+                            <a href="/groups/{{ granter }}">
+                                {{ granter }}{% if not loop.last %},{% endif %}
+                            </a>
+                        {% endfor %}
 		    </td>
                     <td class="request-status">{{ request.status }}</td>
                     <td class="request-requested-at">{{ request.requested_at | print_date }}</td>
@@ -61,10 +66,16 @@
                     <td colspan="4">
                         <dl class="dl-horizontal no-margin-bottom">
                             <dt>Group:</dt>
-			    <dd class="request-group">{{ request.group.name }}</dd>
+			    <dd class="request-group">
+                                <a href="/groups/{{ request.group.name }}">
+                                    {{ request.group.name }}
+                                </a>
+                            </dd>
                             <dt>Who:</dt>
                             <dd class="request-who">
-                                {{ status_change.user.name  }}
+                                <a href="/users/{{ status_change.user.name }}">
+                                    {{ status_change.user.name }}
+                                </a>
                                 ({{ status_change.change_at|long_ago_str }})
                             </dd>
                             <dt>Reason:</dt>


### PR DESCRIPTION
When scrolling through permission requests, or when looking at a single
request, it can be helpful to go look at the user or group in question.
Turning every name into a link will make such investigation easier.