### PR TITLE
Add service account grants to permission page

### DIFF
--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -64,7 +64,7 @@
                 </thead>
                 <tbody>
                 {% for grant in group_grants %}
-                    <tr class="grant-row">
+                    <tr class="group-grant-row">
                         <td class="grant-group">
                             <a href="/groups/{{grant.group}}">{{grant.group}}</a>
                         </td>
@@ -74,9 +74,37 @@
                     </tr>
                 {% endfor %}
                 {% if not group_grants %}
-                    <tr class="no-grants">
+                    <tr class="no-group-grants">
                         <td colspan="2" class="text-center"><em>This permission is not mapped to any
                         groups. To grant this permission to a group, visit the group page.</em></td>
+                    </tr>
+                {% endif %}
+                </tbody>
+            </table>
+
+            <table class="table table-elist">
+                <thead>
+                    <tr>
+                        <th class="col-sm-2">Service Account</th>
+                        <th class="col-sm-5">Argument</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for grant in service_account_grants %}
+                    <tr class="service-grant-row">
+                        <td class="grant-service">
+                            <a href="/users/{{grant.service_account}}">{{grant.service_account}}</a>
+                        </td>
+                        <td class="grant-argument">
+                            {{grant.argument|default("(unargumented)", True)}}
+                        </td>
+                    </tr>
+                {% endfor %}
+                {% if not service_account_grants %}
+                    <tr class="no-service-grants">
+                        <td colspan="2" class="text-center"><em>This permission is not mapped to
+                        any service accounts. To grant this permission to a service account, visit
+                        the service account page.</em></td>
                     </tr>
                 {% endif %}
                 </tbody>

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -44,12 +44,12 @@
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
         {% if not permission.enabled %}
-            <div class="alert alert-warning">
+            <div class="alert alert-warning disabled-warning">
                 <strong>This permission is disabled.</strong> It continues to exist for the record but otherwise has no effect.
             </div>
         {% else %}
             {% if permission.audited %}
-                <div class="alert alert-warning">
+                <div class="alert alert-warning audited-warning">
                     <strong>This is an audited permission.</strong> Any group this permission is applied
                     to will become audited.
                 </div>

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -18,6 +18,7 @@ from grouper import stats
 from grouper.constants import AUDIT_SECURITY, RESERVED_NAMES, USERNAME_VALIDATION
 from grouper.fe.settings import settings
 from grouper.graph import Graph
+from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.models.user import User
 from grouper.perf_profile import record_trace
@@ -25,7 +26,6 @@ from grouper.user_permissions import user_permissions
 from grouper.util import get_database_url
 
 if TYPE_CHECKING:
-    from grouper.usecases.factory import UseCaseFactory
     from jinja2 import Environment
     from typing import Any, Callable, Dict, List, Optional, Text
 
@@ -67,7 +67,7 @@ class GrouperHandler(RequestHandler):
         self.graph = Graph()
         self.session = kwargs["session"]()  # type: Session
         self.template_env = kwargs["template_env"]  # type: Environment
-        self.usecase_factory = kwargs["usecase_factory"]  # type: UseCaseFactory
+        self.usecase_factory = create_graph_usecase_factory(settings(), self.session)
 
         if self.get_argument("_profile", False):
             self.perf_collector = Collector()

--- a/itests/fe/permission_view_test.py
+++ b/itests/fe/permission_view_test.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from grouper.constants import AUDIT_MANAGER, PERMISSION_ADMIN
 from itests.pages.permission_view import PermissionViewPage
 from itests.setup import frontend_server
 from tests.url_util import url
@@ -16,6 +17,7 @@ def test_view(tmpdir, setup, browser):
         setup.create_user("gary@a.co")
         setup.create_permission("audited-permission", "", audited=True)
         setup.create_permission("some-permission", "Some permission")
+        setup.create_permission("disabled-permission", "", enabled=False)
         setup.grant_permission_to_group("some-permission", "", "another-group")
         setup.grant_permission_to_group("some-permission", "foo", "some-group")
         setup.create_service_account("service@svc.localhost", "owner-group")
@@ -32,6 +34,7 @@ def test_view(tmpdir, setup, browser):
         assert not page.has_disable_auditing_button
         assert not page.has_enable_auditing_button
         assert not page.has_audited_warning
+        assert not page.has_disabled_warning
         grants = [(r.group, r.argument) for r in page.group_permission_grant_rows]
         assert grants == [("another-group", "(unargumented)"), ("some-group", "foo")]
         assert page.has_no_service_account_grants
@@ -48,3 +51,63 @@ def test_view(tmpdir, setup, browser):
             (r.service_account, r.argument) for r in page.service_account_permission_grant_rows
         ]
         assert grants == [("service@svc.localhost", "argument")]
