### PR TITLE
Stop using global settings in grouper/ctl

### DIFF
--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -6,15 +6,15 @@ from sqlalchemy.schema import CreateIndex, CreateTable
 
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
-from grouper.settings import settings
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction, Namespace
+    from grouper.settings import Settings
 
 
-def dump_sql_command(args):
-    # type: (Namespace) -> None
+def dump_sql_command(args, settings):
+    # type: (Namespace, Settings) -> None
     db_engine = get_db_engine(get_database_url(settings))
     for table in Model.metadata.sorted_tables:
         print(CreateTable(table).compile(db_engine))

--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -10,11 +10,11 @@ from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction, Namespace
-    from grouper.settings import Settings
+    from grouper.ctl.settings import CtlSettings
 
 
 def dump_sql_command(args, settings):
-    # type: (Namespace, Settings) -> None
+    # type: (Namespace, CtlSettings) -> None
     db_engine = get_db_engine(get_database_url(settings))
     for table in Model.metadata.sorted_tables:
         print(CreateTable(table).compile(db_engine))

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -7,6 +7,7 @@ from grouper.ctl.user_proxy import UserProxyCommand
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
     from grouper.ctl.base import CtlCommand
+    from grouper.ctl.settings import CtlSettings
     from grouper.usecases.factory import UseCaseFactory
 
 
@@ -36,8 +37,9 @@ class CtlCommandFactory(object):
         parser = subparsers.add_parser("user_proxy", help="Start a development reverse proxy")
         UserProxyCommand.add_arguments(parser)
 
-    def __init__(self, usecase_factory):
-        # type: (UseCaseFactory) -> None
+    def __init__(self, settings, usecase_factory):
+        # type: (CtlSettings, UseCaseFactory) -> None
+        self.settings = settings
         self.usecase_factory = usecase_factory
 
     def construct_command(self, command):
@@ -57,7 +59,7 @@ class CtlCommandFactory(object):
 
     def construct_user_command(self):
         # type: () -> UserCommand
-        return UserCommand(self.usecase_factory)
+        return UserCommand(self.settings, self.usecase_factory)
 
     def construct_user_proxy_command(self):
         # type: () -> UserProxyCommand

--- a/grouper/ctl/group.py
+++ b/grouper/ctl/group.py
@@ -16,13 +16,14 @@ from grouper.plugin.exceptions import PluginRejectedGroupMembershipUpdate
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from grouper.ctl.settings import CtlSettings
     from grouper.models.base.session import Session
 
 
 @ensure_valid_groupname
-def group_command(args):
-    # type: (Namespace) -> None
-    session = make_session()
+def group_command(args, settings):
+    # type: (Namespace, CtlSettings) -> None
+    session = make_session(settings)
     group = session.query(Group).filter_by(groupname=args.groupname).scalar()
     if not group:
         logging.error("No such group %s".format(args.groupname))
@@ -32,11 +33,11 @@ def group_command(args):
         # somewhat hacky: using function instance to use # `ensure_valid_username` only on
         # these subcommands
         @ensure_valid_username
-        def call_mutate(args):
-            # type: (Namespace) -> None
+        def call_mutate(args, settings):
+            # type: (Namespace, CtlSettings) -> None
             mutate_group_command(session, group, args)
 
-        call_mutate(args)
+        call_mutate(args, settings)
 
     elif args.subcommand == "log_dump":
         logdump_group_command(session, group, args)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -66,12 +66,12 @@ def main(sys_argv=sys.argv, session=None):
         sa_log.setLevel(logging.INFO)
 
     usecase_factory = create_sql_usecase_factory(settings, session)
-    command_factory = CtlCommandFactory(usecase_factory)
+    command_factory = CtlCommandFactory(settings, usecase_factory)
 
     # Old-style subcommands store a func in callable when setting up their arguments.  New-style
     # subcommands are handled via a factory that constructs and calls the correct object.
     if getattr(args, "func", None):
-        args.func(args)
+        args.func(args, settings)
     else:
         command = command_factory.construct_command(args.command)
         command.run(args)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -51,6 +51,9 @@ def main(sys_argv=sys.argv, session=None):
 
     args = parser.parse_args(sys_argv[1:])
 
