### PR TITLE
Move database URL handling into Settings

### DIFF
--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -20,7 +20,6 @@ from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.setup import build_arg_parser, setup_logging
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -55,8 +54,9 @@ def start_server(args, settings, sentry_client):
 
     # setup database
     logging.debug("configure database session")
-    database_url = args.database_url or get_database_url(settings)
-    Session.configure(bind=get_db_engine(database_url))
+    if args.database_url:
+        settings.database = args.database_url
+    Session.configure(bind=get_db_engine(settings.database_url))
 
     with closing(Session()) as session:
         graph = Graph()

--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -23,7 +23,6 @@ from grouper.models.group import Group
 from grouper.models.group_edge import APPROVER_ROLE_INDICES, GroupEdge
 from grouper.models.user import User
 from grouper.perf_profile import prune_old_traces
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from grouper.background.settings import BackgroundSettings
@@ -129,10 +128,10 @@ class BackgroundProcessor(object):
 
     def run(self):
         # type: () -> None
-        initial_url = get_database_url(self.settings)
+        initial_url = self.settings.database_url
         while True:
             try:
-                if get_database_url(self.settings) != initial_url:
+                if self.settings.database_url != initial_url:
                     self.crash()
                 with closing(Session()) as session:
                     self.logger.info("Expiring edges....")

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -12,7 +12,6 @@ from grouper.plugin import initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.settings import default_settings_path
 from grouper.setup import setup_logging
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -58,7 +57,7 @@ def start_processor(args, settings, sentry_client):
 
     # setup database
     logging.debug("configure database session")
-    Session.configure(bind=get_db_engine(get_database_url(settings)))
+    Session.configure(bind=get_db_engine(settings.database_url))
 
     background = BackgroundProcessor(settings, sentry_client)
     background.run()

--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -6,7 +6,6 @@ from sqlalchemy.schema import CreateIndex, CreateTable
 
 from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction, Namespace
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 def dump_sql_command(args, settings):
     # type: (Namespace, CtlSettings) -> None
-    db_engine = get_db_engine(get_database_url(settings))
+    db_engine = get_db_engine(settings.database_url)
     for table in Model.metadata.sorted_tables:
         print(CreateTable(table).compile(db_engine))
         for index in table.indexes:

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -14,7 +14,7 @@ from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine
 from grouper.models.group import Group
 from grouper.permissions import create_permission, get_permission, grant_permission
-from grouper.util import get_auditors_group_name, get_database_url
+from grouper.util import get_auditors_group_name
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -27,7 +27,7 @@ def sync_db_command(args, settings):
     from grouper.models.perf_profile import PerfProfile  # noqa: F401
     from grouper.models.user_token import UserToken  # noqa: F401
 
-    db_engine = get_db_engine(get_database_url(settings))
+    db_engine = get_db_engine(settings.database_url)
     Model.metadata.create_all(db_engine)
 
     # Add some basic database structures we know we will need if they don't exist.

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 from grouper.constants import NAME_VALIDATION, SERVICE_ACCOUNT_VALIDATION, USERNAME_VALIDATION
 from grouper.models.base.session import get_db_engine, Session
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -70,7 +69,7 @@ def ensure_valid_service_account_name(f):
 
 def make_session(settings):
     # type: (CtlSettings) -> Session
-    db_engine = get_db_engine(get_database_url(settings))
+    db_engine = get_db_engine(settings.database_url)
     Session.configure(bind=db_engine)
     return Session()
 

--- a/grouper/database.py
+++ b/grouper/database.py
@@ -3,16 +3,23 @@ import os
 from contextlib import closing
 from threading import Thread
 from time import sleep
+from typing import TYPE_CHECKING
 
 from grouper import stats
 from grouper.models.base.session import Session
-from grouper.util import get_database_url
+
+if TYPE_CHECKING:
+    from grouper.error_reporting import SentryProxy
+    from grouper.graph import GroupGraph
+    from grouper.settings import Settings
+    from typing import Any, NoReturn
 
 
 class DbRefreshThread(Thread):
     """Background thread for refreshing the in-memory cache of the graph."""
 
     def __init__(self, settings, graph, refresh_interval, sentry_client, *args, **kwargs):
+        # type: (Settings, GroupGraph, int, SentryProxy, *Any, **Any) -> None
         self.settings = settings
         self.graph = graph
         self.refresh_interval = refresh_interval
@@ -21,18 +28,21 @@ class DbRefreshThread(Thread):
         Thread.__init__(self, *args, **kwargs)
 
     def capture_exception(self):