+
+        browser.get(url(frontend_url, "/permissions/disabled-permission"))
+        page = PermissionViewPage(browser)
+        assert page.subheading == "disabled-permission"
+        assert not page.has_disable_permission_button
+        assert page.has_disabled_warning
+
+
+def test_view_change_audited(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "audit-managers")
+        setup.grant_permission_to_group(AUDIT_MANAGER, "", "audit-managers")
+        setup.create_permission("some-permission", "Some permission")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/some-permission"))
+        page = PermissionViewPage(browser)
+        assert not page.has_disable_permission_button
+        assert not page.has_audited_warning
+        assert page.has_enable_auditing_button
+
+        page.click_enable_auditing_button()
+        enable_auditing_modal = page.get_enable_auditing_modal()
+        enable_auditing_modal.confirm()
+
+        assert page.subheading == "some-permission"
+        assert page.has_audited_warning
+        assert not page.has_enable_auditing_button
+        assert page.has_disable_auditing_button
+
+        page.click_disable_auditing_button()
+        disable_auditing_modal = page.get_disable_auditing_modal()
+        disable_auditing_modal.confirm()
+
+        assert page.subheading == "some-permission"
+        assert not page.has_audited_warning
+        assert page.has_enable_auditing_button
+        assert not page.has_disable_auditing_button
+
+
+def test_view_disable(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "administrators")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "administrators")
+        setup.create_permission("some-permission", "Some permission")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/some-permission"))
+        page = PermissionViewPage(browser)
+        assert page.has_disable_permission_button
+
+        page.click_disable_permission_button()
+        disable_permission_modal = page.get_disable_permission_modal()
+        disable_permission_modal.confirm()
+
+        assert page.subheading == "some-permission"
+        assert page.has_disabled_warning
+        assert not page.has_disable_permission_button