+    # Construct the CtlSettings object used for all commands, and set it as the global Settings
+    # object.  All code in grouper.ctl.* takes the CtlSettings object as an argument if needed, but
+    # it may call other legacy code that requires the global Settings object be present.
     settings = CtlSettings.global_settings_from_config(args.config)
 
     log_level = get_loglevel(args, base=logging.INFO)

--- a/grouper/ctl/oneoff.py
+++ b/grouper/ctl/oneoff.py
@@ -4,13 +4,13 @@ from contextlib import contextmanager
 from types import MethodType
 from typing import TYPE_CHECKING
 
-from grouper.ctl.settings import settings
 from grouper.ctl.util import make_session
 from grouper.oneoff import BaseOneOff
 from grouper.plugin import load_plugins
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from grouper.ctl.settings import CtlSettings
     from grouper.models.session import Session
     from typing import Any, Iterator, Tuple
 
@@ -61,12 +61,12 @@ def key_value_arg_type(arg):
     return (k, v)
 
 
-def oneoff_command(args):
-    # type: (Namespace) -> None
-    session = make_session()
+def oneoff_command(args, settings):
+    # type: (Namespace, CtlSettings) -> None
+    session = make_session(settings)
 
     oneoffs = load_plugins(
-        BaseOneOff, settings().oneoff_dirs, settings().oneoff_module_paths, "grouper-ctl"
+        BaseOneOff, settings.oneoff_dirs, settings.oneoff_module_paths, "grouper-ctl"
     )
 
     if args.subcommand == "run":

--- a/grouper/ctl/service_account.py
+++ b/grouper/ctl/service_account.py
@@ -9,12 +9,13 @@ from grouper.service_account import create_service_account
 
 if TYPE_CHECKING:
     from argparse import Namespace
+    from grouper.ctl.settings import CtlSettings
 
 
 @ensure_valid_service_account_name
-def service_account_command(args):
-    # type: (Namespace) -> None
-    session = make_session()
+def service_account_command(args, settings):
+    # type: (Namespace, CtlSettings) -> None
+    session = make_session(settings)
     actor_user = User.get(session, name=args.actor_name)
     if not actor_user:
         logging.fatal('Actor user "{}" is not a valid Grouper user'.format(args.actor_name))

--- a/grouper/ctl/settings.py
+++ b/grouper/ctl/settings.py
@@ -1,6 +1,6 @@
-from typing import cast, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
-from grouper.settings import set_global_settings, Settings, settings as global_settings
+from grouper.settings import set_global_settings, Settings
 
 if TYPE_CHECKING:
     from typing import List, Optional
@@ -29,10 +29,3 @@ class CtlSettings(Settings):
     def update_from_config(self, filename=None, section="ctl"):
         # type: (Optional[str], Optional[str]) -> None
         super(CtlSettings, self).update_from_config(filename, section)
-
-
-# See grouper.settings for more information about why this nonsense is here.
-def settings():
-    # type: () -> CtlSettings
-    """Return a global CtlSettings for grouper-ctl code."""
-    return cast(CtlSettings, global_settings())

--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -15,13 +15,14 @@ from grouper.user_metadata import set_user_metadata
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
+    from grouper.ctl.settings import CtlSettings
     from grouper.usecases.factory import UseCaseFactory
 
 
 @ensure_valid_username
-def user_command(args):
-    # type: (Namespace) -> None
-    session = make_session()
+def user_command(args, settings):
+    # type: (Namespace, CtlSettings) -> None
+    session = make_session(settings)
 
     if args.subcommand == "create":
         for username in args.username:
@@ -184,8 +185,9 @@ class UserCommand(CtlCommand, ConvertUserToServiceAccountUI):
         user_set_metadata_parser.add_argument("metadata_key")
         user_set_metadata_parser.add_argument("metadata_value")
 
-    def __init__(self, usecase_factory):
-        # type: (UseCaseFactory) -> None
+    def __init__(self, settings, usecase_factory):
+        # type: (CtlSettings, UseCaseFactory) -> None
+        self.settings = settings
         self.usecase_factory = usecase_factory
 
     def converted_user_to_service_account(self, user, owner):
