### PR TITLE
Rewrite settings

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -11,189 +11,246 @@ common:
     # Type: str
     database: "sqlite:///grouper.sqlite"
 
-    # If this exists, it should be the path to an executable that Grouper will run. This program
-    # should print a single SqlAlchemy URL and exit 0.
+    # If this exists, it should be the path to an executable that Grouper will
+    # run. This program should print a single SqlAlchemy URL and exit 0.
     #
     # Type: str
     database_source: ""
 
+    # The format in which to display dates in the interface. More details here:
+    # https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior
+    #
+    # Type: str
+    date_format: "%Y-%m-%d %I:%M %p"
+
+    # Number of days before membership expires from a group at which
+    # notification of the upcoming expiration will be sent.
+    #
+    # Type: int
+    expiration_notice_days: 7
+
     # Format for logging output.
-    # See https://docs.python.org/2/library/logging.html#logrecord-attributes
+    # See https://docs.python.org/3/library/logging.html#logrecord-attributes
+    #
     # Type: str
     log_format: "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
 
-    # Directories for plugins. If set, load plugins from these directories. Plugins can affect the
-    # behavior of Grouper.
-    # Type: list of str
+    # Number of days for approvers of audited groups who are not auditors to
+    # become auditors before being expired out of the group
+    #
+    # Type: int
+    nonauditor_expiration_days: 5
+
+    # Directories for plugins. If set, load plugins from these directories.
+    #
+    # Type: List[str]
     plugin_dirs: []
 
-    # Module paths for plugins to load from.
-    # Type: list of str
+    # Module paths to load as plugins, in addition to any found in plugin_dirs.
+    #
+    # Type: List[str]
     plugin_module_paths:
-    - plugins.group_ownership_policy
-    - plugins.ssh_key_policy
-    - plugins.permission_aliases
-
-    # Directories for one-offs. If set, load oneoffs from these directories which
-    # are run via grouper-ctl.
-    # Type: list of str
-    oneoff_dirs: []
-
-    # Module paths for one-offs to load from.
-    # Type: list of str
-    oneoff_module_paths:
-    - oneoffs.refresh_public_keys
-    - oneoffs.check_public_keys
+      - plugins.group_ownership_policy
+      - plugins.permission_aliases
+      - plugins.ssh_key_policy
 
     # Name of permissions for which we restrict ownership calculations to
     # exclude wildcard ownership if any non-wildcard owners are avaiable.
-    # Type: list of str
-    restricted_ownership_permissions:
+    #
+    # Type: List[str]
+    restricted_ownership_permissions: []
 
     # Whether to send notification e-mails.
+    #
     # Type: bool
     send_emails: false
 
     # Server to use to send notification e-mails.
+    #
     # Type: str
     smtp_server: "localhost"
 
-    # Whether to connect to the SMTP server using TLS
+    # Whether to connect to the SMTP server using TLS.
+    #
     # Type: bool
     smtp_use_ssl: false
 
-    # Username to use for logging in to the SMTP server
-    # You should probably not use this unless smtp_use_ssl is true
-    # Leave blank if you want to not authenticate to the SMTP server
+    # Username to use for logging in to the SMTP server. You should probably not
+    # use this unless smtp_use_ssl is true. Leave blank if you want to not
+    # authenticate to the SMTP server.
+    #
     # Type: str
     smtp_username: ""
 
-    # Password to use for logging in to the SMTP server
-    # You should probably not use this unless smtp_use_ssl is true
+    # Password to use for logging in to the SMTP server.  You should probably
+    # not use this unless smtp_use_ssl is true.
+    #
     # Type: str
     smtp_password: ""
 
-    # Address to send email from
+    # Address to send email from.
+    #
     # Type: str
     from_addr: "no-reply@grouper.local"
 
-    # Number of days for approvers of audited groups who are not auditors to become auditors
-    # before being expired out of the group
-    # Type: int
-    nonauditor_expiration_days: 5
-
-    # Url is the location of the Grouper homepage, no trailing slash. This should include a
-    # port if one is needed.
+    # Sentry DSN for logging exceptions.
+    #
     # Type: str
-    url: "http://127.0.0.1:8888"
+    sentry_dsn:
 
-fe:
-    # Number of worker processes to fork for receving requests. This option
-    # is mutually exclusive with debug.
-    # Type: int
-    num_processes: 1
-
-    # The port to listen to requests on.
-    # Type: int
-    port: 8989
-
-    # The IP address to listen to requests on, or leave empty to listen to
-    # all addresses.
+    # The email domain that all service accounts must have.  This will also be
+    # used as the domain when constructing message IDs when Grouper sends email.
+    #
     # Type: str
-    address: "127.0.0.1"
+    service_account_email_domain: "svc.localhost"
 
-    # All traps are stored in the database in UTC. This option chooses the
+    # All times are stored in the database in UTC. This option chooses the
     # timezone for displaying datetime values.
+    #
     # Type: str
     timezone: "UTC"
 
-    # The format in which to display dates in the interface. More details here:
-    # https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+    # Location of the Grouper homepage, no trailing slash. This should include a
+    # port if one is needed.
+    #
     # Type: str
-    date_format: "%Y-%m-%d %I:%M %p"
+    url: "http://127.0.0.1:8888"
 
-    # Passing debug option down tornado. Useful for development to
-    # automatically reload code.
+api:
+    # The IP address to listen to requests on, or leave empty to listen to all
+    # addresses.
+    #
+    # Type: str
+    address: "127.0.0.1"
+
+    # The port to listen to requests on.
+    #
+    # Type: int
+    port: 8990
+
+    # Passing debug option down Tornado. Useful for development to automatically
+    # reload code.
+    #
     # Type: bool
     debug: true
 
-    # This is the prefix url in template to cdnjs. This allows you to point at
-    # and internal mirror for production deployments.
-    # Type: str
-    cdnjs_prefix: "//cdnjs.cloudflare.com"
-
-    # Header to check for Authenticated Username
-    # Type: str
-    user_auth_header: "X-Grouper-User"
+    # Number of worker processes to fork for receving requests. This option is
+    # mutually exclusive with debug.
+    #
+    # Type: int
+    num_processes: 1
 
     # How often to pull cache data from database in seconds.
+    #
     # Type: int
     refresh_interval: 1
 
-    # How to get help from the people who run this Grouper deployment. Should be in the form
-    # of an imperative sentence https://en.wikipedia.org/wiki/Sentence_function#Imperative
-    # For example: "email grouper-admin@example.com"
+    # Sentry DSN for logging exceptions.
+    #
+    # Type: str
+    sentry_dsn:
+
+background:
+    # Sentry DSN for logging exceptions.
+    #
+    # Type: str
+    sentry_dsn:
+
+    # How long to wait between iterations.
+    #
+    # Type: int
+    sleep_interval: 60
+
+ctl:
+    # Directories for one-offs. If set, load oneoffs from these directories
+    # which are run via grouper-ctl.
+    #
+    # Type: List[str]
+    oneoff_dirs: []
+
+    # Module paths for one-offs to load from.
+    #
+    # Type: List[str]
+    oneoff_module_paths:
+      - oneoffs.refresh_public_keys
+      - oneoffs.check_public_keys
+
+fe:
+    # The IP address to listen to requests on, or leave empty to listen to
+    # all addresses.
+    #
+    # Type: str
+    address: "127.0.0.1"
+
+    # The port to listen to requests on.
+    #
+    # Type: int
+    port: 8989
+
+    # This is the prefix URL used to access external resources hosted by a
+    # mirror of CDNJS. This allows you to point at an internal mirror if you
+    # prefer.
+    #
+    # Type: str
+    cdnjs_prefix: "//cdnjs.cloudflare.com"
+
+    # Passing debug option down Tornado. Useful for development to automatically
+    # reload code.
+    #
+    # Type: bool
+    debug: true
+
+    # How to get help from the people who run this Grouper deployment. Should be
+    # in the form of an imperative sentence.
+    # https://en.wikipedia.org/wiki/Sentence_function#Imperative
+    # For example:"email grouper-admin@example.com"
+    #
     # Type: str
     how_to_get_help: "if this is prod, ask someone to fix the how_to_get_help setting"
+
+    # Number of worker processes to fork for receving requests. This option
+    # is mutually exclusive with debug.
+    #
+    # Type: int
+    num_processes: 1
 
     # Help text given when a dropdown permission argument is available in
     # permission request. This is probably help around how this dropdown was
     # populated and how to get what the user wants if they don't see it as an
     # option.
+    #
     # Type: str
-    permission_request_dropdown_help:
+    permission_request_dropdown_help: ""
 
