### PR TITLE
Be consistent about using current_user attribute

### DIFF
--- a/grouper/app.py
+++ b/grouper/app.py
@@ -26,9 +26,8 @@ class GrouperApplication(Application):
         if handler.request.uri == "/debug/stats":
             log_method = access_log.debug
 
-        user = handler.get_current_user()
-        if user:
-            username = user.username
+        if handler.current_user:
+            username = handler.current_user.username
         else:
             username = "-"
 

--- a/grouper/fe/handlers/audits_complete.py
+++ b/grouper/fe/handlers/audits_complete.py
@@ -13,15 +13,14 @@ from grouper.user_permissions import user_has_permission
 
 class AuditsComplete(GrouperHandler):
     def post(self, audit_id):
-        user = self.get_current_user()
-        if not user_has_permission(self.session, user, PERMISSION_AUDITOR):
+        if not user_has_permission(self.session, self.current_user, PERMISSION_AUDITOR):
             return self.forbidden()
 
         audit = self.session.query(Audit).filter(Audit.id == audit_id).one()
 
         # only owners can complete
         owner_ids = {member.id for member in itervalues(audit.group.my_owners())}
-        if user.id not in owner_ids:
+        if self.current_user.id not in owner_ids:
             return self.forbidden()
 
         if audit.complete:
@@ -36,7 +35,7 @@ class AuditsComplete(GrouperHandler):
             if member.id in edges:
                 # You can only approve yourself (otherwise you can remove yourself
                 # from the group and leave it ownerless)
-                if member.member.id == user.id:
+                if member.member.id == self.current_user.id:
                     member.status = "approved"
                 elif edges[member.id] in AUDIT_STATUS_CHOICES:
                     member.status = edges[member.id]

--- a/grouper/fe/handlers/audits_create.py
+++ b/grouper/fe/handlers/audits_create.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 from six import itervalues
 from sqlalchemy.exc import IntegrityError
@@ -15,24 +16,27 @@ from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES
 from grouper.user_permissions import user_has_permission
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class AuditsCreate(GrouperHandler):
-    def get(self):
-        user = self.get_current_user()
-        if not user_has_permission(self.session, user, AUDIT_MANAGER):
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        if not user_has_permission(self.session, self.current_user, AUDIT_MANAGER):
             return self.forbidden()
 
         self.render("audit-create.html", form=AuditCreateForm())
 
-    def post(self):
+    def post(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         form = AuditCreateForm(self.request.arguments)
         if not form.validate():
             return self.render(
                 "audit-create.html", form=form, alerts=self.get_form_alerts(form.errors)
             )
 
-        user = self.get_current_user()
-        if not user_has_permission(self.session, user, AUDIT_MANAGER):
+        if not user_has_permission(self.session, self.current_user, AUDIT_MANAGER):
             return self.forbidden()
 
         # Step 1, detect if there are non-completed audits and fail if so.

--- a/grouper/fe/handlers/audits_view.py
+++ b/grouper/fe/handlers/audits_view.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from grouper.audit import get_audits
 from grouper.constants import AUDIT_MANAGER, AUDIT_VIEWER
 from grouper.fe.util import GrouperHandler
@@ -5,13 +7,16 @@ from grouper.models.audit import Audit
 from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.user_permissions import user_has_permission
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class AuditsView(GrouperHandler):
-    def get(self):
-        user = self.get_current_user()
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         if not (
-            user_has_permission(self.session, user, AUDIT_VIEWER)
-            or user_has_permission(self.session, user, AUDIT_MANAGER)
+            user_has_permission(self.session, self.current_user, AUDIT_VIEWER)
+            or user_has_permission(self.session, self.current_user, AUDIT_MANAGER)
         ):
             return self.forbidden()
 
@@ -28,7 +33,7 @@ class AuditsView(GrouperHandler):
         audits = audits.offset(offset).limit(limit).all()
 
         open_audits = self.session.query(Audit).filter(Audit.complete == False).all()
-        can_start = user_has_permission(self.session, user, AUDIT_MANAGER)
+        can_start = user_has_permission(self.session, self.current_user, AUDIT_MANAGER)
 
         # FIXME(herb): make limit selected from ui
         audit_log_entries = AuditLog.get_entries(

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from sqlalchemy.exc import IntegrityError
 
 from grouper.fe.forms import GroupCreateForm
@@ -5,9 +7,13 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class GroupsView(GrouperHandler):
-    def get(self):
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         self.handle_refresh()
         offset = int(self.get_argument("offset", 0))
         limit = int(self.get_argument("limit", 100))
@@ -45,14 +51,13 @@ class GroupsView(GrouperHandler):
             enabled=enabled,
         )
 
-    def post(self):
+    def post(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
         form = GroupCreateForm(self.request.arguments)
         if not form.validate():
             return self.render(
                 "group-create.html", form=form, alerts=self.get_form_alerts(form.errors)
             )
-
-        user = self.get_current_user()
 
         group = Group(
             groupname=form.data["groupname"],
@@ -70,7 +75,14 @@ class GroupsView(GrouperHandler):
                 "group-create.html", form=form, alerts=self.get_form_alerts(form.errors)
             )
 
-        group.add_member(user, user, "Group Creator", "actioned", None, form.data["creatorrole"])
+        group.add_member(
+            self.current_user,
+            self.current_user,
+            "Group Creator",
+            "actioned",
+            None,
+            form.data["creatorrole"],
+        )
         self.session.commit()
 
         AuditLog.log(

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from six import itervalues
 from sqlalchemy import asc, or_
@@ -15,8 +16,14 @@ from grouper.models.group_edge import GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.models.user import User
+    from typing import Optional
+
 
 def user_has_permission(session, user, permission, argument=None):
+    # type: (Session, Optional[User], str, Optional[str]) -> bool
     """See if this user has a given permission/argument
 
     NOTE: only enabled permissions are considered.
@@ -32,6 +39,8 @@ def user_has_permission(session, user, permission, argument=None):
     Returns:
         bool: Whether or not this user fulfills the permission.
     """
+    if not user:
+        return False
     for perm in user_permissions(session, user):
         if perm.name != permission:
             continue

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -23,24 +23,15 @@ if TYPE_CHECKING:
 
 
 def user_has_permission(session, user, permission, argument=None):
-    # type: (Session, Optional[User], str, Optional[str]) -> bool
+    # type: (Session, User, str, Optional[str]) -> bool
     """See if this user has a given permission/argument
 
     NOTE: only enabled permissions are considered.
 
     This walks a user's permissions (local/direct only) and determines if they have the given
-    permission. If an argument is specified, we validate if they have exactly that argument
+    permission. If an argument is specified, return True only if they have exactly that argument
     or if they have the wildcard ('*') argument.
-
-    Args:
-        permission (str): Name of permission to check for.
-        argument (str, Optional): Name of argument to check for.
-
-    Returns:
-        bool: Whether or not this user fulfills the permission.
     """
-    if not user:
-        return False
     for perm in user_permissions(session, user):
         if perm.name != permission:
             continue


### PR DESCRIPTION
With Tornado, if you define a get_current_user method, it will use
this to populate current_user on demand and cache the result.  We
were using that in most places, but calling get_current_user
directly in some places, which was confusing.  Use the current_user
attribute everywhere, and ensure that everything works properly if
get_current_user returns None.