@@ -211,7 +213,7 @@ class UserCommand(CtlCommand, ConvertUserToServiceAccountUI):
             usecase.convert_user_to_service_account(args.username, args.owner)
 
         elif args.subcommand == "list":
-            session = make_session()
+            session = make_session(self.settings)
             all_users = get_all_users(session)
             for user in all_users:
                 user_enabled = "enabled" if user.enabled else "disabled"
@@ -219,4 +221,4 @@ class UserCommand(CtlCommand, ConvertUserToServiceAccountUI):
             return
 
         else:
-            user_command(args)
+            user_command(args, self.settings)

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -9,22 +9,23 @@ from typing import TYPE_CHECKING
 
 from grouper.constants import NAME_VALIDATION, SERVICE_ACCOUNT_VALIDATION, USERNAME_VALIDATION
 from grouper.models.base.session import get_db_engine, Session
-from grouper.settings import settings
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from datetime import date
+    from grouper.ctl.settings import CtlSettings
+    from grouper.settings import Settings
     from typing import Callable, Generator
 
 DATE_FORMAT = "%Y-%m-%d"
 
 
 def ensure_valid_username(f):
-    # type: (Callable[[Namespace], None]) -> Callable[[Namespace], None]
+    # type: (Callable[[Namespace, CtlSettings], None]) -> Callable[[Namespace, CtlSettings], None]
     @wraps(f)
-    def wrapper(args):
-        # type: (Namespace) -> None
+    def wrapper(args, settings):
+        # type: (Namespace, CtlSettings) -> None
         usernames = args.username if type(args.username) == list else [args.username]
         valid = True
         for username in usernames:
@@ -35,42 +36,42 @@ def ensure_valid_username(f):
         if not valid:
             return
 
-        return f(args)
+        return f(args, settings)
 
     return wrapper
 
 
 def ensure_valid_groupname(f):
-    # type: (Callable[[Namespace], None]) -> Callable[[Namespace], None]
+    # type: (Callable[[Namespace, CtlSettings], None]) -> Callable[[Namespace, CtlSettings], None]
     @wraps(f)
-    def wrapper(args):
-        # type: (Namespace) -> None
+    def wrapper(args, settings):
+        # type: (Namespace, CtlSettings) -> None
         if not re.match("^{}$".format(NAME_VALIDATION), args.groupname):
             logging.error("Invalid group name {}".format(args.groupname))
             return
 
-        return f(args)
+        return f(args, settings)
 
     return wrapper
 
 
 def ensure_valid_service_account_name(f):
-    # type: (Callable[[Namespace], None]) -> Callable[[Namespace], None]
+    # type: (Callable[[Namespace, CtlSettings], None]) -> Callable[[Namespace, CtlSettings], None]
     @wraps(f)
-    def wrapper(args):
-        # type: (Namespace) -> None
+    def wrapper(args, settings):
+        # type: (Namespace, CtlSettings) -> None
         if not re.match("^{}$".format(SERVICE_ACCOUNT_VALIDATION), args.name):
             logging.error('Invalid service account name "{}"'.format(args.name))
             return
 
-        return f(args)
+        return f(args, settings)
 
     return wrapper
 
 
-def make_session():
-    # type: () -> Session
-    db_engine = get_db_engine(get_database_url(settings()))
+def make_session(settings):
+    # type: (Settings) -> Session
+    db_engine = get_db_engine(get_database_url(settings))
     Session.configure(bind=db_engine)
     return Session()
 

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from argparse import Namespace
     from datetime import date
     from grouper.ctl.settings import CtlSettings
-    from grouper.settings import Settings
     from typing import Callable, Generator
 
 DATE_FORMAT = "%Y-%m-%d"
@@ -70,7 +69,7 @@ def ensure_valid_service_account_name(f):
 
 
 def make_session(settings):
-    # type: (Settings) -> Session
+    # type: (CtlSettings) -> Session
     db_engine = get_db_engine(get_database_url(settings))
     Session.configure(bind=db_engine)
     return Session()


### PR DESCRIPTION
Pass settings in properly to all of the grouper-ctl command
implementations and stop using the global settings object.  (Still
set the global settings object, since other code elsewhere in
Grouper called by this code may still require it.)