-    # Site-specific docs.
-    # Type: list of maps giving url, name, and description strings.
-    site_docs:
-
-    # Sentry DSN for logging exceptions
+    # Help text given when a text entry field is used for the permission
+    # argument. This is probably help for how to determine what values can be
+    # typed into this entry field.
+    #
     # Type: str
-    sentry_dsn:
-
-    # A list of lists of the shells that users are allowed to select. The first argument is
-    # the shell location (i.e. /bin/bash), and the second is a user readable format for the
-    # shell
-    shell:
-        - [/bin/false, Your administrator has not configured Grouper for shell management]
-
-    # The email domain that all service accounts must have
-    # Type: str
-    service_account_email_domain: "svc.localhost"
-
-api:
-    # Number of worker processes to fork for receving requests. This option
-    # is mutually exclusive with debug.
-    # Type: int
-    num_processes: 1
-
-    # The port to listen to requests on.
-    # Type: int
-    port: 8990
-
-    # The IP address to listen to requests on, or leave empty to listen to
-    # all addresses.
-    # Type: str
-    address: "127.0.0.1"
-
-    # Passing debug option down tornado. Useful for development to
-    # automatically reload code.
-    # Type: bool
-    debug: true
+    permission_request_text_help: ""
 
     # How often to pull cache data from database in seconds.
+    #
     # Type: int
     refresh_interval: 1
 
-    # Sentry DSN for logging exceptions
-    # Type: str
-    sentry_dsn:
+    # A list of lists of the shells that users are allowed to select. The first
+    # argument is the shell location (i.e. /bin/bash), and the second is a user
+    # readable comment describing the shell.
+    #
+    # Type: List[Tuple[str, str]]
+    shell:
+        - [/bin/false, Your administrator has not configured Grouper for shell management]
 
-background:
-    # Sentry DSN for logging exceptions
-    # Type: str
-    sentry_dsn:
+    # Site-specific docs.  Each list entry should provide url, name, and
+    # description keys.
+    #
+    # Type: List[Dict[str, str]]
+    site_docs: []
 
-    # How long to wait between iterations
-    # Type: int
-    sleep_interval: 60
+    # Header that contains the authenticated username of a Grouper user. This
+    # must be provided by an upstream web proxy that does authentication.
+    # Grouper itself has no mechanism to authenticate users.
+    #
+    # Type: str
+    user_auth_header: "X-Grouper-User"

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -35,12 +35,6 @@ common:
     # Type: str
     log_format: "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
 
-    # Number of days for approvers of audited groups who are not auditors to
-    # become auditors before being expired out of the group
-    #
-    # Type: int
-    nonauditor_expiration_days: 5
-
     # Directories for plugins. If set, load plugins from these directories.
     #
     # Type: List[str]

--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -19,7 +19,6 @@ from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import set_global_settings
 from grouper.setup import build_arg_parser, setup_logging
 from grouper.util import get_database_url
 
@@ -98,9 +97,7 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings = ApiSettings()
-        settings.update_from_config(args.config)
-        set_global_settings(settings)
+        settings = ApiSettings.global_settings_from_config(args.config)
 
         # setup logging
         setup_logging(args, settings.log_format)

--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -10,7 +10,7 @@ import tornado.ioloop
 
 from grouper import stats
 from grouper.api.routes import HANDLERS
-from grouper.api.settings import settings
+from grouper.api.settings import ApiSettings
 from grouper.app import GrouperApplication
 from grouper.database import DbRefreshThread
 from grouper.error_reporting import get_sentry_client, setup_signal_handlers
@@ -19,29 +19,28 @@ from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+from grouper.settings import set_global_settings
 from grouper.setup import build_arg_parser, setup_logging
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from grouper.error_reporting import SentryProxy
-    from grouper.fe.settings import Settings
     from grouper.graph import GroupGraph
     from grouper.usecases.factory import UseCaseFactory
     from typing import List
 
 
 def create_api_application(graph, settings, usecase_factory):
-    # type: (GroupGraph, Settings, UseCaseFactory) -> GrouperApplication
+    # type: (GroupGraph, ApiSettings, UseCaseFactory) -> GrouperApplication
     tornado_settings = {"debug": settings.debug}
     handler_settings = {"graph": graph, "usecase_factory": usecase_factory}
     handlers = [(route, handler_class, handler_settings) for (route, handler_class) in HANDLERS]
     return GrouperApplication(handlers, **tornado_settings)
 
 
-def start_server(args, sentry_client):
-    # type: (Namespace, SentryProxy) -> None
-
+def start_server(args, settings, sentry_client):
+    # type: (Namespace, ApiSettings, SentryProxy) -> None
     log_level = logging.getLevelName(logging.getLogger().level)
     logging.info("begin. log_level={}".format(log_level))
 
@@ -59,8 +58,6 @@ def start_server(args, sentry_client):
     logging.debug("configure database session")
     database_url = args.database_url or get_database_url(settings)
     Session.configure(bind=get_db_engine(database_url))
-
-    settings.start_config_thread(args.config, "api")
 
     with closing(Session()) as session:
         graph = Graph()
@@ -101,7 +98,9 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings.update_from_config(args.config, "api")
+        settings = ApiSettings()
+        settings.update_from_config(args.config)
+        set_global_settings(settings)
 
         # setup logging
         setup_logging(args, settings.log_format)
@@ -113,7 +112,7 @@ def main(sys_argv=sys.argv):
         sys.exit(1)
 
     try:
-        start_server(args, sentry_client)
+        start_server(args, settings, sentry_client)
     except Exception:
         sentry_client.captureException()
     finally:

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -1,7 +1,25 @@
-from grouper.settings import Settings, settings as base_settings
+from typing import TYPE_CHECKING
+
+from grouper.settings import Settings
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
-settings = Settings.from_settings(
-    base_settings,
-    {"address": None, "debug": False, "num_processes": 1, "port": 8990, "refresh_interval": 60},
-)
+class ApiSettings(Settings):
+    """Grouper API server settings."""
+
+    def __init__(self):
+        """Set up API defaults."""
+        super(ApiSettings, self).__init__()
+
+        # Keep attributes here in the same order as in config/dev.yaml.
+        self.address = "127.0.0.1"
+        self.debug = False
+        self.num_processes = 1
+        self.port = 8990
+        self.refresh_interval = 60
+
+    def update_from_config(self, filename=None, section="api"):
+        # type: (Optional[str], Optional[str]) -> None
+        super(ApiSettings, self).update_from_config(filename, section)

--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from grouper.settings import Settings
+from grouper.settings import set_global_settings, Settings
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -8,6 +8,15 @@ if TYPE_CHECKING:
 
 class ApiSettings(Settings):
     """Grouper API server settings."""
+
+    @staticmethod
+    def global_settings_from_config(filename=None, section="api"):
+        # type: (Optional[str], Optional[str]) -> ApiSettings
+        """Create and return a new global Settings singleton."""
+        settings = ApiSettings()
+        settings.update_from_config(filename, section)
+        set_global_settings(settings)
+        return settings
 
     def __init__(self):
         """Set up API defaults."""

--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -26,7 +26,7 @@ from grouper.perf_profile import prune_old_traces
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
-    from grouper.settings import Settings
+    from grouper.background.settings import BackgroundSettings
     from grouper.error_reporting import SentryProxy
     from typing import Dict, Set
 