+        # type: () -> None
         if self.sentry_client:
             self.sentry_client.captureException()
 
     def crash(self):
+        # type: () -> NoReturn
         os._exit(1)
 
     def run(self):
-        initial_url = get_database_url(self.settings)
+        # type () -> None
+        initial_url = self.settings.database_url
         while True:
             self.logger.debug("Updating Graph from Database.")
             try:
-                if get_database_url(self.settings) != initial_url:
+                if self.settings.database_url != initial_url:
                     self.crash()
                 with closing(Session()) as session:
                     self.graph.update_from_db(session)

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -23,7 +23,6 @@ from grouper.models.base.session import get_db_engine, Session
 from grouper.plugin import get_plugin_proxy, initialize_plugins
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.setup import build_arg_parser, setup_logging
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -74,8 +73,9 @@ def start_server(args, settings, sentry_client):
 
     # setup database
     logging.debug("configure database session")
-    database_url = args.database_url or get_database_url(settings)
-    Session.configure(bind=get_db_engine(database_url))
+    if args.database_url:
+        settings.database = args.database_url
+    Session.configure(bind=get_db_engine(settings.database_url))
 
     usecase_factory = create_graph_usecase_factory(settings, Session())
     application = create_fe_application(settings, usecase_factory, args.deployment_name)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -22,7 +22,6 @@ from grouper.models.base.session import get_db_engine, Session
 from grouper.models.user import User
 from grouper.perf_profile import record_trace
 from grouper.user_permissions import user_permissions
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from grouper.usecases.factory import UseCaseFactory
@@ -151,7 +150,7 @@ class GrouperHandler(RequestHandler):
         except sqlalchemy.exc.OperationalError:
             # Failed to connect to database or create user, try to reconfigure the db. This invokes
             # the fetcher to try to see if our URL string has changed.