--- a/itests/fe/permission_view_test.py
+++ b/itests/fe/permission_view_test.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.permission_view import PermissionViewPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_view(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+        setup.create_permission("audited-permission", "", audited=True)
+        setup.create_permission("some-permission", "Some permission")
+        setup.grant_permission_to_group("some-permission", "", "another-group")
+        setup.grant_permission_to_group("some-permission", "foo", "some-group")
+        setup.create_service_account("service@svc.localhost", "owner-group")
+        setup.grant_permission_to_service_account(
+            "audited-permission", "argument", "service@svc.localhost"
+        )
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/some-permission"))
+        page = PermissionViewPage(browser)
+        assert page.subheading == "some-permission"
+        assert page.description == "Some permission"
+        assert not page.has_disable_permission_button
+        assert not page.has_disable_auditing_button
+        assert not page.has_enable_auditing_button
+        assert not page.has_audited_warning
+        grants = [(r.group, r.argument) for r in page.group_permission_grant_rows]
+        assert grants == [("another-group", "(unargumented)"), ("some-group", "foo")]
+        assert page.has_no_service_account_grants
+
+        browser.get(url(frontend_url, "/permissions/audited-permission"))
+        page = PermissionViewPage(browser)
+        assert page.subheading == "audited-permission"
+        assert not page.description
+        assert page.has_audited_warning
+        assert not page.has_disable_auditing_button
+        assert not page.has_enable_auditing_button
+        assert page.has_no_group_grants
+        grants = [
+            (r.service_account, r.argument) for r in page.service_account_permission_grant_rows
+        ]
+        assert grants == [("service@svc.localhost", "argument")]

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 from grouper.constants import PERMISSION_CREATE
 from grouper.entities.permission import Permission
 from grouper.fe.template_util import print_date
-from itests.pages.permission_view import PermissionViewPage
 from itests.pages.permissions import PermissionsPage
 from itests.setup import frontend_server
 from tests.url_util import url
@@ -139,43 +138,3 @@ def test_list_create_button(tmpdir, setup, browser):
             setup.add_user_to_group("gary@a.co", "admins")
         browser.get(url(frontend_url, "/permissions?refresh=yes"))
         assert page.has_create_permission_button
-
-
-def test_view(tmpdir, setup, browser):
-    # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-        setup.create_permission("audited-permission", "", audited=True)
-        setup.create_permission("some-permission", "Some permission")
-        setup.grant_permission_to_group("some-permission", "", "another-group")
-        setup.grant_permission_to_group("some-permission", "foo", "some-group")
-        setup.create_service_account("service@svc.localhost", "owner-group")
-        setup.grant_permission_to_service_account(
-            "audited-permission", "argument", "service@svc.localhost"
-        )
-
-    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
-        browser.get(url(frontend_url, "/permissions/some-permission"))
-        page = PermissionViewPage(browser)
-        assert page.subheading == "some-permission"
-        assert page.description == "Some permission"
-        assert not page.has_disable_permission_button
-        assert not page.has_disable_auditing_button
-        assert not page.has_enable_auditing_button
-        assert not page.has_audited_warning
-        grants = [(r.group, r.argument) for r in page.group_permission_grant_rows]
-        assert grants == [("another-group", "(unargumented)"), ("some-group", "foo")]
-        assert page.has_no_service_account_grants
-
-        browser.get(url(frontend_url, "/permissions/audited-permission"))
-        page = PermissionViewPage(browser)
-        assert page.subheading == "audited-permission"
-        assert not page.description
-        assert page.has_audited_warning
-        assert not page.has_disable_auditing_button
-        assert not page.has_enable_auditing_button
-        assert page.has_no_group_grants
-        grants = [
-            (r.service_account, r.argument) for r in page.service_account_permission_grant_rows
-        ]
-        assert grants == [("service@svc.localhost", "argument")]

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -144,10 +144,15 @@ def test_list_create_button(tmpdir, setup, browser):
 def test_view(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
     with setup.transaction():
+        setup.create_user("gary@a.co")
         setup.create_permission("audited-permission", "", audited=True)
         setup.create_permission("some-permission", "Some permission")
         setup.grant_permission_to_group("some-permission", "", "another-group")
         setup.grant_permission_to_group("some-permission", "foo", "some-group")
+        setup.create_service_account("service@svc.localhost", "owner-group")
+        setup.grant_permission_to_service_account(
+            "audited-permission", "argument", "service@svc.localhost"
+        )
 
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/some-permission"))
@@ -158,9 +163,9 @@ def test_view(tmpdir, setup, browser):
         assert not page.has_disable_auditing_button
         assert not page.has_enable_auditing_button
         assert not page.has_audited_warning
-
-        grants = [(r.group, r.argument) for r in page.permission_grant_rows]
+        grants = [(r.group, r.argument) for r in page.group_permission_grant_rows]
         assert grants == [("another-group", "(unargumented)"), ("some-group", "foo")]
+        assert page.has_no_service_account_grants
 
         browser.get(url(frontend_url, "/permissions/audited-permission"))
         page = PermissionViewPage(browser)
@@ -169,4 +174,8 @@ def test_view(tmpdir, setup, browser):
         assert page.has_audited_warning
         assert not page.has_disable_auditing_button
         assert not page.has_enable_auditing_button
-        assert page.has_no_grants
+        assert page.has_no_group_grants
+        grants = [
+            (r.service_account, r.argument) for r in page.service_account_permission_grant_rows
+        ]
+        assert grants == [("service@svc.localhost", "argument")]

--- a/itests/pages/permission_view.py
+++ b/itests/pages/permission_view.py
@@ -38,18 +38,29 @@ class PermissionViewPage(BasePage):
         return self.find_elements_by_class_name("enable-auditing") != []
 
     @property
-    def has_no_grants(self):
+    def has_no_group_grants(self):
         # type: () -> bool
-        return self.find_elements_by_class_name("no-grants") != []
+        return self.find_elements_by_class_name("no-group-grants") != []
 
     @property
-    def permission_grant_rows(self):
-        # type: () -> List[PermissionViewGrantRow]
-        all_permission_grant_rows = self.find_elements_by_class_name("grant-row")
-        return [PermissionViewGrantRow(row) for row in all_permission_grant_rows]
+    def has_no_service_account_grants(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("no-service-grants") != []
+
+    @property
+    def group_permission_grant_rows(self):
+        # type: () -> List[PermissionGroupGrantRow]
+        all_permission_grant_rows = self.find_elements_by_class_name("group-grant-row")
+        return [PermissionGroupGrantRow(row) for row in all_permission_grant_rows]
+
+    @property
+    def service_account_permission_grant_rows(self):
+        # type: () -> List[PermissionServiceAccountGrantRow]
+        all_permission_grant_rows = self.find_elements_by_class_name("service-grant-row")
+        return [PermissionServiceAccountGrantRow(row) for row in all_permission_grant_rows]
 
 
-class PermissionViewGrantRow(BaseElement):
+class PermissionGroupGrantRow(BaseElement):
     @property
     def argument(self):
         # type: () -> str
@@ -59,3 +70,15 @@ class PermissionViewGrantRow(BaseElement):
     def group(self):
         # type: () -> str
         return self.find_element_by_class_name("grant-group").text
+
+
+class PermissionServiceAccountGrantRow(BaseElement):
+    @property
+    def argument(self):
+        # type: () -> str
+        return self.find_element_by_class_name("grant-argument").text
+
+    @property
+    def service_account(self):
+        # type: () -> str
+        return self.find_element_by_class_name("grant-service").text

--- a/itests/pages/permission_view.py
+++ b/itests/pages/permission_view.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from itests.pages.base import BaseElement, BasePage
+from itests.pages.base import BaseElement, BaseModal, BasePage
 
 if TYPE_CHECKING:
     from typing import List, Optional
@@ -16,11 +16,12 @@ class PermissionViewPage(BasePage):
     @property
     def has_audited_warning(self):
         # type: () -> bool
-        warnings = self.find_elements_by_class_name("alert-warning")
-        for warning in warnings:
-            if "audited permission" in warning.text:
-                return True
-        return False
+        return self.find_elements_by_class_name("audited-warning") != []
+
+    @property
+    def has_disabled_warning(self):
+        # type: () -> bool
+        return self.find_elements_by_class_name("disabled-warning") != []
 
     @property
     def has_disable_auditing_button(self):
@@ -59,6 +60,39 @@ class PermissionViewPage(BasePage):
         all_permission_grant_rows = self.find_elements_by_class_name("service-grant-row")
         return [PermissionServiceAccountGrantRow(row) for row in all_permission_grant_rows]
 
+    def click_disable_auditing_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("disable-auditing")
+        button.click()
+
+    def click_enable_auditing_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("enable-auditing")
+        button.click()
+
+    def click_disable_permission_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("disable-permission")
+        button.click()
+
+    def get_disable_auditing_modal(self):
+        # type: () -> DisableAuditingModal
+        element = self.find_element_by_id("disableAuditingModal")
+        self.wait_until_visible(element)
+        return DisableAuditingModal(element)
+
+    def get_enable_auditing_modal(self):
+        # type: () -> EnableAuditingModal
+        element = self.find_element_by_id("enableAuditingModal")
+        self.wait_until_visible(element)
+        return EnableAuditingModal(element)
+
+    def get_disable_permission_modal(self):
+        # type: () -> DisablePermissionModal
+        element = self.find_element_by_id("disablePermModal")
+        self.wait_until_visible(element)
+        return DisablePermissionModal(element)
+
 
 class PermissionGroupGrantRow(BaseElement):
     @property
@@ -82,3 +116,15 @@ class PermissionServiceAccountGrantRow(BaseElement):
     def service_account(self):
         # type: () -> str
         return self.find_element_by_class_name("grant-service").text
+
+
+class DisableAuditingModal(BaseModal):
+    pass
+
+
+class EnableAuditingModal(BaseModal):
+    pass
+
+
+class DisablePermissionModal(BaseModal):
+    pass

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -322,7 +322,4 @@ def fe_app(session, standard_graph, tmpdir):
     # type: (Session, GroupGraph, LocalPath) -> GrouperApplication
     settings = FrontendSettings()
     set_global_settings(settings)
-    usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
-    return create_fe_application(
-        settings, usecase_factory, "", xsrf_cookies=False, session=lambda: session
-    )
+    return create_fe_application(settings, "", xsrf_cookies=False, session=lambda: session)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -12,6 +12,12 @@ without creating the user and group first, and both will be created if not prese
 
 This is the new test setup mechanism, replacing the fixtures defined in tests.fixtures.  All new
 tests should use this mechanism and not rely on standard_graph or other pytest fixtures.
+
+Currently, most test setup work here is done via direct calls to the model.  This is only temporary
+because the necessary methods are not yet available from service and repository objects.  As soon
+as a facility is available from a service or repository, the setup code should call that method
+instead of directly manipulating the model.  Eventually, it should just be another client of the
+service and repository layers.
 """
 
 import os

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -28,6 +28,8 @@ from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
+from grouper.models.service_account import ServiceAccount
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.user import User
 from grouper.plugin import initialize_plugins
 from grouper.repositories.factory import GraphRepositoryFactory
@@ -199,3 +201,31 @@ class SetupTest(object):
         group_obj.add_member(
             requester=user_obj, user_or_group=user_obj, reason="", status="pending", role=role
         )
+
+    def create_service_account(self, service_account, owner, description="", machine_set=""):
+        # type: (str, str, str, str) -> None
+        self.create_group(owner)
+        if User.get(self.session, name=service_account):
+            return
+        user = User(username=service_account)
+        user.add(self.session)
+        service_account_obj = ServiceAccount(
+            user_id=user.id, description=description, machine_set=machine_set
+        )
+        service_account_obj.add(self.session)
+        user.is_service_account = True
+
+    def grant_permission_to_service_account(self, permission, argument, service_account):
+        # type: (str, str, str) -> None
+        self.create_permission(permission)
+        permission_obj = Permission.get(self.session, name=permission)
+        assert permission_obj
+        user_obj = User.get(self.session, name=service_account)
+        assert user_obj, "Must create the service account first"
+        assert user_obj.is_service_account
+        grant = ServiceAccountPermissionMap(
+            permission_id=permission_obj.id,
+            service_account_id=user_obj.service_account.id,
+            argument=argument,
+        )
+        grant.add(self.session)


### PR DESCRIPTION
Add a second table showing all the service accounts to which a
permission has been granted.  Update the tests accordingly.  Add
some test machinery to create a service account and grant a
permission to it.