@@ -38,7 +38,7 @@ class BackgroundProcessor(object):
     """
 
     def __init__(self, settings, sentry_client):
-        # type: (Settings, SentryProxy) -> None
+        # type: (BackgroundSettings, SentryProxy) -> None
         """Initialize new BackgroundProcessor"""
 
         self.settings = settings

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -10,7 +10,7 @@ from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import default_settings_path, set_global_settings
+from grouper.settings import default_settings_path
 from grouper.setup import setup_logging
 from grouper.util import get_database_url
 
@@ -74,9 +74,7 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings = BackgroundSettings()
-        settings.update_from_config(args.config)
-        set_global_settings(settings)
+        settings = BackgroundSettings.global_settings_from_config(args.config)
 
         # setup logging
         setup_logging(args, settings.log_format)

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -5,16 +5,17 @@ from typing import TYPE_CHECKING
 
 from grouper import __version__
 from grouper.background.background_processor import BackgroundProcessor
-from grouper.background.settings import settings
+from grouper.background.settings import BackgroundSettings
 from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import default_settings_path
+from grouper.settings import default_settings_path, set_global_settings
 from grouper.setup import setup_logging
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
+    from argparse import Namespace
     from grouper.error_reporting import SentryProxy
     from typing import List
 
@@ -42,9 +43,8 @@ def build_arg_parser():
     return parser
 
 
-def start_processor(args, sentry_client):
-    # type: (argparse.Namespace, SentryProxy) -> None
-
+def start_processor(args, settings, sentry_client):
+    # type: (Namespace, BackgroundSettings, SentryProxy) -> None
     log_level = logging.getLevelName(logging.getLogger().level)
     logging.info("begin. log_level={}".format(log_level))
 
@@ -60,8 +60,6 @@ def start_processor(args, sentry_client):
     logging.debug("configure database session")
     Session.configure(bind=get_db_engine(get_database_url(settings)))
 
-    settings.start_config_thread(args.config, "background")
-
     background = BackgroundProcessor(settings, sentry_client)
     background.run()
 
@@ -76,7 +74,9 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings.update_from_config(args.config, "background")
+        settings = BackgroundSettings()
+        settings.update_from_config(args.config)
+        set_global_settings(settings)
 
         # setup logging
         setup_logging(args, settings.log_format)
@@ -87,4 +87,4 @@ def main(sys_argv=sys.argv):
         logging.exception("uncaught exception in startup")
         sys.exit(1)
 
-    start_processor(args, sentry_client)
+    start_processor(args, settings, sentry_client)

--- a/grouper/background/settings.py
+++ b/grouper/background/settings.py
@@ -1,4 +1,21 @@
-from grouper.settings import Settings, settings as base_settings
+from typing import TYPE_CHECKING
+
+from grouper.settings import Settings
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
-settings = Settings.from_settings(base_settings, {"sleep_interval": 60})
+class BackgroundSettings(Settings):
+    """Grouper background processor settings."""
+
+    def __init__(self):
+        # type: () -> None
+        super(BackgroundSettings, self).__init__()
+
+        # Keep attributes here in the same order as in config/dev.yaml.
+        self.sleep_interval = 60
+
+    def update_from_config(self, filename=None, section="background"):
+        # type: (Optional[str], Optional[str]) -> None
+        super(BackgroundSettings, self).update_from_config(filename, section)

--- a/grouper/background/settings.py
+++ b/grouper/background/settings.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from grouper.settings import Settings
+from grouper.settings import set_global_settings, Settings
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -8,6 +8,15 @@ if TYPE_CHECKING:
 
 class BackgroundSettings(Settings):
     """Grouper background processor settings."""
+
+    @staticmethod
+    def global_settings_from_config(filename=None, section="background"):
+        # type: (Optional[str], Optional[str]) -> BackgroundSettings
+        """Create and return a new global Settings singleton."""
+        settings = BackgroundSettings()
+        settings.update_from_config(filename, section)
+        set_global_settings(settings)
+        return settings
 
     def __init__(self):
         # type: () -> None

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -10,7 +10,7 @@ from grouper.ctl.settings import CtlSettings
 from grouper.initialization import create_sql_usecase_factory
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import default_settings_path, set_global_settings
+from grouper.settings import default_settings_path
 from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
@@ -51,9 +51,7 @@ def main(sys_argv=sys.argv, session=None):
 
     args = parser.parse_args(sys_argv[1:])
 
-    settings = CtlSettings()
-    settings.update_from_config(args.config)
-    set_global_settings(settings)
+    settings = CtlSettings.global_settings_from_config(args.config)
 
     log_level = get_loglevel(args, base=logging.INFO)
     logging.basicConfig(level=log_level, format=settings.log_format)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING
 from grouper import __version__
 from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db
 from grouper.ctl.factory import CtlCommandFactory
+from grouper.ctl.settings import CtlSettings
 from grouper.initialization import create_sql_usecase_factory
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import default_settings_path, settings
+from grouper.settings import default_settings_path, set_global_settings
 from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
@@ -19,8 +20,8 @@ if TYPE_CHECKING:
 sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
-def main(sys_argv=sys.argv, start_config_thread=True, session=None):
-    # type: (List[str], bool, Optional[Session]) -> None
+def main(sys_argv=sys.argv, session=None):
+    # type: (List[str], Optional[Session]) -> None
     description_msg = "Grouper Control"
     parser = argparse.ArgumentParser(description=description_msg)
 
@@ -50,9 +51,9 @@ def main(sys_argv=sys.argv, start_config_thread=True, session=None):
 
     args = parser.parse_args(sys_argv[1:])
 
-    if start_config_thread:
-        settings.update_from_config(args.config)
-        settings.start_config_thread(args.config)
+    settings = CtlSettings()
+    settings.update_from_config(args.config)
+    set_global_settings(settings)
 
     log_level = get_loglevel(args, base=logging.INFO)
     logging.basicConfig(level=log_level, format=settings.log_format)

--- a/grouper/ctl/oneoff.py
+++ b/grouper/ctl/oneoff.py
@@ -4,10 +4,10 @@ from contextlib import contextmanager
 from types import MethodType
 from typing import TYPE_CHECKING
 
+from grouper.ctl.settings import settings
 from grouper.ctl.util import make_session
 from grouper.oneoff import BaseOneOff
 from grouper.plugin import load_plugins
-from grouper.settings import settings
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -66,7 +66,7 @@ def oneoff_command(args):
     session = make_session()
 
     oneoffs = load_plugins(
-        BaseOneOff, settings.oneoff_dirs, settings.oneoff_module_paths, "grouper-ctl"
+        BaseOneOff, settings().oneoff_dirs, settings().oneoff_module_paths, "grouper-ctl"
     )
 
     if args.subcommand == "run":

--- a/grouper/ctl/settings.py
+++ b/grouper/ctl/settings.py
@@ -1,0 +1,29 @@
+from typing import cast, TYPE_CHECKING
+
+from grouper.settings import Settings, settings as global_settings
+
+if TYPE_CHECKING:
+    from typing import List, Optional
+
+
+class CtlSettings(Settings):
+    """grouper-ctl settings."""
+
+    def __init__(self):
+        # type: () -> None
+        super(CtlSettings, self).__init__()
+
+        # Keep attributes here in the same order as in config/dev.yaml.
+        self.oneoff_dirs = []  # type: List[str]
+        self.oneoff_module_paths = []  # type: List[str]
+
+    def update_from_config(self, filename=None, section="ctl"):
+        # type: (Optional[str], Optional[str]) -> None
+        super(CtlSettings, self).update_from_config(filename, section)
+
+
+# See grouper.settings for more information about why this nonsense is here.
+def settings():
+    # type: () -> CtlSettings
+    """Return a global CtlSettings for grouper-ctl code."""
+    return cast(CtlSettings, global_settings())

--- a/grouper/ctl/settings.py
+++ b/grouper/ctl/settings.py
@@ -1,6 +1,6 @@
 from typing import cast, TYPE_CHECKING
 
-from grouper.settings import Settings, settings as global_settings
+from grouper.settings import set_global_settings, Settings, settings as global_settings
 
 if TYPE_CHECKING:
     from typing import List, Optional
@@ -8,6 +8,15 @@ if TYPE_CHECKING:
 
 class CtlSettings(Settings):
     """grouper-ctl settings."""
+
+    @staticmethod
+    def global_settings_from_config(filename=None, section="ctl"):
+        # type: (Optional[str], Optional[str]) -> CtlSettings
+        """Create and return a new global Settings singleton."""
+        settings = CtlSettings()
+        settings.update_from_config(filename, section)
+        set_global_settings(settings)
+        return settings
 
     def __init__(self):
         # type: () -> None

--- a/grouper/email_util.py
+++ b/grouper/email_util.py
@@ -3,6 +3,7 @@ import smtplib
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from typing import TYPE_CHECKING
 
 from six import itervalues, string_types
 
@@ -11,6 +12,10 @@ from grouper.models.async_notification import AsyncNotification
 from grouper.models.audit_log import AuditLog
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.user import User
+
+if TYPE_CHECKING:
+    from grouper.settings import Settings
+    from typing import List
 
 
 def send_email(session, recipients, subject, template, settings, context):
@@ -136,9 +141,9 @@ def get_email_from_template(recipient_list, subject, template, settings, context
         MIMEMultipart: Constructed object for the email message.
     """
     template_env = get_template_env()
-    sender = settings["from_addr"]
+    sender = settings.from_addr
 
-    context["url"] = settings["url"]
+    context["url"] = settings.url
 
     text_template = template_env.get_template("email/{}.txt".format(template)).render(**context)
     html_template = template_env.get_template("email/{}.html".format(template)).render(**context)
