### PR TITLE
Lay the groundwork for showing service permission grants

### DIFF
--- a/grouper/entities/audit_log_entry.py
+++ b/grouper/entities/audit_log_entry.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 from typing import NamedTuple, Optional
 
 AuditLogEntry = NamedTuple(
     "AuditLogEntry",
     [
+        ("date", datetime),
         ("actor", str),
         ("action", str),
         ("description", str),

--- a/grouper/entities/permission.py
+++ b/grouper/entities/permission.py
@@ -2,7 +2,19 @@ from datetime import datetime
 from typing import NamedTuple
 
 Permission = NamedTuple(
-    "Permission", [("name", str), ("description", str), ("created_on", datetime)]
+    "Permission",
+    [
+        ("name", str),
+        ("description", str),
+        ("created_on", datetime),
+        ("audited", bool),
+        ("enabled", bool),
+    ],
+)
+
+# The actions a user can perform on a permission.
+PermissionAccess = NamedTuple(
+    "PermissionAccess", [("can_disable", bool), ("can_change_audited_status", bool)]
 )
 
 

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -1,3 +1,10 @@
 from typing import NamedTuple
 
 PermissionGrant = NamedTuple("PermissionGrant", [("name", str), ("argument", str)])
+GroupPermissionGrant = NamedTuple(
+    "GroupPermissionGrant", [("group", str), ("permission", str), ("argument", str)]
+)
+ServiceAccountPermissionGrant = NamedTuple(
+    "ServiceAccountPermissionGrant",
+    [("service_account", str), ("permission", str), ("argument", str)],
+)

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -1,32 +1,43 @@
-from grouper.constants import AUDIT_MANAGER
+from typing import TYPE_CHECKING
+
 from grouper.fe.util import GrouperHandler
-from grouper.permissions import (
-    get_groups_by_permission,
-    get_log_entries_by_permission,
-    get_permission,
-)
-from grouper.user_permissions import user_has_permission, user_is_permission_admin
+from grouper.usecases.view_permission import ViewPermissionUI
+
+if TYPE_CHECKING:
+    from grouper.entities.audit_log_entry import AuditLogEntry
+    from grouper.entities.permission import Permission, PermissionAccess
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
+    from typing import Any, List
 
 
-class PermissionView(GrouperHandler):
-    def get(self, name=None):
-        # TODO: use cached data instead, add refresh to appropriate redirects.
-        permission = get_permission(self.session, name)
-        if not permission:
-            return self.notfound()
-
-        can_change_audit_status = user_is_permission_admin(
-            self.session, self.current_user
-        ) or user_has_permission(self.session, self.current_user, AUDIT_MANAGER)
-        can_disable = user_is_permission_admin(self.session, self.current_user)
-        mapped_groups = get_groups_by_permission(self.session, permission)
-        log_entries = get_log_entries_by_permission(self.session, permission)
-
+class PermissionView(GrouperHandler, ViewPermissionUI):
+    def viewed_permission(
+        self,
+        permission,  # type: Permission
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+        access,  # type: PermissionAccess
+        audit_log_entries,  # type: List[AuditLogEntry]
+    ):
+        # type (...) -> None
         self.render(
             "permission.html",
             permission=permission,
-            can_disable=can_disable,
-            mapped_groups=mapped_groups,
-            log_entries=log_entries,
-            can_change_audit_status=can_change_audit_status,
+            access=access,
+            group_grants=group_grants,
+            service_account_grants=service_account_grants,
+            audit_log_entries=audit_log_entries,
         )
+
+    def view_permission_failed_not_found(self, name):
+        # type: (str) -> None
+        self.notfound()
+
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        name = kwargs["name"]  # type: str
+        usecase = self.usecase_factory.create_view_permission_usecase(self)
+        usecase.view_permission(name, self.current_user.username, audit_log_limit=20)

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -358,6 +358,7 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
+{# The old panel, which uses an old serialization format for the entries based on SQLAlchemy. #}
 {% macro log_entry_panel(log_entries) -%}
     <div class="panel panel-default">
         <div class="panel-heading">
@@ -397,6 +398,58 @@ enabled. Membership in this group is regularly reviewed.
                     </tr>
                 {% endfor %}
                 {% if not log_entries %}
+                    <tr>
+                        <td colspan="5" class="text-center">
+                            <em>No activity found.</em>
+                        </td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{%- endmacro %}
+
+{# The new panel, which expects a list of AuditLogEntry. #}
+{% macro audit_log_panel(audit_log_entries) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Recent Activity</h3>
+        </div>
+        <div class="standard-panel">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Date</th>
+                        <th class="col-sm-2">Actor</th>
+                        <th class="col-sm-2">Action</th>
+                        <th class="col-sm-2">Description</th>
+                        <th class="col-sm-2">Extra</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for entry in audit_log_entries %}
+                    <tr>
+                        <td class="col-sm-2">{{ entry.date|print_date }}</td>
+                        <td class="col-sm-2">
+                            {{ account(entry.actor, type="user") }}
+                        </td>
+                        <td class="col-sm-2">{{ entry.action }}</td>
+                        <td class="col-sm-2">{{ entry.description|escape }}</td>
+                        <td class="col-sm-2">
+                            {% if entry.on_group %}
+                                Group: {{ account(entry.on_group, type="group") }}<br />
+                            {% endif %}
+                            {% if entry.on_permission %}
+                                Permission: {{ permission(entry.on_permission) }}<br />
+                            {% endif %}
+                            {% if entry.on_user %}
+                                User: {{ account(entry.on_user, type="user") }}<br />
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                {% if not audit_log_entries %}
                     <tr>
                         <td colspan="5" class="text-center">
                             <em>No activity found.</em>

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import log_entry_panel, paginator, dropdown with context %}
+{% from 'macros/ui.html' import audit_log_panel, paginator, dropdown with context %}
 
 {% block subtitle %} permission {{ permission.name }}{% endblock %}
 
@@ -12,12 +12,12 @@
 {% endblock %}
 
 {% block headingbuttons %}
-    {% if permission.enabled and can_disable %}
+    {% if permission.enabled and access.can_disable %}
         <button class="btn btn-danger disable-permission" data-toggle="modal" data-target="#disablePermModal">
             <i class="fa fa-minus"></i> Disable Permission
         </button>
     {% endif %}
-    {% if permission.enabled and can_change_audit_status %}
+    {% if permission.enabled and access.can_change_audited_status %}
         {% if permission.audited %}
             <button class="btn btn-danger disable-auditing" data-toggle="modal" data-target="#disableAuditingModal">
                 <i class="fa fa-minus"></i> Disable Auditing
@@ -63,17 +63,17 @@
                     </tr>
                 </thead>
                 <tbody>
-                {% for mapped_group in mapped_groups %}
+                {% for grant in group_grants %}
                     <tr class="grant-row">
                         <td class="grant-group">
-                            <a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a>
+                            <a href="/groups/{{grant.group}}">{{grant.group}}</a>
                         </td>
                         <td class="grant-argument">
-                            {{mapped_group.argument|default("(unargumented)", True)}}
+                            {{grant.argument|default("(unargumented)", True)}}
                         </td>
                     </tr>
                 {% endfor %}
-                {% if not mapped_groups %}
+                {% if not group_grants %}
                     <tr class="no-grants">
                         <td colspan="2" class="text-center"><em>This permission is not mapped to any
                         groups. To grant this permission to a group, visit the group page.</em></td>
@@ -87,7 +87,7 @@
 
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
-        {{ log_entry_panel(log_entries) }}
+        {{ audit_log_panel(audit_log_entries) }}
     </div>
 </div>
 

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -19,11 +19,11 @@
     {% endif %}
     {% if permission.enabled and can_change_audit_status %}
         {% if permission.audited %}
-            <button class="btn btn-danger" data-toggle="modal" data-target="#disableAuditingModal">
+            <button class="btn btn-danger disable-auditing" data-toggle="modal" data-target="#disableAuditingModal">
                 <i class="fa fa-minus"></i> Disable Auditing
             </button>
         {% else %}
-            <button class="btn btn-warning" data-toggle="modal" data-target="#enableAuditingModal">
+            <button class="btn btn-warning enable-auditing" data-toggle="modal" data-target="#enableAuditingModal">
                 <i class="fa fa-plus"></i> Enable Auditing
             </button>
         {% endif %}
@@ -36,7 +36,8 @@
 {% block content %}
 {% if permission.description %}
     <p>
-        <b>Description:</b> “{{ permission.description }}”
+        <b>Description:</b>
+        “<span class="permission-description">{{ permission.description }}</span>”
     </p>
 {% endif %}
 
@@ -63,13 +64,17 @@
                 </thead>
                 <tbody>
                 {% for mapped_group in mapped_groups %}
-                    <tr>
-                        <td><a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a></td>
-                        <td>{{mapped_group.argument|default("(unargumented)", True)}}</td>
+                    <tr class="grant-row">
+                        <td class="grant-group">
+                            <a href="/groups/{{mapped_group.groupname}}">{{mapped_group.groupname}}</a>
+                        </td>
+                        <td class="grant-argument">
+                            {{mapped_group.argument|default("(unargumented)", True)}}
+                        </td>
                     </tr>
                 {% endfor %}
                 {% if not mapped_groups %}
-                    <tr>
+                    <tr class="no-grants">
                         <td colspan="2" class="text-center"><em>This permission is not mapped to any
                         groups. To grant this permission to a group, visit the group page.</em></td>
                     </tr>

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -26,8 +26,8 @@ class AuditLogRepository(object):
         # type: (Session) -> None
         self.session = session
 
-    def get_entries_affecting_permission(self, permission):
-        # type: (str) -> List[AuditLogEntry]
+    def entries_affecting_permission(self, permission, limit):
+        # type: (str, int) -> List[AuditLogEntry]
         permission_obj = Permission.get(self.session, name=permission)
         if not permission_obj:
             return []
@@ -35,6 +35,7 @@ class AuditLogRepository(object):
             self.session.query(AuditLog)
             .filter(AuditLog.on_permission_id == permission_obj.id)
             .order_by(desc(AuditLog.log_time))
+            .limit(limit)
         )
         return [self._to_audit_log_entry(e) for e in results]
 
@@ -104,6 +105,7 @@ class AuditLogRepository(object):
     def _to_audit_log_entry(self, entry):
         # type: (AuditLog) -> AuditLogEntry
         return AuditLogEntry(
+            date=entry.log_time,
             actor=entry.actor.username,
             action=entry.action,
             description=entry.description,

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -48,6 +48,7 @@ class AuditLogRepository(object):
         on_group=None,  # type: Optional[str]
         on_permission=None,  # type: Optional[str]
         category=AuditLogCategory.general,  # type: AuditLogCategory
+        date=None,  # type: Optional[datetime]
     ):
         # type: (...) -> None
         """Log an action to the audit log.
@@ -56,6 +57,8 @@ class AuditLogRepository(object):
         are ported to this service.
         """
         actor = self._id_for_user(authorization.actor)
+        if not date:
+            date = datetime.utcnow()
 
         # We currently have no way to log audit log entries for objects that no longer exist.  This
         # should eventually be fixed via a schema change to use strings for all fields of the audit
@@ -66,7 +69,7 @@ class AuditLogRepository(object):
 
         entry = AuditLog(
             actor_id=actor,
-            log_time=datetime.utcnow(),
+            log_time=date,
             action=action,
             description=description,
             on_user_id=user,

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -89,7 +89,8 @@ class GraphRepositoryFactory(RepositoryFactory):
 
     def create_permission_grant_repository(self):
         # type: () -> PermissionGrantRepository
-        return GraphPermissionGrantRepository(self.graph)
+        sql_permission_grant_repository = SQLPermissionGrantRepository(self.session)
+        return GraphPermissionGrantRepository(self.graph, sql_permission_grant_repository)
 
     def create_service_account_repository(self):
         # type: () -> ServiceAccountRepository

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -6,7 +6,11 @@ from six import with_metaclass
 if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
-    from grouper.entities.permission_grant import PermissionGrant
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        PermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.repositories.checkpoint import CheckpointRepository
     from grouper.repositories.group_request import GroupRequestRepository
@@ -49,8 +53,18 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission grant repositories."""
 
     @abstractmethod
-    def permission_grants_for_user(self, user):
+    def group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        pass
+
+    @abstractmethod
+    def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
+        pass
+
+    @abstractmethod
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -54,7 +54,13 @@ class GraphPermissionRepository(PermissionRepository):
 
         # Convert to the correct data transfer object.
         permissions = [
-            Permission(name=p.name, description=p.description, created_on=p.created_on)
+            Permission(
+                name=p.name,
+                description=p.description,
+                created_on=p.created_on,
+                audited=p.audited,
+                enabled=True,
+            )
             for p in perm_tuples
         ]
         return PaginatedList[Permission](
@@ -78,6 +84,8 @@ class SQLPermissionRepository(PermissionRepository):
             name=permission.name,
             description=permission.description,
             created_on=permission.created_on,
+            audited=permission.audited,
+            enabled=permission.enabled,
         )
 
     def disable_permission(self, name):

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -3,12 +3,18 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_
 
-from grouper.entities.permission_grant import PermissionGrant
+from grouper.entities.permission_grant import (
+    GroupPermissionGrant,
+    PermissionGrant,
+    ServiceAccountPermissionGrant,
+)
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
+from grouper.models.service_account import ServiceAccount
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.user import User
 from grouper.repositories.interfaces import PermissionGrantRepository
 
@@ -21,13 +27,18 @@ if TYPE_CHECKING:
 class GraphPermissionGrantRepository(PermissionGrantRepository):
     """Graph-aware storage layer for permission grants."""
 
-    def __init__(self, graph):
-        # type: (GroupGraph) -> None
+    def __init__(self, graph, repository):
+        # type: (GroupGraph, PermissionGrantRepository) -> None
         self.graph = graph
+        self.repository = repository
 
-    def permission_grants_for_user(self, user):
+    def group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        return self.repository.group_grants_for_permission(name)
+
+    def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
-        user_details = self.graph.get_user_details(user)
+        user_details = self.graph.get_user_details(name)
         permissions = []
         for permission_data in user_details["permissions"]:
             permission = PermissionGrant(
@@ -35,6 +46,10 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
             )
             permissions.append(permission)
         return permissions
+
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        return self.repository.service_account_grants_for_permission(name)
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
@@ -51,10 +66,27 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
         # type: (Session) -> None
         self.session = session
 
-    def permission_grants_for_user(self, username):
+    def group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        permission = Permission.get(self.session, name=name)
+        if not permission or not permission.enabled:
+            return []
+        grants = (
+            self.session.query(Group.groupname, PermissionMap.argument)
+            .filter(
+                PermissionMap.permission_id == permission.id,
+                Group.id == PermissionMap.group_id,
+                Group.enabled == True,
+            )
+            .order_by(Group.groupname, PermissionMap.argument)
+            .all()
+        )
+        return [GroupPermissionGrant(g.groupname, name, g.argument) for g in grants]
+
+    def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
         now = datetime.utcnow()
-        user = User.get(self.session, name=username)
+        user = User.get(self.session, name=name)
         if not user or user.role_user or user.is_service_account or not user.enabled:
             return []
 
@@ -110,6 +142,24 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
             .all()
         )
         return [PermissionGrant(g.name, g.argument) for g in group_permission_grants]
+
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        permission = Permission.get(self.session, name=name)
+        if not permission or not permission.enabled:
+            return []
+        grants = (
+            self.session.query(User.username, ServiceAccountPermissionMap.argument)
+            .filter(
+                ServiceAccountPermissionMap.permission_id == permission.id,
+                ServiceAccount.id == ServiceAccountPermissionMap.service_account_id,
+                User.id == ServiceAccount.user_id,
+                User.enabled == True,
+            )
+            .order_by(User.username, ServiceAccountPermissionMap.argument)
+            .all()
+        )
+        return [ServiceAccountPermissionGrant(g.username, name, g.argument) for g in grants]
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -1,12 +1,16 @@
 from typing import TYPE_CHECKING
 
+from grouper.usecases.interfaces import AuditLogInterface
+
 if TYPE_CHECKING:
+    from grouper.entities.audit_log_entry import AuditLogEntry
     from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.usecases.authorization import Authorization
+    from typing import List
 
 
-class AuditLogService(object):
+class AuditLogService(AuditLogInterface):
     """Updates the audit log when changes are made."""
 
     def __init__(self, audit_log_repository):
@@ -20,6 +24,15 @@ class AuditLogService(object):
             action="create_service_account_from_disabled_user",
             description="Convert a disabled user into a disabled service account",
             on_user=user,
+        )
+
+    def log_create_permission(self, permission, authorization):
+        # type: (str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="create_permission",
+            description="Created permission.",
+            on_permission=permission,
         )
 
     def log_disable_permission(self, permission, authorization):
@@ -59,3 +72,7 @@ class AuditLogService(object):
             on_group=request.group,
             on_user=request.requester,
         )
+
+    def entries_affecting_permission(self, permission, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        return self.audit_log_repository.entries_affecting_permission(permission, limit)

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -3,74 +3,86 @@ from typing import TYPE_CHECKING
 from grouper.usecases.interfaces import AuditLogInterface
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from grouper.entities.audit_log_entry import AuditLogEntry
     from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.usecases.authorization import Authorization
-    from typing import List
+    from typing import List, Optional
 
 
 class AuditLogService(AuditLogInterface):
-    """Updates the audit log when changes are made."""
+    """Updates the audit log when changes are made.
+
+    The date parameter to the log methods is primarily for use in tests, where to get a consistent
+    sort order the audit log entries may need to be spaced out over time.  If not set, the default
+    is the current time.
+    """
 
     def __init__(self, audit_log_repository):
         # type: (AuditLogRepository) -> None
         self.audit_log_repository = audit_log_repository
 
-    def log_create_service_account_from_disabled_user(self, user, authorization):
-        # type: (str, Authorization) -> None
+    def log_create_service_account_from_disabled_user(self, user, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="create_service_account_from_disabled_user",
             description="Convert a disabled user into a disabled service account",
             on_user=user,
+            date=date,
         )
 
-    def log_create_permission(self, permission, authorization):
-        # type: (str, Authorization) -> None
+    def log_create_permission(self, permission, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="create_permission",
             description="Created permission.",
             on_permission=permission,
+            date=date,
         )
 
-    def log_disable_permission(self, permission, authorization):
-        # type: (str, Authorization) -> None
+    def log_disable_permission(self, permission, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="disable_permission",
             description="Disabled permission",
             on_permission=permission,
+            date=date,
         )
 
-    def log_disable_user(self, username, authorization):
-        # type: (str, Authorization) -> None
+    def log_disable_user(self, username, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="disable_user",
             description="Disabled user",
             on_user=username,
+            date=date,
         )
 
-    def log_enable_service_account(self, user, owner, authorization):
-        # type: (str, str, Authorization) -> None
+    def log_enable_service_account(self, user, owner, authorization, date=None):
+        # type: (str, str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="enable_service_account",
             description="Enabled service account",
             on_user=user,
             on_group=owner,
+            date=date,
         )
 
-    def log_user_group_request_status_change(self, request, status, authorization):
-        # type: (UserGroupRequest, GroupRequestStatus, Authorization) -> None
+    def log_user_group_request_status_change(self, request, status, authorization, date=None):
+        # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
             authorization=authorization,
             action="update_request",
             description="Updated request to status: {}".format(status.value),
             on_group=request.group,
             on_user=request.requester,
+            date=date,
         )
 
     def entries_affecting_permission(self, permission, limit):

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -10,6 +10,7 @@ from grouper.services.user import UserService
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import RepositoryFactory
     from grouper.usecases.interfaces import (
+        AuditLogInterface,
         GroupRequestInterface,
         PermissionInterface,
         ServiceAccountInterface,
@@ -25,24 +26,29 @@ class ServiceFactory(object):
         # type: (RepositoryFactory) -> None
         self.repository_factory = repository_factory
 
+    def create_audit_log_service(self):
+        # type: () -> AuditLogInterface
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        return AuditLogService(audit_log_repository)
+
     def create_group_request_service(self):
         # type: () -> GroupRequestInterface
-        audit_log_repository = self.repository_factory.create_audit_log_repository()
-        audit_log_service = AuditLogService(audit_log_repository)
+        audit_log_service = self.create_audit_log_service()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return GroupRequestService(group_request_repository, audit_log_service)
 
     def create_permission_service(self):
         # type: () -> PermissionInterface
-        audit_log_repository = self.repository_factory.create_audit_log_repository()
-        audit_log_service = AuditLogService(audit_log_repository)
+        audit_log_service = self.create_audit_log_service()
         permission_repository = self.repository_factory.create_permission_repository()
-        return PermissionService(audit_log_service, permission_repository)
+        permission_grant_repository = self.repository_factory.create_permission_grant_repository()
+        return PermissionService(
+            audit_log_service, permission_repository, permission_grant_repository
+        )
 
     def create_service_account_service(self):
         # type: () -> ServiceAccountInterface
-        audit_log_repository = self.repository_factory.create_audit_log_repository()
-        audit_log_service = AuditLogService(audit_log_repository)
+        audit_log_service = self.create_audit_log_service()
         user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
         group_edge_repository = self.repository_factory.create_group_edge_repository()
@@ -63,8 +69,7 @@ class ServiceFactory(object):
 
     def create_user_service(self):
         # type: () -> UserInterface
-        audit_log_repository = self.repository_factory.create_audit_log_repository()
-        audit_log_service = AuditLogService(audit_log_repository)
+        audit_log_service = self.create_audit_log_service()
         user_repository = self.repository_factory.create_user_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
         group_edge_repository = self.repository_factory.create_group_edge_repository()

--- a/grouper/services/group_request.py
+++ b/grouper/services/group_request.py
@@ -5,15 +5,15 @@ from grouper.usecases.interfaces import GroupRequestInterface
 
 if TYPE_CHECKING:
     from grouper.repositories.group_request import GroupRequestRepository
-    from grouper.services.audit_log import AuditLogService
     from grouper.usecases.authorization import Authorization
+    from grouper.usecases.interfaces import AuditLogInterface
 
 
 class GroupRequestService(GroupRequestInterface):
     """High-level logic to manipulate requests to join groups."""
 
     def __init__(self, group_request_repository, audit_log_service):
-        # type: (GroupRequestRepository, AuditLogService) -> None
+        # type: (GroupRequestRepository, AuditLogInterface) -> None
         self.group_request_repository = group_request_repository
         self.audit_log_service = audit_log_service
 

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
     from grouper.repositories.group_request import GroupRequestRepository
     from grouper.repositories.service_account import ServiceAccountRepository
     from grouper.repositories.user import UserRepository
-    from grouper.services.audit_log import AuditLogService
     from grouper.usecases.authorization import Authorization
+    from grouper.usecases.interfaces import AuditLogInterface
 
 
 class ServiceAccountService(ServiceAccountInterface):
@@ -25,7 +25,7 @@ class ServiceAccountService(ServiceAccountInterface):
         service_account_repository,  # type: ServiceAccountRepository
         group_edge_repository,  # type: GroupEdgeRepository
         group_request_repository,  # type: GroupRequestRepository
-        audit_log_service,  # type: AuditLogService
+        audit_log_service,  # type: AuditLogInterface
     ):
         # type: (...) -> None
         self.user_repository = user_repository

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
-from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE, USER_ADMIN
+from grouper.constants import AUDIT_MANAGER, PERMISSION_ADMIN, PERMISSION_CREATE, USER_ADMIN
+from grouper.entities.permission import PermissionAccess
 from grouper.usecases.interfaces import UserInterface
 
 if TYPE_CHECKING:
@@ -8,8 +9,8 @@ if TYPE_CHECKING:
     from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.user import UserRepository
-    from grouper.services.audit_log import AuditLogService
     from grouper.usecases.authorization import Authorization
+    from grouper.usecases.interfaces import AuditLogInterface
     from typing import List
 
 
@@ -21,7 +22,7 @@ class UserService(UserInterface):
         user_repository,  # type: UserRepository
         permission_grant_repository,  # type: PermissionGrantRepository
         group_edge_repository,  # type: GroupEdgeRepository
-        audit_log_service,  # type: AuditLogService
+        audit_log_service,  # type: AuditLogInterface
     ):
         # type: (...) -> None
         self.user_repository = user_repository
@@ -38,9 +39,20 @@ class UserService(UserInterface):
         # type: (str) -> List[str]
         return self.group_edge_repository.groups_of_user(user)
 
+    def permission_access_for_user(self, user, permission):
+        # type: (str, str) -> PermissionAccess
+        permission_admin = self.user_is_permission_admin(user)
+        can_disable = permission_admin
+        can_change_audited_status = permission_admin or self.user_is_audit_manager(user)
+        return PermissionAccess(can_disable, can_change_audited_status)
+
     def permission_grants_for_user(self, user):
         # type: (str) -> List[PermissionGrant]
         return self.permission_grant_repository.permission_grants_for_user(user)
+
+    def user_is_audit_manager(self, user):
+        # type: (str) -> bool
+        return self.permission_grant_repository.user_has_permission(user, AUDIT_MANAGER)
 
     def user_is_permission_admin(self, user):
         # type: (str) -> bool

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -3,12 +3,14 @@ from typing import TYPE_CHECKING
 from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
 from grouper.usecases.list_permissions import ListPermissions
+from grouper.usecases.view_permission import ViewPermission
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.list_permissions import ListPermissionsUI
+    from grouper.usecases.view_permission import ViewPermissionUI
 
 
 class UseCaseFactory(object):
@@ -45,3 +47,10 @@ class UseCaseFactory(object):
         permission_service = self.service_factory.create_permission_service()
         user_service = self.service_factory.create_user_service()
         return ListPermissions(ui, permission_service, user_service)
+
+    def create_view_permission_usecase(self, ui):
+        # type: (ViewPermissionUI) -> ViewPermission
+        permission_service = self.service_factory.create_permission_service()
+        user_service = self.service_factory.create_user_service()
+        audit_log_service = self.service_factory.create_audit_log_service()
+        return ViewPermission(ui, permission_service, user_service, audit_log_service)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from six import with_metaclass
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from grouper.entities.audit_log_entry import AuditLogEntry
     from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
     from grouper.entities.pagination import PaginatedList, Pagination
@@ -32,36 +33,41 @@ if TYPE_CHECKING:
 
 
 class AuditLogInterface(with_metaclass(ABCMeta, object)):
-    """Abstract base class for the audit log."""
+    """Abstract base class for the audit log.
+
+    The date parameter to the log methods is primarily for use in tests, where to get a consistent
+    sort order the audit log entries may need to be spaced out over time.  If not set, the default
+    is the current time.
+    """
 
     @abstractmethod
-    def log_create_service_account_from_disabled_user(self, user, authorization):
-        # type: (str, Authorization) -> None
+    def log_create_service_account_from_disabled_user(self, user, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
-    def log_create_permission(self, permission, authorization):
-        # type: (str, Authorization) -> None
+    def log_create_permission(self, permission, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
-    def log_disable_permission(self, permission, authorization):
-        # type: (str, Authorization) -> None
+    def log_disable_permission(self, permission, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
-    def log_disable_user(self, username, authorization):
-        # type: (str, Authorization) -> None
+    def log_disable_user(self, username, authorization, date=None):
+        # type: (str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
-    def log_enable_service_account(self, user, owner, authorization):
-        # type: (str, str, Authorization) -> None
+    def log_enable_service_account(self, user, owner, authorization, date=None):
+        # type: (str, str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
-    def log_user_group_request_status_change(self, request, status, authorization):
-        # type: (UserGroupRequest, GroupRequestStatus, Authorization) -> None
+    def log_user_group_request_status_change(self, request, status, authorization, date=None):
+        # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod

--- a/grouper/usecases/view_permission.py
+++ b/grouper/usecases/view_permission.py
@@ -1,0 +1,58 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from six import with_metaclass
+
+if TYPE_CHECKING:
+    from grouper.entities.audit_log_entry import AuditLogEntry
+    from grouper.entities.permission import Permission, PermissionAccess
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
+    from grouper.usecases.interfaces import AuditLogInterface, PermissionInterface, UserInterface
+    from typing import List
+
+
+class ViewPermissionUI(with_metaclass(ABCMeta, object)):
+    """Abstract base class for UI for ListPermissions."""
+
+    @abstractmethod
+    def viewed_permission(
+        self,
+        permission,  # type: Permission
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+        access,  # type: PermissionAccess
+        audit_log_entries,  # type: List[AuditLogEntry]
+    ):
+        # type: (...) -> None
+        pass
+
+    @abstractmethod
+    def view_permission_failed_not_found(self, name):
+        # type: (str) -> None
+        pass
+
+
+class ViewPermission(object):
+    """View a single permission."""
+
+    def __init__(self, ui, permission_service, user_service, audit_log_service):
+        # type: (ViewPermissionUI, PermissionInterface, UserInterface, AuditLogInterface) -> None
+        self.ui = ui
+        self.permission_service = permission_service
+        self.user_service = user_service
+        self.audit_log_service = audit_log_service
+
+    def view_permission(self, name, actor, audit_log_limit):
+        # type: (str, str, int) -> None
+        permission = self.permission_service.permission(name)
+        if not permission:
+            self.ui.view_permission_failed_not_found(name)
+            return
+        group_grants = self.permission_service.group_grants_for_permission(name)
+        service_grants = self.permission_service.service_account_grants_for_permission(name)
+        audit_log = self.audit_log_service.entries_affecting_permission(name, audit_log_limit)
+        access = self.user_service.permission_access_for_user(actor, name)
+        self.ui.viewed_permission(permission, group_grants, service_grants, access, audit_log)

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -28,9 +28,23 @@ def create_test_data(setup):
     now_minus_one_second = datetime.utcfromtimestamp(int(time() - 1))
     now = datetime.utcfromtimestamp(int(time()))
     permissions = [
-        Permission(name="first-permission", description="first", created_on=now_minus_one_second),
-        Permission(name="audited-permission", description="", created_on=now),
-        Permission(name="early-permission", description="is early", created_on=early_date),
+        Permission(
+            name="first-permission",
+            description="first",
+            created_on=now_minus_one_second,
+            audited=False,
+            enabled=True,
+        ),
+        Permission(
+            name="audited-permission", description="", created_on=now, audited=True, enabled=True
+        ),
+        Permission(
+            name="early-permission",
+            description="is early",
+            created_on=early_date,
+            audited=False,
+            enabled=True,
+        ),
     ]
     with setup.transaction():
         for permission in permissions:
@@ -38,7 +52,7 @@ def create_test_data(setup):
                 name=permission.name,
                 description=permission.description,
                 created_on=permission.created_on,
-                audited=(permission.name == "audited-permission"),
+                audited=permission.audited,
             )
         setup.create_permission("disabled", enabled=False)
         setup.create_user("gary@a.co")

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from grouper.constants import PERMISSION_CREATE
 from grouper.entities.permission import Permission
 from grouper.fe.template_util import print_date
+from itests.pages.permission_view import PermissionViewPage
 from itests.pages.permissions import PermissionsPage
 from itests.setup import frontend_server
 from tests.url_util import url
@@ -109,7 +110,7 @@ def test_list_pagination(tmpdir, setup, browser):
         assert page.limit_label == "Limit: 10"
 
 
-def test_create_button(tmpdir, setup, browser):
+def test_list_create_button(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
     with setup.transaction():
         setup.create_user("gary@a.co")
@@ -124,3 +125,34 @@ def test_create_button(tmpdir, setup, browser):
             setup.add_user_to_group("gary@a.co", "admins")
         browser.get(url(frontend_url, "/permissions?refresh=yes"))
         assert page.has_create_permission_button
+
+
+def test_view(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_permission("audited-permission", "", audited=True)
+        setup.create_permission("some-permission", "Some permission")
+        setup.grant_permission_to_group("some-permission", "", "another-group")
+        setup.grant_permission_to_group("some-permission", "foo", "some-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/some-permission"))
+        page = PermissionViewPage(browser)
+        assert page.subheading == "some-permission"
+        assert page.description == "Some permission"
+        assert not page.has_disable_permission_button
+        assert not page.has_disable_auditing_button
+        assert not page.has_enable_auditing_button
+        assert not page.has_audited_warning
+
+        grants = [(r.group, r.argument) for r in page.permission_grant_rows]
+        assert grants == [("another-group", "(unargumented)"), ("some-group", "foo")]
+
+        browser.get(url(frontend_url, "/permissions/audited-permission"))
+        page = PermissionViewPage(browser)
+        assert page.subheading == "audited-permission"
+        assert not page.description
+        assert page.has_audited_warning
+        assert not page.has_disable_auditing_button
+        assert not page.has_enable_auditing_button
+        assert page.has_no_grants

--- a/itests/pages/permission_view.py
+++ b/itests/pages/permission_view.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.base import BaseElement, BasePage
+
+if TYPE_CHECKING:
+    from typing import List, Optional
+
+
+class PermissionViewPage(BasePage):
+    @property
+    def description(self):
+        # type: () -> Optional[str]
+        descriptions = self.find_elements_by_class_name("permission-description")
+        return descriptions[0].text if descriptions else None
+
+    @property
+    def has_audited_warning(self):
+        # type: () -> bool
+        warnings = self.find_elements_by_class_name("alert-warning")
+        for warning in warnings:
+            if "audited permission" in warning.text:
+                return True
+        return False
+
+    @property
+    def has_disable_auditing_button(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("disable-auditing") != []
+
+    @property
+    def has_disable_permission_button(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("disable-permission") != []
+
+    @property
+    def has_enable_auditing_button(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("enable-auditing") != []
+
+    @property
+    def has_no_grants(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("no-grants") != []
+
+    @property
+    def permission_grant_rows(self):
+        # type: () -> List[PermissionViewGrantRow]
+        all_permission_grant_rows = self.find_elements_by_class_name("grant-row")
+        return [PermissionViewGrantRow(row) for row in all_permission_grant_rows]
+
+
+class PermissionViewGrantRow(BaseElement):
+    @property
+    def argument(self):
+        # type: () -> str
+        return self.find_element_by_class_name("grant-argument").text
+
+    @property
+    def group(self):
+        # type: () -> str
+        return self.find_element_by_class_name("grant-group").text

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -22,8 +22,8 @@ def test_permission_disable(setup):
     assert mock_ui.mock_calls == [call.disabled_permission("some-permission")]
     assert not Permission.get(setup.session, name="some-permission").enabled
 
-    audit_log_repository = setup.repository_factory.create_audit_log_repository()
-    audit_log_entries = audit_log_repository.get_entries_affecting_permission("some-permission")
+    audit_log_service = setup.service_factory.create_audit_log_service()
+    audit_log_entries = audit_log_service.entries_affecting_permission("some-permission", 20)
     assert len(audit_log_entries) == 1
     assert audit_log_entries[0].actor == "gary@a.co"
     assert audit_log_entries[0].action == "disable_permission"

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -44,9 +44,23 @@ def create_test_data(setup):
     now_minus_one_second = datetime.utcfromtimestamp(int(time() - 1))
     now = datetime.utcfromtimestamp(int(time()))
     permissions = [
-        Permission(name="first-permission", description="first", created_on=now_minus_one_second),
-        Permission(name="audited-permission", description="", created_on=now),
-        Permission(name="early-permission", description="is early", created_on=early_date),
+        Permission(
+            name="first-permission",
+            description="first",
+            created_on=now_minus_one_second,
+            audited=False,
+            enabled=True,
+        ),
+        Permission(
+            name="audited-permission", description="", created_on=now, audited=True, enabled=True
+        ),
+        Permission(
+            name="early-permission",
+            description="is early",
+            created_on=early_date,
+            audited=False,
+            enabled=True,
+        ),
     ]
     with setup.transaction():
         for permission in permissions:
@@ -54,7 +68,7 @@ def create_test_data(setup):
                 name=permission.name,
                 description=permission.description,
                 created_on=permission.created_on,
-                audited=(permission.name == "audited-permission"),
+                audited=permission.audited,
             )
         setup.create_permission("disabled", enabled=False)
         setup.create_user("gary@a.co")

--- a/tests/usecases/view_permission_test.py
+++ b/tests/usecases/view_permission_test.py
@@ -1,0 +1,125 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import AUDIT_MANAGER, PERMISSION_ADMIN
+from grouper.usecases.authorization import Authorization
+from grouper.usecases.view_permission import ViewPermissionUI
+
+if TYPE_CHECKING:
+    from grouper.entities.audit_log_entry import AuditLogEntry
+    from grouper.entities.permission import Permission, PermissionAccess
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
+    from tests.setup import SetupTest
+    from typing import List
+
+
+class MockUI(ViewPermissionUI):
+    def view_permission_failed_not_found(self, name):
+        # type: (str) -> None
+        self.failed = True
+
+    def viewed_permission(
+        self,
+        permission,  # type: Permission
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+        access,  # type: PermissionAccess
+        audit_log_entries,  # type: List[AuditLogEntry]
+    ):
+        # type (...) -> None
+        self.permission = permission
+        self.group_grants = group_grants
+        self.service_account_grants = service_account_grants
+        self.access = access
+        self.audit_log_entries = audit_log_entries
+
+
+def test_view_permissions(setup):
+    # type: (SetupTest) -> None
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_view_permission_usecase(mock_ui)
+    with setup.transaction():
+        setup.create_permission("audited-permission", "", audited=True)
+        setup.create_permission("some-permission", "Some permission")
+        setup.create_permission("disabled-permission", "", enabled=False)
+        setup.grant_permission_to_group("some-permission", "", "another-group")
+        setup.grant_permission_to_group("some-permission", "foo", "some-group")
+        setup.create_user("gary@a.co")
+        audit_log_service = setup.service_factory.create_audit_log_service()
+        authorization = Authorization("gary@a.co")
+        audit_log_service.log_create_permission("disabled-permission", authorization)
+        audit_log_service.log_disable_permission("disabled-permission", authorization)
+
+    # Regular permission with some grants.
+    usecase.view_permission("some-permission", "gary@a.co", 20)
+    assert mock_ui.permission.name == "some-permission"
+    assert mock_ui.permission.description == "Some permission"
+    assert not mock_ui.permission.audited
+    assert mock_ui.permission.enabled
+    group_grants = [(g.group, g.permission, g.argument) for g in mock_ui.group_grants]
+    assert group_grants == [
+        ("another-group", "some-permission", ""),
+        ("some-group", "some-permission", "foo"),
+    ]
+    assert mock_ui.service_account_grants == []
+    assert not mock_ui.access.can_disable
+    assert not mock_ui.access.can_change_audited_status
+    assert mock_ui.audit_log_entries == []
+
+    # Audited permission without grants.
+    usecase.view_permission("audited-permission", "gary@a.co", 20)
+    assert mock_ui.permission.name == "audited-permission"
+    assert mock_ui.permission.description == ""
+    assert mock_ui.permission.audited
+    assert mock_ui.permission.enabled
+    assert mock_ui.group_grants == []
+
+    # Disabled permission with some log entries.
+    usecase.view_permission("disabled-permission", "gary@a.co", 20)
+    assert mock_ui.permission.name == "disabled-permission"
+    assert not mock_ui.permission.audited
+    assert not mock_ui.permission.enabled
+    assert mock_ui.group_grants == []
+    assert mock_ui.service_account_grants == []
+    audit_log_entries = [(l.actor, l.action, l.on_permission) for l in mock_ui.audit_log_entries]
+    assert audit_log_entries == [
+        ("gary@a.co", "disable_permission", "disabled-permission"),
+        ("gary@a.co", "create_permission", "disabled-permission"),
+    ]
+
+    # Limit the number of audit log entries.
+    usecase.view_permission("disabled-permission", "gary@a.co", 1)
+    audit_log_entries = [(l.actor, l.action, l.on_permission) for l in mock_ui.audit_log_entries]
+    assert audit_log_entries == [("gary@a.co", "disable_permission", "disabled-permission")]
+
+
+def test_view_permissions_access(setup):
+    # type: (SetupTest) -> None
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_view_permission_usecase(mock_ui)
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "audit-managers")
+        setup.grant_permission_to_group(AUDIT_MANAGER, "", "audit-managers")
+        setup.create_permission("some-permission", "Some permission")
+
+    # Can manage audited permissions, but is not a permission admin.
+    usecase.view_permission("some-permission", "gary@a.co", 20)
+    assert mock_ui.access.can_change_audited_status
+    assert not mock_ui.access.can_disable
+
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "audit-managers")
+        setup.add_user_to_group("zorkian@a.co", "grouper-administrators")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "grouper-administrators")
+
+    # Now is both a permission admin and an audit manager.
+    usecase.view_permission("some-permission", "gary@a.co", 20)
+    assert mock_ui.access.can_change_audited_status
+    assert mock_ui.access.can_disable
+
+    # Just having permission admin is enough.
+    usecase.view_permission("some-permission", "zorkian@a.co", 20)
+    assert mock_ui.access.can_change_audited_status
+    assert mock_ui.access.can_disable

--- a/tests/usecases/view_permission_test.py
+++ b/tests/usecases/view_permission_test.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from grouper.constants import AUDIT_MANAGER, PERMISSION_ADMIN
@@ -49,7 +50,10 @@ def test_view_permissions(setup):
         setup.create_user("gary@a.co")
         audit_log_service = setup.service_factory.create_audit_log_service()
         authorization = Authorization("gary@a.co")
-        audit_log_service.log_create_permission("disabled-permission", authorization)
+        one_minute_ago = datetime.utcnow() - timedelta(minutes=1)
+        audit_log_service.log_create_permission(
+            "disabled-permission", authorization, date=one_minute_ago
+        )
         audit_log_service.log_disable_permission("disabled-permission", authorization)
 
     # Regular permission with some grants.


### PR DESCRIPTION
Currently, viewing a permission only shows the grants to groups. We want to also show the grants to service accounts. This PR lays the groundwork by converting viewing of a single permission to a usecase.