-            Session.configure(bind=get_db_engine(get_database_url(settings())))
+            Session.configure(bind=get_db_engine(settings().database_url))
             raise DatabaseFailure()
 
         # service accounts are, by definition, not interactive users

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -15,7 +15,6 @@ from grouper.repositories.permission_grant import (
 from grouper.repositories.service_account import ServiceAccountRepository
 from grouper.repositories.transaction import TransactionRepository
 from grouper.repositories.user import UserRepository
-from grouper.util import get_database_url
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
@@ -61,7 +60,7 @@ class GraphRepositoryFactory(RepositoryFactory):
     def session(self):
         # type: () -> Session
         if not self._session:
-            db_engine = get_db_engine(get_database_url(self.settings))
+            db_engine = get_db_engine(self.settings.database_url)
             Session.configure(bind=db_engine)
             self._session = Session()
         return self._session
@@ -128,7 +127,7 @@ class SQLRepositoryFactory(RepositoryFactory):
     def session(self):
         # type: () -> Session
         if not self._session:
-            db_engine = get_db_engine(get_database_url(self.settings))
+            db_engine = get_db_engine(self.settings.database_url)
             Session.configure(bind=db_engine)
             self._session = Session()
         return self._session

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -106,6 +106,16 @@ class Settings(object):
     @property
     def database_url(self):
         # type: () -> str
+        """Return the configured database URL.
+
+        If database is set in the config file or directly on the Settings object, it is the static
+        URL.  Otherwise, database_source must be set and be the path to a program that will be run
+        to determine the database URL.
+
+        The database_source program will be run every time the database_url attribute is accessed.
+        Caching doesn't seem worthwhile given that it is only accessed during process startup, on
+        each loop of a periodic background thread, or after a database error.
+        """
         if self.database:
             return self.database
         if not self.database and not self.database_source:

--- a/tests/ctl/misc_test.py
+++ b/tests/ctl/misc_test.py
@@ -109,7 +109,6 @@ def test_user_public_key(make_session, session, users):  # noqa: F811
 
 @patch("grouper.ctl.sync_db.make_session")
 @patch("grouper.ctl.sync_db.get_auditors_group_name", return_value="my-auditors")
-@patch("grouper.ctl.sync_db.get_database_url", new=noop)
 @patch("grouper.ctl.sync_db.get_db_engine", new=noop)
 @patch.object(Model.metadata, "create_all", new=noop)
 def test_sync_db_default_group(

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -113,23 +113,3 @@ def test_database_url():
             mock_subprocess.return_value = ""
             with pytest.raises(DatabaseSourceException):
                 assert settings.database_url
-
-    # If the minimum delay before retrying hasn't been reached, the program shouldn't be called
-    # repeatedly on subsequent accesses.  But it should be called repeatedly if the delay has been
-    # reached.
-    settings = Settings()
-    settings.database_source = "/path/to/program"
-    with patch.object(Settings, "DB_URL_MIN_CACHE_TIME", new=15):
-        with patch("subprocess.check_output") as mock_subprocess:
-            mock_subprocess.return_value = "sqlite:///cache.sqlite"
-            assert settings.database_url == "sqlite:///cache.sqlite"
-            assert settings.database_url == "sqlite:///cache.sqlite"
-            assert mock_subprocess.call_count == 1
-    settings = Settings()
-    settings.database_source = "/path/to/program"
-    with patch.object(Settings, "DB_URL_MAX_CACHE_TIME", new=0):
-        with patch("subprocess.check_output") as mock_subprocess:
-            mock_subprocess.return_value = "sqlite:///cache.sqlite"
-            assert settings.database_url == "sqlite:///cache.sqlite"
-            assert settings.database_url == "sqlite:///cache.sqlite"
-            assert mock_subprocess.call_count == 2

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,0 +1,135 @@
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+import pytz
+from mock import call, patch
+
+from grouper.settings import DatabaseSourceException, InvalidSettingsError, Settings
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+
+# Data to test loading settings from different sections.
+CONFIG_SECTIONS = """
+common:
+  database: foo
+
+other:
+  database: bar
+"""
+
+# Data to test ignoring unknown and internal settings.
+CONFIG_BOGUS = """
+common:
+    _logger: bar
+    foo: bar
+    timezone_object: UTC
+    database_url: blah
+"""
+
+
+def test_update_from_config(tmpdir):
+    # type: (LocalPath) -> None
+    settings = Settings()
+    assert not settings.database
+
+    # Create a config file that sets database to different values in different sections.
+    config_path = str(tmpdir.join("test.yaml"))
+    with open(config_path, "w") as config:
+        config.write(CONFIG_SECTIONS)
+
+    # Default loading should only see the common section, but another can be specified.
+    settings.update_from_config(config_path)
+    assert settings.database == "foo"
+    settings.update_from_config(config_path, section="other")
+    assert settings.database == "bar"
+
+    # The special timezone_object attribute should be initialized and kept in sync.
+    assert settings.timezone_object == pytz.timezone("UTC")
+    with open(config_path, "w") as config:
+        config.write("common:\n  timezone: US/Pacific\n")
+    settings.update_from_config(config_path)
+    assert settings.timezone_object == pytz.timezone("US/Pacific")
+
+    # Create a config file that tries to set unknown or internal attributes.
+    with open(config_path, "w") as config:
+        config.write(CONFIG_BOGUS)
+    settings.update_from_config(config_path)
+    assert settings._logger != "bar"
+    assert not hasattr(settings, "foo")
+    assert settings.timezone_object == pytz.timezone("US/Pacific")
+    assert settings.database_url == "bar"
+
+
+def test_database_url():
+    # type: () -> None
+    settings = Settings()
+
+    # The default is uninitialized and should throw an error until we load a configuration.
+    with pytest.raises(InvalidSettingsError):
+        assert settings.database_url
+
+    # If database is set, it should be used.
+    settings.database = "sqlite:///grouper.sqlite"
+    assert settings.database_url == "sqlite:///grouper.sqlite"
+    settings.database_source = "/bin/false"
+    assert settings.database_url == "sqlite:///grouper.sqlite"
+
+    # If only database_source is set, it should be run to get a URL.
+    settings.database = ""
+    settings.database_source = "/path/to/program"
+    with patch("subprocess.check_output") as mock_subprocess:
+        mock_subprocess.return_value = "sqlite:///other.sqlite"
+        assert settings.database_url == "sqlite:///other.sqlite"
+        assert mock_subprocess.call_args_list == [
+            call(["/path/to/program"], stderr=subprocess.STDOUT)
+        ]
+
+    # If the command fails, it should be retried.  Disable the delay to not make the test slow.
+    settings = Settings()
+    settings.database_source = "/path/to/program"
+    with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
+        with patch("subprocess.check_output") as mock_subprocess:
+            exception = subprocess.CalledProcessError(1, "/path/to/program")
+            mock_subprocess.side_effect = [exception, "sqlite:///third.sqlite"]
+            assert settings.database_url == "sqlite:///third.sqlite"
+            assert mock_subprocess.call_count == 2
+
+    # Commands that return an empty URL should also be retried.
+    settings = Settings()
+    settings.database_source = "/path/to/program"
+    with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
+        with patch("subprocess.check_output") as mock_subprocess:
+            mock_subprocess.side_effect = ["", "sqlite:///notempty.sqlite"]
+            assert settings.database_url == "sqlite:///notempty.sqlite"
+            assert mock_subprocess.call_count == 2
+
+    # Too many retries should raise an exception.
+    settings = Settings()
+    settings.database_source = "/path/to/program"
+    with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
+        with patch("subprocess.check_output") as mock_subprocess:
+            mock_subprocess.return_value = ""
+            with pytest.raises(DatabaseSourceException):
+                assert settings.database_url
+
+    # If the minimum delay before retrying hasn't been reached, the program shouldn't be called
+    # repeatedly on subsequent accesses.  But it should be called repeatedly if the delay has been
+    # reached.
+    settings = Settings()
+    settings.database_source = "/path/to/program"
+    with patch.object(Settings, "DB_URL_MIN_CACHE_TIME", new=15):
+        with patch("subprocess.check_output") as mock_subprocess:
+            mock_subprocess.return_value = "sqlite:///cache.sqlite"
+            assert settings.database_url == "sqlite:///cache.sqlite"
+            assert settings.database_url == "sqlite:///cache.sqlite"
+            assert mock_subprocess.call_count == 1
+    settings = Settings()
+    settings.database_source = "/path/to/program"
+    with patch.object(Settings, "DB_URL_MAX_CACHE_TIME", new=0):
+        with patch("subprocess.check_output") as mock_subprocess:
+            mock_subprocess.return_value = "sqlite:///cache.sqlite"
+            assert settings.database_url == "sqlite:///cache.sqlite"
+            assert settings.database_url == "sqlite:///cache.sqlite"
+            assert mock_subprocess.call_count == 2

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -80,7 +80,7 @@ def test_database_url():
     settings.database = ""
     settings.database_source = "/path/to/program"
     with patch("subprocess.check_output") as mock_subprocess:
-        mock_subprocess.return_value = "sqlite:///other.sqlite"
+        mock_subprocess.return_value = "sqlite:///other.sqlite\n"
         assert settings.database_url == "sqlite:///other.sqlite"
         assert mock_subprocess.call_args_list == [
             call(["/path/to/program"], stderr=subprocess.STDOUT)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -60,15 +60,15 @@ class SetupTest(object):
         # type: (LocalPath) -> None
         self.settings = Settings()
         self.settings.database = db_url(tmpdir)
-        self.session = self.create_session(tmpdir)
+        self.session = self.create_session()
         self.graph = GroupGraph()
         self.repository_factory = GraphRepositoryFactory(self.settings, self.session, self.graph)
         self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)
         self._transaction_service = self.service_factory.create_transaction_service()
 
-    def create_session(self, tmpdir):
-        # type: (LocalPath) -> Session
+    def create_session(self):
+        # type: () -> Session
         db_engine = get_db_engine(self.settings.database_url)
 
         # Reinitialize plugins in case a previous test configured some.

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -58,10 +58,10 @@ class SetupTest(object):
 
     def __init__(self, tmpdir):
         # type: (LocalPath) -> None
-        self.session = self.create_session(tmpdir)
-        self.graph = GroupGraph()
         self.settings = Settings()
         self.settings.database = db_url(tmpdir)
+        self.session = self.create_session(tmpdir)
+        self.graph = GroupGraph()
         self.repository_factory = GraphRepositoryFactory(self.settings, self.session, self.graph)
         self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)
@@ -69,7 +69,7 @@ class SetupTest(object):
 
     def create_session(self, tmpdir):
         # type: (LocalPath) -> Session
-        db_engine = get_db_engine(db_url(tmpdir))
+        db_engine = get_db_engine(self.settings.database_url)
 
         # Reinitialize plugins in case a previous test configured some.
         initialize_plugins([], [], "tests")


### PR DESCRIPTION
Rather than using a separate utility function to interpret Settings
and maintain a separate global cache, move database_url to a
property on Settings and the logic for running a database_source
command to private methods.  This simplifies a lot of callers.

In the API and frontend servers, properly override the database URL
if a URL was given on the command line.  This prevents the server
from later running a database_source command and overriding a URL
explicitly given via a command-line argument.

Add a test for Settings behavior, including this new code.