@@ -160,6 +165,7 @@ def get_email_from_template(recipient_list, subject, template, settings, context
 
 
 def send_email_raw(settings, recipient_list, msg_raw):
+    # type: (Settings, List[str], str) -> None
     """Send raw email (from string)
 
     Given some recipients and the string version of a message, this sends it immediately
@@ -174,17 +180,17 @@ def send_email_raw(settings, recipient_list, msg_raw):
     Returns:
         Nothing.
     """
-    if not settings["send_emails"]:
+    if not settings.send_emails:
         logging.debug(msg_raw)
         return
 
-    sender = settings["from_addr"]
-    username = settings["smtp_username"]
-    password = settings["smtp_password"]
-    use_ssl = settings["smtp_use_ssl"]
+    sender = settings.from_addr
+    username = settings.smtp_username
+    password = settings.smtp_password
+    use_ssl = settings.smtp_use_ssl
 
     smtp_cls = smtplib.SMTP_SSL if use_ssl else smtplib.SMTP
-    smtp = smtp_cls(settings["smtp_server"])
+    smtp = smtp_cls(settings.smtp_server)
 
     if username:
         smtp.login(username, password)

--- a/grouper/expiration.py
+++ b/grouper/expiration.py
@@ -5,7 +5,6 @@ from sqlalchemy import or_
 
 from grouper.constants import ILLEGAL_NAME_CHARACTER
 from grouper.email_util import send_async_email
-from grouper.fe.settings import settings as fe_settings
 from grouper.models.async_notification import AsyncNotification
 from grouper.settings import settings
 
@@ -60,7 +59,7 @@ def add_expiration(
 ):
     # type: (...) -> None
     async_key = _expiration_key(group_name, member_name)
-    send_after = expiration - timedelta(settings.expiration_notice_days)
+    send_after = expiration - timedelta(settings().expiration_notice_days)
     email_context = {
         "expiration": expiration,
         "group_name": group_name,
@@ -73,7 +72,7 @@ def add_expiration(
         recipients=recipients,
         subject="expiration warning for membership in group '{}'".format(group_name),
         template="expiration_warning",
-        settings=fe_settings,
+        settings=settings(),
         context=email_context,
         send_after=send_after,
         async_key=async_key,

--- a/grouper/fe/handlers/audits_create.py
+++ b/grouper/fe/handlers/audits_create.py
@@ -107,7 +107,7 @@ class AuditsCreate(GrouperHandler):
                 mail_to,
                 "Group Audit: {}".format(group.name),
                 "audit_notice",
-                settings,
+                settings(),
                 {"group": group.name, "ends_at": ends_at},
             )
 
@@ -117,7 +117,7 @@ class AuditsCreate(GrouperHandler):
                     mail_to,
                     "Group Audit: {} - {} day(s) left".format(group.name, days_prior),
                     "audit_notice_reminder",
-                    settings,
+                    settings(),
                     {"group": group.name, "ends_at": ends_at, "days_left": days_prior},
                     email_time,
                     async_key="audit-{}".format(group.id),

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -150,7 +150,7 @@ class GroupAdd(GrouperHandler):
                 [member.name],
                 "Added to group: {}".format(group.name),
                 "request_actioned",
-                settings,
+                settings(),
                 {
                     "group_name": group.name,
                     "actioned_by": self.current_user.name,

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -136,7 +136,7 @@ class GroupJoin(GrouperHandler):
             subj = self.render_template(
                 "email/pending_request_subj.tmpl", group=group.name, user=self.current_user.name
             )
-            send_email(self.session, mail_to, subj, "pending_request", settings, email_context)
+            send_email(self.session, mail_to, subj, "pending_request", settings(), email_context)
 
         elif group.canjoin == "canjoin":
             AuditLog.log(

--- a/grouper/fe/handlers/group_permission_request.py
+++ b/grouper/fe/handlers/group_permission_request.py
@@ -40,7 +40,7 @@ class GroupPermissionRequest(GrouperHandler):
             return self.forbidden()
 
         args_by_perm = get_grantable_permissions(
-            self.session, settings.restricted_ownership_permissions
+            self.session, settings().restricted_ownership_permissions
         )
         dropdown_form, text_form = GroupPermissionRequest._get_forms(args_by_perm, None)
 
@@ -50,8 +50,8 @@ class GroupPermissionRequest(GrouperHandler):
             text_form=text_form,
             group=group,
             args_by_perm_json=json.dumps(args_by_perm),
-            dropdown_help=settings.permission_request_dropdown_help,
-            text_help=settings.permission_request_text_help,
+            dropdown_help=settings().permission_request_dropdown_help,
+            text_help=settings().permission_request_text_help,
         )
 
     def post(self, *args, **kwargs):
@@ -69,7 +69,7 @@ class GroupPermissionRequest(GrouperHandler):
 
         # check inputs
         args_by_perm = get_grantable_permissions(
-            self.session, settings.restricted_ownership_permissions
+            self.session, settings().restricted_ownership_permissions
         )
         dropdown_form, text_form = GroupPermissionRequest._get_forms(
             args_by_perm, self.request.arguments
@@ -96,8 +96,8 @@ class GroupPermissionRequest(GrouperHandler):
                 group=group,
                 args_by_perm_json=json.dumps(args_by_perm),
                 alerts=self.get_form_alerts(form.errors),
-                dropdown_help=settings.permission_request_dropdown_help,
-                text_help=settings.permission_request_text_help,
+                dropdown_help=settings().permission_request_dropdown_help,
+                text_help=settings().permission_request_text_help,
             )
 
         permission = get_permission(self.session, form.permission_name.data)

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -161,7 +161,7 @@ class GroupRequestUpdate(GrouperHandler):
             approver_mail_to,
             subj,
             "approver_request_updated",
-            settings,
+            settings(),
             {
                 "group_name": group.name,
                 "requester": request.requester.username,
@@ -179,7 +179,7 @@ class GroupRequestUpdate(GrouperHandler):
                 [request.requester.name],
                 "Added to group: {}".format(group.groupname),
                 "request_actioned",
-                settings,
+                settings(),
                 {
                     "group_name": group.name,
                     "actioned_by": self.current_user.name,
@@ -194,7 +194,7 @@ class GroupRequestUpdate(GrouperHandler):
                 [request.requester.name],
                 "Request to join cancelled: {}".format(group.groupname),
                 "request_cancelled",
-                settings,
+                settings(),
                 {
                     "group_name": group.name,
                     "cancelled_by": self.current_user.name,

--- a/grouper/fe/handlers/help.py
+++ b/grouper/fe/handlers/help.py
@@ -14,8 +14,8 @@ class Help(GrouperHandler):
         # type: (*Any, **Any) -> None
         self.render(
             "help.html",
-            how_to_get_help=settings.how_to_get_help,
-            site_docs=settings.site_docs,
+            how_to_get_help=settings().how_to_get_help,
+            site_docs=settings().site_docs,
             grant_perm=get_permission(self.session, PERMISSION_GRANT),
             create_perm=get_permission(self.session, PERMISSION_CREATE),
             audit_perm=get_permission(self.session, PERMISSION_AUDITOR),

--- a/grouper/fe/handlers/public_key_add.py
+++ b/grouper/fe/handlers/public_key_add.py
@@ -95,7 +95,7 @@ class PublicKeyAdd(GrouperHandler):
             [user.name],
             "Public SSH key added",
             "ssh_keys_changed",
-            settings,
+            settings(),
             email_context,
         )
 

--- a/grouper/fe/handlers/public_key_delete.py
+++ b/grouper/fe/handlers/public_key_delete.py
@@ -83,7 +83,7 @@ class PublicKeyDelete(GrouperHandler):
             [user.name],
             "Public SSH key removed",
             "ssh_keys_changed",
-            settings,
+            settings(),
             email_context,
         )
 

--- a/grouper/fe/handlers/service_account_create.py
+++ b/grouper/fe/handlers/service_account_create.py
@@ -42,7 +42,7 @@ class ServiceAccountCreate(GrouperHandler):
 
         if "@" not in self.request.arguments["name"][0].decode():
             self.request.arguments["name"][0] += (
-                "@" + settings.service_account_email_domain
+                "@" + settings().service_account_email_domain
             ).encode()
 
         if not can_create_service_account(self.session, self.current_user, group):
@@ -57,10 +57,10 @@ class ServiceAccountCreate(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors),
             )
 
-        if form.data["name"].split("@")[-1] != settings.service_account_email_domain:
+        if form.data["name"].split("@")[-1] != settings().service_account_email_domain:
             form.name.errors.append(
                 "All service accounts must have a username ending in {}".format(
-                    settings.service_account_email_domain
+                    settings().service_account_email_domain
                 )
             )
             return self.render(

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -92,7 +92,7 @@ class UserPasswordAdd(GrouperHandler):
             [user.name],
             "User password created",
             "user_password_created",
-            settings,
+            settings(),
             email_context,
         )
         return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/handlers/user_shell.py
+++ b/grouper/fe/handlers/user_shell.py
@@ -38,7 +38,7 @@ class UserShell(GrouperHandler):
             return self.forbidden()
 
         form = UserShellForm()
-        form.shell.choices = settings.shell
+        form.shell.choices = settings().shell
 
         self.render("user-shell.html", form=form, user=user)
 
@@ -55,7 +55,7 @@ class UserShell(GrouperHandler):
             return self.forbidden()
 
         form = UserShellForm(self.request.arguments)
-        form.shell.choices = settings.shell
+        form.shell.choices = settings().shell
         if not form.validate():
             return self.render(
                 "user-shell.html", form=form, user=user, alerts=self.get_form_alerts(form.errors)

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -96,7 +96,7 @@ class UserTokenAdd(GrouperHandler):
             [user.name],
             "User token created",
             "user_tokens_changed",
-            settings,
+            settings(),
             email_context,
         )
         return self.render("user-token-created.html", token=token, secret=secret)

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -22,7 +22,6 @@ from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import get_plugin_proxy, initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
-from grouper.settings import set_global_settings
 from grouper.setup import build_arg_parser, setup_logging
 from grouper.util import get_database_url
 
@@ -124,9 +123,7 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings = FrontendSettings()
-        settings.update_from_config(args.config)
-        set_global_settings(settings)
+        settings = FrontendSettings.global_settings_from_config(args.config)
 
         # setup logging
         setup_logging(args, settings.log_format)

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -15,45 +15,51 @@ from grouper.app import GrouperApplication
 from grouper.database import DbRefreshThread
 from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.fe.routes import HANDLERS
-from grouper.fe.settings import settings
+from grouper.fe.settings import FrontendSettings
 from grouper.fe.template_util import get_template_env
 from grouper.graph import Graph
 from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import get_plugin_proxy, initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+from grouper.settings import set_global_settings
 from grouper.setup import build_arg_parser, setup_logging
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from grouper.error_reporting import SentryProxy
-    from grouper.fe.settings import Settings
     from grouper.usecases.factory import UseCaseFactory
     from typing import Callable, List
 
 
 def create_fe_application(
-    settings, usecase_factory, deployment_name, xsrf_cookies=True, session=None
+    settings,  # type: FrontendSettings
+    usecase_factory,  # type: UseCaseFactory
+    deployment_name,  # type: str
+    xsrf_cookies=True,  # type: bool
+    session=None,  # type: Callable[[], Session]
 ):
-    # type: (Settings, UseCaseFactory, str, bool, Callable[[], Session]) -> GrouperApplication
+    # type: (...) -> GrouperApplication
     tornado_settings = {
         "debug": settings.debug,
         "static_path": os.path.join(os.path.dirname(grouper.fe.__file__), "static"),
         "xsrf_cookies": xsrf_cookies,
     }
+    extra_globals = {"cdnjs_prefix": settings.cdnjs_prefix}
     handler_settings = {
         "session": session if session else Session,
-        "template_env": get_template_env(deployment_name=deployment_name),
+        "template_env": get_template_env(
+            deployment_name=deployment_name, extra_globals=extra_globals
+        ),
         "usecase_factory": usecase_factory,
     }
     handlers = [(route, handler_class, handler_settings) for (route, handler_class) in HANDLERS]
     return GrouperApplication(handlers, **tornado_settings)
 
 
-def start_server(args, sentry_client):
-    # type: (Namespace, SentryProxy) -> None
-
+def start_server(args, settings, sentry_client):
+    # type: (Namespace, FrontendSettings, SentryProxy) -> None
     log_level = logging.getLevelName(logging.getLogger().level)
     logging.info("begin. log_level={}".format(log_level))
 
@@ -90,11 +96,8 @@ def start_server(args, sentry_client):
 
     stats.set_defaults()
 
-    # Create the Graph and start the config / graph update threads post fork to ensure each
-    # process gets updated.
-
-    settings.start_config_thread(args.config, "fe")
-
+    # Create the Graph and start the graph update thread post fork to ensure each process gets
+    # updated.
     with closing(Session()) as session:
         graph = Graph()
         graph.update_from_db(session)
@@ -121,7 +124,9 @@ def main(sys_argv=sys.argv):
 
     try:
         # load settings
-        settings.update_from_config(args.config, "fe")
+        settings = FrontendSettings()
+        settings.update_from_config(args.config)
+        set_global_settings(settings)
 
         # setup logging
         setup_logging(args, settings.log_format)
@@ -133,7 +138,7 @@ def main(sys_argv=sys.argv):
         sys.exit(1)
 
     try:
-        start_server(args, sentry_client)
+        start_server(args, settings, sentry_client)
     except Exception:
         sentry_client.captureException()
     finally:

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -1,6 +1,6 @@
 from typing import cast, TYPE_CHECKING
 
-from grouper.settings import Settings, settings as global_settings
+from grouper.settings import set_global_settings, Settings, settings as global_settings
 
 if TYPE_CHECKING:
     from typing import Dict, List, Optional
@@ -8,6 +8,15 @@ if TYPE_CHECKING:
 
 class FrontendSettings(Settings):
     """Grouper frontend settings."""
+
+    @staticmethod
+    def global_settings_from_config(filename=None, section="fe"):
+        # type: (Optional[str], Optional[str]) -> FrontendSettings
+        """Create and return a new global Settings singleton."""
+        settings = FrontendSettings()
+        settings.update_from_config(filename, section)
+        set_global_settings(settings)
+        return settings
 
     def __init__(self):
         """Set up frontend defaults."""

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -1,38 +1,41 @@
-import pytz
+from typing import cast, TYPE_CHECKING
 
-from grouper.settings import Settings, settings as base_settings
+from grouper.settings import Settings, settings as global_settings
 
-
-class FeSettings(Settings):
-
-    default_timezone = pytz.timezone("UTC")
-
-    def override_timezone(self, value):
-        try:
-            return pytz.timezone(value)
-        except pytz.exceptions.UnknownTimeZoneError:
-            return self.default_timezone
+if TYPE_CHECKING:
+    from typing import Dict, List, Optional
 
 
-settings = FeSettings.from_settings(
-    base_settings,
-    {
-        "address": None,
-        "cdnjs_prefix": "//cdnjs.cloudflare.com",
-        "date_format": "%Y-%m-%d %I:%M %p",
-        "debug": False,
-        "how_to_get_help": None,
-        "num_processes": 1,
-        "permission_request_dropdown_help": None,
-        "permission_request_text_help": None,
-        "port": 8989,
-        "refresh_interval": 60,
-        "service_account_email_domain": "svc.localhost",
-        "shell": [
-            ["/bin/false", "Shell support in Grouper has not been setup by the administrator"]
-        ],
-        "site_docs": None,
-        "timezone": FeSettings.default_timezone,
-        "user_auth_header": "X-Grouper-User",
-    },
-)
+class FrontendSettings(Settings):
+    """Grouper frontend settings."""
+
+    def __init__(self):
+        """Set up frontend defaults."""
+        super(FrontendSettings, self).__init__()
+
+        # Keep attributes here in the same order as in config/dev.yaml.
+        self.address = "127.0.0.1"
+        self.port = 8989
+        self.cdnjs_prefix = "//cdnjs.cloudflare.com"
+        self.debug = False
+        self.how_to_get_help = "if this is prod, ask someone to fix the how_to_get_help setting"
+        self.num_processes = 1
+        self.permission_request_dropdown_help = ""
+        self.permission_request_text_help = ""
+        self.refresh_interval = 60
+        self.shell = (
+            [["/bin/false", "Shell support in Grouper has not been setup by the administrator"]],
+        )
+        self.site_docs = []  # type: List[Dict[str, str]]
+        self.user_auth_header = "X-Grouper-User"
+
+    def update_from_config(self, filename=None, section="fe"):
+        # type: (Optional[str], Optional[str]) -> None
+        super(FrontendSettings, self).update_from_config(filename, section)
+
+
+# See grouper.settings for more information about why this nonsense is here.
+def settings():
+    # type: () -> FrontendSettings
+    """Return a global FrontendSettings for frontend code."""
+    return cast(FrontendSettings, global_settings())

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -53,8 +53,8 @@ def print_date(date):
         return ""
 
     date_obj = _make_date_obj(date)
-    date_obj = date_obj.astimezone(settings["timezone"])
-    return date_obj.strftime(settings["date_format"])
+    date_obj = date_obj.astimezone(settings().timezone_object)
+    return date_obj.strftime(settings().date_format)
 
 
 def expires_when_str(date_obj, utcnow_fn=_utcnow):
@@ -122,7 +122,6 @@ def get_template_env(
         "long_ago_str": long_ago_str,
     }
     j_globals = {
-        "cdnjs_prefix": settings.cdnjs_prefix,
         "deployment_name": deployment_name,
         "ROLES": GROUP_EDGE_ROLES,
         "TYPES": OBJ_TYPES_IDX,

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -131,7 +131,7 @@ class GrouperHandler(RequestHandler):
 
     def get_current_user(self):
         # type: () -> Optional[User]
-        username = self.request.headers.get(settings.user_auth_header)
+        username = self.request.headers.get(settings().user_auth_header)
         if not username:
             return None
 
@@ -151,7 +151,7 @@ class GrouperHandler(RequestHandler):
         except sqlalchemy.exc.OperationalError:
             # Failed to connect to database or create user, try to reconfigure the db. This invokes
             # the fetcher to try to see if our URL string has changed.
-            Session.configure(bind=get_db_engine(get_database_url(settings)))
+            Session.configure(bind=get_db_engine(get_database_url(settings())))
             raise DatabaseFailure()
 
         # service accounts are, by definition, not interactive users
@@ -275,7 +275,7 @@ class GrouperHandler(RequestHandler):
         # type: () -> None
         self.set_status(403)
         self.raise_and_log_exception(tornado.web.HTTPError(403))
-        self.render("errors/forbidden.html", how_to_get_help=settings.how_to_get_help)
+        self.render("errors/forbidden.html", how_to_get_help=settings().how_to_get_help)
 
     def notfound(self):
         # type: () -> None

--- a/grouper/models/permission_request.py
+++ b/grouper/models/permission_request.py
@@ -34,4 +34,4 @@ class PermissionRequest(Model):
     @property
     def reference_id(self):
         # type: () -> str
-        return reference_id(settings, "permission", self)
+        return reference_id(settings(), "permission", self)

--- a/grouper/models/request.py
+++ b/grouper/models/request.py
@@ -49,7 +49,7 @@ class Request(Model, CommentObjectMixin):
     @property
     def reference_id(self):
         # type: () -> str
-        return reference_id(settings, "group", self)
+        return reference_id(settings(), "group", self)
 
     def my_status_updates(self):
         requests = self.session.query(

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -613,7 +613,9 @@ def create_request(session, user, group, permission, argument, reason):
         .get_template("email/pending_permission_request_subj.tmpl")
         .render(permission=permission.name, group=group.name)
     )
-    send_email(session, set(mail_to), subj, "pending_permission_request", settings, email_context)
+    send_email(
+        session, set(mail_to), subj, "pending_permission_request", settings(), email_context
+    )
 
     return request
 
@@ -857,7 +859,9 @@ def update_request(
         "argument": request.argument,
     }
 
-    send_email(session, [request.requester.name], subject, email_template, settings, email_context)
+    send_email(
+        session, [request.requester.name], subject, email_template, settings(), email_context
+    )
 
 
 def permission_list_to_dict(perms):

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -1,117 +1,123 @@
 import logging
 import os
-import threading
-import time
+from typing import TYPE_CHECKING
 
+import pytz
 import yaml
 from six import iteritems
 
-from grouper import stats
+if TYPE_CHECKING:
+    from pytz import BaseTzInfo
+    from typing import List, Optional
 
-
-class Settings(object):
-    def __init__(self, initial_settings):
-        self.settings = initial_settings
-        self.lock = threading.Lock()
-        self.logger = logging.getLogger(__name__)
-        self._loading_thread_started = False
-
-    @classmethod
-    def from_settings(cls, settings, initial_settings=None):
-        _settings = {}
-        _settings.update(settings.settings)
-        if initial_settings:
-            _settings.update(initial_settings)
-        return cls(_settings)
-
-    def update_from_config(self, filename, section=None):
-        self.logger.debug("Loading " + filename)
-        with open(filename) as config:
-            data = yaml.safe_load(config.read())
-
-        settings = {}
-        settings.update(data.get("common", {}))
-        if section:
-            settings.update(data.get(section, {}))
-
-        for key, value in iteritems(settings):
-            key = key.lower()
-
-            # Limit the parts of the config file that can have an effect.
-            if key not in self.settings:
-                continue
-
-            override = getattr(self, "override_%s" % key, None)
-            if override is not None and callable(override):
-                value = override(value)
-
-            self[key] = value
-
-        stats.log_gauge("successful-config-update", 1)
-
-    def start_config_thread(self, filename, section=None, refresh_config_seconds=10):
-        """
-        Start a daemon thread to reload the given config file and section periodically.
-        Load the config once before returning.  This function must be called at
-        most once.
-        """
-        assert not self._loading_thread_started, "start_config_thread called twice!"
-
-        def refresh_config_loop():
-            while True:
-                try:
-                    self.update_from_config(filename, section=section)
-                except (IOError, yaml.parser.ParserError):
-                    stats.log_gauge("successful-config-update", 0)
-                    stats.log_gauge("failed-config-update", 1)
-
-                time.sleep(refresh_config_seconds)
-
-        thread = threading.Thread(target=refresh_config_loop)
-        thread.daemon = True
-        thread.start()
-        self._loading_thread_started = True
-
-    def __setitem__(self, key, value):
-        with self.lock:
-            self.settings[key] = value
-
-    def __getitem__(self, key):
-        with self.lock:
-            return self.settings[key]
-
-    def __getattr__(self, name):
-        with self.lock:
-            try:
-                return self.settings[name]
-            except KeyError as err:
-                raise AttributeError(err)
+# TODO(rra): Desire for a single global settings object is currently deeply embedded.  The rewrite
+# to hexagonal architecture is probably required before we can fully eliminate it.
+_GLOBAL_SETTINGS_OBJECT = None
 
 
 def default_settings_path():
+    # type: () -> str
     return os.environ.get("GROUPER_SETTINGS", "/etc/grouper.yaml")
 
 
-settings = Settings(
-    {
-        "auditors_group": None,
-        "database": None,
-        "database_source": None,
-        "expiration_notice_days": 7,
-        "nonauditor_expiration_days": 5,
-        "from_addr": "no-reply@grouper.local",
-        "log_format": "%(asctime)-15s\t%(levelname)s\t%(message)s",
-        "oneoff_dirs": [],
-        "oneoff_module_paths": [],
-        "plugin_dirs": [],
-        "plugin_module_paths": [],
-        "restricted_ownership_permissions": None,
-        "send_emails": True,
-        "sentry_dsn": None,
-        "smtp_password": "",
-        "smtp_server": "localhost",
-        "smtp_use_ssl": False,
-        "smtp_username": "",
-        "url": "http://127.0.0.1:8888",
-    }
-)
+class Settings(object):
+    """Grouper configuration settings.
+
+    Provides a parent class for settings objects, machinery for reading settings from the YAML
+    configuration file, and defaults for base settings that apply regardless of application.  Each
+    Grouper application with its own settings will subclass this class and add additional default
+    values and configuration of what sections of the settings file to load.
+    """
+
+    def __init__(self):
+        # type: () -> None
+        """Set up base defaults."""
+        self._logger = logging.getLogger(__name__)
+
+        # Keep attributes here in the same order as in config/dev.yaml.
+        self.auditors_group = ""
+        self.database = ""
+        self.database_source = ""
+        self.date_format = "%Y-%m-%d %I:%M %p"
+        self.expiration_notice_days = 7
+        self.log_format = "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
+        self.nonauditor_expiration_days = 5
+        self.plugin_dirs = []  # type: List[str]
+        self.plugin_module_paths = []  # type: List[str]
+        self.restricted_ownership_permissions = []  # type: List[str]
+        self.send_emails = True
+        self.smtp_server = "localhost"
+        self.smtp_use_ssl = False
+        self.smtp_username = ""
+        self.smtp_password = ""
+        self.from_addr = "no-reply@grouper.local"
+        self.sentry_dsn = None
+        self.service_account_email_domain = "svc.localhost"
+        self.timezone = "UTC"
+        self.url = "http://127.0.0.1:8888"
+
+        # Hide this with a leading underscore so that the configuration can't mess with it.
+        self._timezone_object = pytz.timezone("UTC")
+
+    @property
+    def timezone_object(self):
+        # type: () -> BaseTzInfo
+        return self._timezone_object
+
+    def update_from_config(self, filename=None, section=None):
+        # type: (str, Optional[str]) -> None
+        """Load configuration information from a file and update settings.
+
+        The file will be parsed as YAML.  By default, the common section will be loaded.  If any
+        additional section was specified as a parameter, that section will also be loaded, after
+        the common section.
+
+        Only settings that match an existing attribute in the Settings object will be updated.
+        Other settings in the configuration file will be silently ignored (well, with a debug log
+        message).
+        """
+        if not filename:
+            filename = default_settings_path()
+        self._logger.debug("Loading %s", filename)
+        with open(filename) as config:
+            data = yaml.safe_load(config)
+        settings = data.get("common", {})
+        if section:
+            settings.update(data.get(section, {}))
+
+        # Update the stored attributes from the configuration file, skipping any setting that
+        # doesn't correspond to an attribute on the settings object.  Update the timezone object if
+        # needed.
+        for key, value in iteritems(settings):
+            key = key.lower()
+            if key.startswith("_"):
+                self._logger.warning("Ignoring invalid setting %s", key)
+                continue
+            if not hasattr(self, key):
+                self._logger.debug("Ignoring unknown setting %s", key)
+                continue
+            setattr(self, key, value)
+            if key == "timezone":
+                self._timezone_object = pytz.timezone(self.timezone)
+
+
+def settings():
+    # type: () -> Settings
+    assert _GLOBAL_SETTINGS_OBJECT, "Global Settings object not initialized"
+    return _GLOBAL_SETTINGS_OBJECT
+
+
+def set_global_settings(settings):
+    # type: (Settings) -> None
+    """Set the global settings object with another one.
+
+    This is a horrible hack forced by the use of global singletons for settings, instead of passing
+    around a proper object.
+
+    Each component of Grouper subclasses the global settings object to add its own settings.
+    However, some generic code in Grouper wants to load the current settings object, and may run in
+    multiple components.  We therefore need to set a global singleton after the component has
+    initialized it from a configuration file, and then use it in all other code.
+    """
+    global _GLOBAL_SETTINGS_OBJECT
+    _GLOBAL_SETTINGS_OBJECT = settings

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -29,6 +29,21 @@ class Settings(object):
     values and configuration of what sections of the settings file to load.
     """
 
+    @staticmethod
+    def global_settings_from_config(filename=None, section=None):
+        # type: (Optional[str], Optional[str]) -> Settings
+        """Create and return a new global Settings singleton.
+
+        Create a new Settings object, load the specified configuration file, and then set it as the
+        global singleton Settings object.  This static method is currently required because so much
+        of the code assumes a globally-accessible Settings object rather than passing Settings in
+        to functions that need it.  Once Settings is injected everywhere, this will be deleted.
+        """
+        settings = Settings()
+        settings.update_from_config(filename, section)
+        set_global_settings(settings)
+        return settings
+
     def __init__(self):
         # type: () -> None
         """Set up base defaults."""
@@ -64,7 +79,7 @@ class Settings(object):
         return self._timezone_object
 
     def update_from_config(self, filename=None, section=None):
-        # type: (str, Optional[str]) -> None
+        # type: (Optional[str], Optional[str]) -> None
         """Load configuration information from a file and update settings.
 
         The file will be parsed as YAML.  By default, the common section will be loaded.  If any

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -41,7 +41,6 @@ class Settings(object):
         self.date_format = "%Y-%m-%d %I:%M %p"
         self.expiration_notice_days = 7
         self.log_format = "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
-        self.nonauditor_expiration_days = 5
         self.plugin_dirs = []  # type: List[str]
         self.plugin_module_paths = []  # type: List[str]
         self.restricted_ownership_permissions = []  # type: List[str]

--- a/grouper/util.py
+++ b/grouper/util.py
@@ -116,10 +116,7 @@ def singleton(f):
 def reference_id(settings, request_type, request):
     # type: (Settings, str, Any) -> str
     """Generates the 'References' for a request"""
-    try:
-        domain = settings["service_account_email_domain"]
-    except KeyError:
-        domain = "grouper.local"
+    domain = settings.service_account_email_domain
     return "<{type}.{id}.{ts}@{prefix}.{domain}>".format(
         type=request_type,
         id=request.id,

--- a/tests/audit_test.py
+++ b/tests/audit_test.py
@@ -16,6 +16,7 @@ from grouper.audit import (
     UserNotAuditor,
 )
 from grouper.background.background_processor import BackgroundProcessor
+from grouper.background.settings import BackgroundSettings
 from grouper.constants import AUDIT_VIEWER, PERMISSION_AUDITOR
 from grouper.graph import NoSuchGroup
 from grouper.models.audit_log import AuditLog, AuditLogCategory
@@ -23,7 +24,7 @@ from grouper.models.group import Group
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing, get_or_create_permission
-from grouper.settings import settings
+from grouper.settings import set_global_settings
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
     graph,
@@ -291,6 +292,8 @@ def test_auditor_promotion(mock_nnp, mock_gagn, session, graph, permissions, use
     user43 will be added to the auditors group.
 
     """
+    settings = BackgroundSettings()
+    set_global_settings(settings)
 
     #
     # set up our test part of the graph

--- a/tests/ctl_util.py
+++ b/tests/ctl_util.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.main import main
+from tests.path_util import src_path
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
@@ -9,11 +10,11 @@ if TYPE_CHECKING:
 
 def call_main(session, *args):
     # type: (Session, *str) -> None
-    argv = ["grouper-ctl"] + list(args)
-    main(sys_argv=argv, start_config_thread=False, session=session)
+    argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml")] + list(args)
+    main(sys_argv=argv, session=session)
 
 
 def run_ctl(setup, *args):
     # type: (SetupTest, *str) -> None
-    argv = ["grouper-ctl"] + list(args)
-    main(sys_argv=argv, start_config_thread=False, session=setup.session)
+    argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml")] + list(args)
+    main(sys_argv=argv, session=setup.session)

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -4,11 +4,12 @@ import pytest
 from mock import patch
 
 from grouper.background.background_processor import BackgroundProcessor
+from grouper.background.settings import BackgroundSettings
 from grouper.models.async_notification import AsyncNotification
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 from grouper.models.group_edge import GroupEdge
-from grouper.settings import settings
+from grouper.settings import set_global_settings
 from tests.fixtures import (  # noqa: F401
     graph,
     groups,
@@ -60,6 +61,8 @@ def test_expire_edges(expired_graph, session):  # noqa: F811
         assert edge.active == True
 
     # Expire the edges.
+    settings = BackgroundSettings()
+    set_global_settings(settings)
     background = BackgroundProcessor(settings, None)
     background.expire_edges(session)
 
@@ -108,6 +111,8 @@ def test_promote_nonauditors(
         assert not affected_users.intersection(get_users(graph, "auditors"))
 
         # do the promotion logic
+        settings = BackgroundSettings()
+        set_global_settings(settings)
         background = BackgroundProcessor(settings, None)
         background.promote_nonauditors(session)
 

--- a/tests/fe/util_test.py
+++ b/tests/fe/util_test.py
@@ -1,19 +1,10 @@
 from datetime import datetime
 
 import pytz
-from mock import patch
 from pytz import UTC
 
 from grouper.fe.template_util import expires_when_str, long_ago_str, print_date
-
-
-def fake_settings_getitem(key):
-    if key == "timezone":
-        return pytz.timezone("US/Pacific")
-    elif key == "date_format":
-        return "%Y-%m-%d %I:%M %p"
-
-    assert "unknown setting"
+from grouper.settings import set_global_settings, Settings
 
 
 def test_expires_when_str():
@@ -52,9 +43,13 @@ def test_long_ago_str():
         assert long_ago_str(date_, utcnow_fn=utcnow_fn) == expected, msg
 
 
-@patch("grouper.fe.template_util.settings")
-def test_print_date(mock_settings):
-    mock_settings.__getitem__.side_effect = fake_settings_getitem
+def test_print_date():
+    # type: () -> None
+    settings = Settings()
+    settings.date_format = "%Y-%m-%d %I:%M %p"
+    settings.timezone = "US/Pacific"
+    settings._timezone_object = pytz.timezone("US/Pacific")
+    set_global_settings(settings)
 
     for date_, expected, msg in [
         (datetime(2015, 8, 11, 18, tzinfo=UTC), "2015-08-11 11:00 AM", "from datetime object"),

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from grouper.api.main import create_api_application
+from grouper.api.settings import ApiSettings
 from grouper.app import GrouperApplication
 from grouper.constants import (
     AUDIT_MANAGER,
@@ -16,6 +17,7 @@ from grouper.constants import (
     USER_ADMIN,
 )
 from grouper.fe.main import create_fe_application
+from grouper.fe.settings import FrontendSettings
 from grouper.graph import Graph
 from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.model_base import Model
@@ -25,7 +27,7 @@ from grouper.models.permission import Permission
 from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing
 from grouper.service_account import create_service_account
-from grouper.settings import Settings
+from grouper.settings import set_global_settings, Settings
 from tests.path_util import db_url
 from tests.util import add_member, grant_permission
 
@@ -164,6 +166,9 @@ def standard_graph(session, graph, users, groups, service_accounts, permissions)
 
 @pytest.fixture
 def session(request, tmpdir):
+    settings = Settings()
+    set_global_settings(settings)
+
     db_engine = get_db_engine(db_url(tmpdir))
 
     # Create the database schema and the corresponding session.
@@ -298,7 +303,8 @@ def permissions(session, users):
 @pytest.fixture
 def api_app(session, standard_graph):
     # type: (Session, GroupGraph) -> GrouperApplication
-    settings = Settings({"debug": False})
+    settings = ApiSettings()
+    set_global_settings(settings)
     usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
     return create_api_application(standard_graph, settings, usecase_factory)
 
@@ -306,7 +312,8 @@ def api_app(session, standard_graph):
 @pytest.fixture
 def fe_app(session, standard_graph, tmpdir):
     # type: (Session, GroupGraph, LocalPath) -> GrouperApplication
-    settings = Settings({"debug": False})
+    settings = FrontendSettings()
+    set_global_settings(settings)
     usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
     return create_fe_application(
         settings, usecase_factory, "", xsrf_cookies=False, session=lambda: session

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -12,7 +12,7 @@ from tests.util import add_member, edit_member, grant_permission, revoke_member
 @pytest.fixture
 def expiring_graph(session, graph, users, groups, permissions):  # noqa: F811
     now = datetime.utcnow()
-    note_exp_now = now + timedelta(settings.expiration_notice_days)
+    note_exp_now = now + timedelta(settings().expiration_notice_days)
     week = timedelta(7)
 
     add_member(groups["team-sre"], users["oliver@a.co"], role="owner")
@@ -41,7 +41,7 @@ def test_expiration_notifications(
     expiring_graph, session, users, groups, permissions  # noqa: F811
 ):
     now = datetime.utcnow()
-    note_exp_now = now + timedelta(settings.expiration_notice_days)
+    note_exp_now = now + timedelta(settings().expiration_notice_days)
     day = timedelta(1)
     week = timedelta(7)
 
@@ -105,10 +105,10 @@ def test_expiration_notifications(
     ]
 
     # Send notices about expirations coming up in the next day, next week.
-    notices_sent = process_async_emails(settings, session, now + day, dry_run=True)
+    notices_sent = process_async_emails(settings(), session, now + day, dry_run=True)
     assert notices_sent == 0
 
-    notices_sent = process_async_emails(settings, session, now + week, dry_run=True)
+    notices_sent = process_async_emails(settings(), session, now + week, dry_run=True)
     assert notices_sent == 3
     # ("serving-team", "team-sre", "gary@a.co")
     # ("serving-team", "team-sre", "oliver@a.co")
@@ -123,7 +123,7 @@ def test_expiration_notifications(
     assert upcoming_expirations == [("tech-ops", "gary@a.co", "gary@a.co")]
 
     # We already sent these notices.
-    notices_sent = process_async_emails(settings, session, now + week, dry_run=True)
+    notices_sent = process_async_emails(settings(), session, now + week, dry_run=True)
     assert notices_sent == 0
 
     # Extend gary's membership to beyond worth mentioning expiration in two weeks.
@@ -132,5 +132,5 @@ def test_expiration_notifications(
     upcoming_expirations = _get_unsent_expirations(session, now + 2 * week)
     assert upcoming_expirations == []
 
-    notices_sent = process_async_emails(settings, session, now + 2 * week, dry_run=True)
+    notices_sent = process_async_emails(settings(), session, now + 2 * week, dry_run=True)
     assert notices_sent == 0

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -59,7 +59,8 @@ class SetupTest(object):
         # type: (LocalPath) -> None
         self.session = self.create_session(tmpdir)
         self.graph = GroupGraph()
-        self.settings = Settings({"database": db_url(tmpdir)})
+        self.settings = Settings()
+        self.settings.database = db_url(tmpdir)
         self.repository_factory = GraphRepositoryFactory(self.settings, self.session, self.graph)
         self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)

--- a/tests/shells_test.py
+++ b/tests/shells_test.py
@@ -1,9 +1,9 @@
 import pytest
-from mock import patch
 from six.moves.urllib.parse import urlencode
 
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.models.user import User
+from grouper.settings import settings
 from grouper.user_metadata import get_user_metadata_by_key
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
@@ -20,66 +20,65 @@ from tests.url_util import url
 
 @pytest.mark.gen_test
 def test_shell(session, users, http_client, base_url):  # noqa: F811
-    with patch("grouper.fe.handlers.user_shell.settings") as mock_settings:
-        mock_settings.shell = [["/bin/bash", "bash"], ["/bin/zsh", "zsh"]]
+    settings().shell = [["/bin/bash", "bash"], ["/bin/zsh", "zsh"]]
 
-        user = users["zorkian@a.co"]
-        assert not get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
+    user = users["zorkian@a.co"]
+    assert not get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
 
-        user = User.get(session, name=user.username)
-        fe_url = url(base_url, "/users/{}/shell".format(user.username))
-        resp = yield http_client.fetch(
-            fe_url,
-            method="POST",
-            body=urlencode({"shell": "/bin/bash"}),
-            headers={"X-Grouper-User": user.username},
-        )
-        assert resp.code == 200
+    user = User.get(session, name=user.username)
+    fe_url = url(base_url, "/users/{}/shell".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"shell": "/bin/bash"}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
 
-        user = User.get(session, name=user.username)
+    user = User.get(session, name=user.username)
 
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
-        ), "The user should have shell metadata"
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
-            == "/bin/bash"
-        )
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
+    ), "The user should have shell metadata"
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
+        == "/bin/bash"
+    )
 
-        fe_url = url(base_url, "/users/{}/shell".format(user.username))
-        resp = yield http_client.fetch(
-            fe_url,
-            method="POST",
-            body=urlencode({"shell": "/bin/fish"}),
-            headers={"X-Grouper-User": user.username},
-        )
-        assert resp.code == 200
+    fe_url = url(base_url, "/users/{}/shell".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"shell": "/bin/fish"}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
 
-        user = User.get(session, name=user.username)
+    user = User.get(session, name=user.username)
 
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
-        ), "The user should have shell metadata"
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
-            == "/bin/bash"
-        )
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
+    ), "The user should have shell metadata"
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
+        == "/bin/bash"
+    )
 
-        fe_url = url(base_url, "/users/{}/shell".format(user.username))
-        resp = yield http_client.fetch(
-            fe_url,
-            method="POST",
-            body=urlencode({"shell": "/bin/zsh"}),
-            headers={"X-Grouper-User": user.username},
-        )
-        assert resp.code == 200
+    fe_url = url(base_url, "/users/{}/shell".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"shell": "/bin/zsh"}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
 
-        user = User.get(session, name=user.username)
+    user = User.get(session, name=user.username)
 
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
-        ), "The user should have shell metadata"
-        assert (
-            get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
-            == "/bin/zsh"
-        )
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY) is not None
+    ), "The user should have shell metadata"
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
+        == "/bin/zsh"
+    )


### PR DESCRIPTION
Replace the complex Settings object with a much simpler, more
transparent container object that exports its attributes directly,
allowing for better typing.  Remove the background reload thread,
which was both unnecessary complexity and made rollouts dangerous
because the running service would immediately pick up configuration
changes.

Some horrible hacks were required to maintain the global settings
singleton.  This can be slowly teased apart over time with other
refactors, but is currently deeply embedded in the code.  Passing
settings as an argument required very painful and sweeping changes
and would have made the diff far too large.

Fix a long-standing bug where there were multiple global singletons
and only some were reloaded by the background thread.  There is now
a single global settings singleton, but this required changing
settings to be a function (and thus some widespread code changes).

Shuffle some settings around between sections (mostly moving them
to common, although ctl now has a separate section with the oneoffs)
to reflect where those settings are used and to not require frontend
settings when sending email in the background processor.