### PR TITLE
Reinitialize plugins between tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,6 +26,7 @@ from grouper.models.group import Group
 from grouper.models.permission import Permission
 from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing
+from grouper.plugin import initialize_plugins
 from grouper.service_account import create_service_account
 from grouper.settings import set_global_settings, Settings
 from tests.path_util import db_url
@@ -170,6 +171,9 @@ def session(request, tmpdir):
     # type: (FixtureRequest, LocalPath) -> None
     settings = Settings()
     set_global_settings(settings)
+
+    # Reinitialize plugins in case a previous test configured some.
+    initialize_plugins(settings.plugin_dirs, settings.plugin_module_paths, "tests")
 
     db_engine = get_db_engine(db_url(tmpdir))
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -29,6 +29,7 @@ from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User
+from grouper.plugin import initialize_plugins
 from grouper.repositories.factory import GraphRepositoryFactory
 from grouper.services.factory import ServiceFactory
 from grouper.settings import Settings
@@ -69,6 +70,9 @@ class SetupTest(object):
     def create_session(self, tmpdir):
         # type: (LocalPath) -> Session
         db_engine = get_db_engine(db_url(tmpdir))
+
+        # Reinitialize plugins in case a previous test configured some.
+        initialize_plugins([], [], "tests")
 
         # If using a persistent database, clear the database first.
         if "MEROU_TEST_DATABASE" in os.environ:


### PR DESCRIPTION
The PluginProxy object is global and remembers previously-configured
plugin paths, and the grouper-ctl tests initialize plugins.  This
was accidentally not causing test failures because pytest was running
tests in a predictable order that ran all plugin-sensitive tests
before grouper-ctl tests by accident, but a different test framework
that ran the tests in a different order showed this problem.

Reinitialize plugins between tests for now until we can fix this
problem properly by injecting the PluginProxy into classes that need
it.