### PR TITLE
Clean up disabled permission handling

### DIFF
--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -44,18 +44,23 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
         # type: (str) -> None
         logging.info("disabled permission %s", name)
 
-    def disable_permission_failed_existing_group_grants(self, name, grants):
-        # type: (str, List[GroupPermissionGrant]) -> None
-        groups = [g.group for g in grants]
-        logging.critical("permission %s still granted to groups %s", name, ", ".join(groups))
-        sys.exit(1)
-
-    def disable_permission_failed_existing_service_account_grants(self, name, grants):
-        # type: (str, List[ServiceAccountPermissionGrant]) -> None
-        service_accounts = [g.service_account for g in grants]
-        logging.critical(
-            "permission %s still granted to service accounts %s", name, ", ".join(service_accounts)
-        )
+    def disable_permission_failed_existing_grants(
+        self,
+        name,  # type: str
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+    ):
+        # type: (...) -> None
+        message = ""
+        if group_grants:
+            groups = [g.group for g in group_grants]
+            message = "groups " + ", ".join(groups)
+        if service_account_grants:
+            service_accounts = [g.service_account for g in service_account_grants]
+            if message:
+                message += " and "
+            message += "service accounts " + ", ".join(service_accounts)
+        logging.critical("permission %s still granted to %s", message)
         sys.exit(1)
 
     def disable_permission_failed_not_found(self, name):

--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -7,7 +7,12 @@ from grouper.usecases.disable_permission import DisablePermissionUI
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
     from grouper.usecases.factory import UseCaseFactory
+    from typing import List
 
 
 class PermissionCommand(CtlCommand, DisablePermissionUI):
@@ -38,6 +43,20 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
     def disabled_permission(self, name):
         # type: (str) -> None
         logging.info("disabled permission %s", name)
+
+    def disable_permission_failed_existing_group_grants(self, name, grants):
+        # type: (str, List[GroupPermissionGrant]) -> None
+        groups = [g.group for g in grants]
+        logging.critical("permission %s still granted to groups %s", name, ", ".join(groups))
+        sys.exit(1)
+
+    def disable_permission_failed_existing_service_account_grants(self, name, grants):
+        # type: (str, List[ServiceAccountPermissionGrant]) -> None
+        service_accounts = [g.service_account for g in grants]
+        logging.critical(
+            "permission %s still granted to service accounts %s", name, ", ".join(service_accounts)
+        )
+        sys.exit(1)
 
     def disable_permission_failed_not_found(self, name):
         # type: (str) -> None

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -1,5 +1,14 @@
-from grouper.fe.util import GrouperHandler
+from typing import TYPE_CHECKING
+
+from grouper.fe.util import Alert, GrouperHandler
 from grouper.usecases.disable_permission import DisablePermissionUI
+
+if TYPE_CHECKING:
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
+    from typing import List
 
 
 class PermissionDisable(GrouperHandler, DisablePermissionUI):
@@ -8,6 +17,23 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
     def disabled_permission(self, name):
         # type: (str) -> None
         self.redirect("/permissions/{}".format(name))
+
+    def disable_permission_failed_existing_group_grants(self, name, grants):
+        # type: (str, List[GroupPermissionGrant]) -> None
+        """The permission view page will show the grants, so we don't include them in the error."""
+        alert = Alert(
+            "danger", "Permission cannot be disabled while it is still granted to some groups"
+        )
+        self.redirect("/permissions/{}".format(name), alerts=[alert])
+
+    def disable_permission_failed_existing_service_account_grants(self, name, grants):
+        # type: (str, List[ServiceAccountPermissionGrant]) -> None
+        """The permission view page will show the grants, so we don't include them in the error."""
+        alert = Alert(
+            "danger",
+            "Permission cannot be disabled while it is still granted to some service accounts",
+        )
+        self.redirect("/permissions/{}".format(name), alerts=[alert])
 
     def disable_permission_failed_not_found(self, name):
         # type: (str) -> None

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -18,20 +18,20 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         # type: (str) -> None
         self.redirect("/permissions/{}".format(name))
 
-    def disable_permission_failed_existing_group_grants(self, name, grants):
-        # type: (str, List[GroupPermissionGrant]) -> None
-        """The permission view page will show the grants, so we don't include them in the error."""
-        alert = Alert(
-            "danger", "Permission cannot be disabled while it is still granted to some groups"
-        )
-        self.redirect("/permissions/{}".format(name), alerts=[alert])
-
-    def disable_permission_failed_existing_service_account_grants(self, name, grants):
-        # type: (str, List[ServiceAccountPermissionGrant]) -> None
+    def disable_permission_failed_existing_grants(
+        self,
+        name,  # type: str
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+    ):
+        # type: (...) -> None
         """The permission view page will show the grants, so we don't include them in the error."""
         alert = Alert(
             "danger",
-            "Permission cannot be disabled while it is still granted to some service accounts",
+            (
+                "Permission cannot be disabled while it is still granted to some groups or"
+                " service accounts"
+            ),
         )
         self.redirect("/permissions/{}".format(name), alerts=[alert])
 

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -128,11 +128,12 @@ class GrouperHandler(RequestHandler):
             self.graph.update_from_db(self.session)
 
     def redirect(self, url, *args, **kwargs):
+        # type: (str, *Any, **Any) -> None
         if self.is_refresh():
             url = urljoin(url, "?refresh=yes")
-
-        self.set_alerts(kwargs.pop("alerts", []))
-        return super(GrouperHandler, self).redirect(url, *args, **kwargs)
+        alerts = kwargs.pop("alerts", [])  # type: List[Alert]
+        self.set_alerts(alerts)
+        super(GrouperHandler, self).redirect(url, *args, **kwargs)
 
     def get_current_user(self):
         # type: () -> Optional[User]

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -254,7 +254,6 @@ class GroupGraph(object):
             Permission.id == PermissionMap.permission_id,
             PermissionMap.group_id == Group.id,
             Group.enabled == True,
-            Permission.enabled == True,
         )
 
         for (permission, permission_map) in permissions:

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -80,8 +80,13 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def revoke_inactive_group_grants_for_permission(self, name):
+    def revoke_all_group_grants(self, permission):
         # type: (str) -> List[GroupPermissionGrant]
+        pass
+
+    @abstractmethod
+    def revoke_all_service_account_grants(self, permission):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -65,8 +65,13 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def group_grants_for_permission(self, name):
-        # type: (str) -> List[GroupPermissionGrant]
+    def group_grants_for_permission(self, name, include_disabled_groups=False):
+        # type: (str, bool) -> List[GroupPermissionGrant]
+        pass
+
+    @abstractmethod
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
         pass
 
     @abstractmethod
@@ -75,8 +80,8 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
+    def revoke_inactive_group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -39,9 +39,13 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         # type: (str, str, str) -> None
         self.repository.grant_permission_to_group(permission, argument, group)
 
-    def group_grants_for_permission(self, name):
-        # type: (str) -> List[GroupPermissionGrant]
+    def group_grants_for_permission(self, name, include_disabled_groups=False):
+        # type: (str, bool) -> List[GroupPermissionGrant]
         return self.repository.group_grants_for_permission(name)
+
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        return self.repository.service_account_grants_for_permission(name)
 
     def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
@@ -54,9 +58,9 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
             permissions.append(permission)
         return permissions
 
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
-        return self.repository.service_account_grants_for_permission(name)
+    def revoke_inactive_group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        return self.repository.revoke_inactive_group_grants_for_permission(name)
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
@@ -87,22 +91,37 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
         )
         mapping.add(self.session)
 
-    def group_grants_for_permission(self, name):
-        # type: (str) -> List[GroupPermissionGrant]
+    def group_grants_for_permission(self, name, include_disabled_groups=False):
+        # type: (str, bool) -> List[GroupPermissionGrant]
         permission = Permission.get(self.session, name=name)
         if not permission or not permission.enabled:
             return []
         grants = (
             self.session.query(Group.groupname, PermissionMap.argument)
             .filter(
-                PermissionMap.permission_id == permission.id,
-                Group.id == PermissionMap.group_id,
-                Group.enabled == True,
+                PermissionMap.permission_id == permission.id, Group.id == PermissionMap.group_id
             )
             .order_by(Group.groupname, PermissionMap.argument)
-            .all()
         )
-        return [GroupPermissionGrant(g.groupname, name, g.argument) for g in grants]
+        if not include_disabled_groups:
+            grants = grants.filter(Group.enabled == True)
+        return [GroupPermissionGrant(g.groupname, name, g.argument) for g in grants.all()]
+
+    def service_account_grants_for_permission(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        permission = Permission.get(self.session, name=name)
+        if not permission or not permission.enabled:
+            return []
+        grants = (
+            self.session.query(User.username, ServiceAccountPermissionMap.argument)
+            .filter(
+                ServiceAccountPermissionMap.permission_id == permission.id,
+                ServiceAccount.id == ServiceAccountPermissionMap.service_account_id,
+                User.id == ServiceAccount.user_id,
+            )
+            .order_by(User.username, ServiceAccountPermissionMap.argument)
+        )
+        return [ServiceAccountPermissionGrant(g.username, name, g.argument) for g in grants.all()]
 
     def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
@@ -164,23 +183,24 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
         )
         return [PermissionGrant(g.name, g.argument) for g in group_permission_grants]
 
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
+    def revoke_inactive_group_grants_for_permission(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        """Delete all permission grants for a permission to disabled groups."""
         permission = Permission.get(self.session, name=name)
-        if not permission or not permission.enabled:
+        if not permission:
             return []
         grants = (
-            self.session.query(User.username, ServiceAccountPermissionMap.argument)
+            self.session.query(PermissionMap.id, Group.groupname, PermissionMap.argument)
             .filter(
-                ServiceAccountPermissionMap.permission_id == permission.id,
-                ServiceAccount.id == ServiceAccountPermissionMap.service_account_id,
-                User.id == ServiceAccount.user_id,
-                User.enabled == True,
+                Group.id == PermissionMap.group_id,
+                PermissionMap.permission_id == permission.id,
+                Group.enabled == False,
             )
-            .order_by(User.username, ServiceAccountPermissionMap.argument)
             .all()
         )
-        return [ServiceAccountPermissionGrant(g.username, name, g.argument) for g in grants]
+        ids = [g.id for g in grants]
+        self.session.query(PermissionMap).filter(PermissionMap.id.in_(ids)).delete()
+        return [GroupPermissionGrant(g.groupname, permission, g.argument) for g in grants]
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -199,8 +199,10 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
             .all()
         )
         ids = [g.id for g in grants]
-        self.session.query(PermissionMap).filter(PermissionMap.id.in_(ids)).delete()
-        return [GroupPermissionGrant(g.groupname, permission, g.argument) for g in grants]
+        self.session.query(PermissionMap).filter(PermissionMap.id.in_(ids)).delete(
+            synchronize_session="fetch"
+        )
+        return [GroupPermissionGrant(g.groupname, name, g.argument) for g in grants]
 
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool

--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -207,7 +207,6 @@ def service_account_permissions(session, service_account):
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
         ServiceAccount.user_id == User.id,
         User.enabled == True,
-        Permission.enabled == True,
     )
     out = []
     for permission in permissions:
@@ -231,7 +230,6 @@ def all_service_account_permissions(session):
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
         ServiceAccount.user_id == User.id,
         User.enabled == True,
-        Permission.enabled == True,
     )
     for permission in permissions:
         out[permission[1].service_account.user.username].append(

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -91,6 +91,23 @@ class AuditLogService(AuditLogInterface):
             on_permission=permission,
         )
 
+    def log_revoke_service_account_permission_grant(
+        self,
+        service_account,  # type: str
+        permission,  # type: str
+        argument,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="revoke_permission",
+            description="Revoked permission with argument: {}".format(argument),
+            on_permission=permission,
+            on_user=service_account,
+        )
+
     def log_user_group_request_status_change(self, request, status, authorization, date=None):
         # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -74,6 +74,23 @@ class AuditLogService(AuditLogInterface):
             date=date,
         )
 
+    def log_revoke_group_permission_grant(
+        self,
+        group,  # type: str
+        permission,  # type: str
+        argument,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="revoke_permission",
+            description="Revoked permission with argument: {}".format(argument),
+            on_group=group,
+            on_permission=permission,
+        )
+
     def log_user_group_request_status_change(self, request, status, authorization, date=None):
         # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(

--- a/grouper/usecases/disable_permission.py
+++ b/grouper/usecases/disable_permission.py
@@ -27,13 +27,13 @@ class DisablePermissionUI(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def disable_permission_failed_existing_group_grants(self, name, grants):
-        # type: (str, List[GroupPermissionGrant]) -> None
-        pass
-
-    @abstractmethod
-    def disable_permission_failed_existing_service_account_grants(self, name, grants):
-        # type: (str, List[ServiceAccountPermissionGrant]) -> None
+    def disable_permission_failed_existing_grants(
+        self,
+        name,  # type: str
+        group_grants,  # type: List[GroupPermissionGrant]
+        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
+    ):
+        # type: (...) -> None
         pass
 
     @abstractmethod
@@ -84,12 +84,9 @@ class DisablePermission(object):
 
         # Check if this permission is still granted to any groups or service accounts.
         group_grants = self.permission_service.group_grants_for_permission(name)
-        if group_grants:
-            self.ui.disable_permission_failed_existing_group_grants(name, group_grants)
-            return
         service_grants = self.permission_service.service_account_grants_for_permission(name)
-        if service_grants:
-            self.ui.disable_permission_failed_existing_service_account_grants(name, service_grants)
+        if group_grants or service_grants:
+            self.ui.disable_permission_failed_existing_grants(name, group_grants, service_grants)
             return
 
         # Everything looks good.  Disable the permission.

--- a/grouper/usecases/disable_permission.py
+++ b/grouper/usecases/disable_permission.py
@@ -72,6 +72,13 @@ class DisablePermission(object):
 
     def disable_permission(self, name):
         # type: (str) -> None
+        """Disable a permission if it has no active grants.
+
+        An active grant is defined as a permission grant to either an enabled group or an enabled
+        service account.  If it has grants to disabled groups (group permission grants are
+        preserved on group disable to allow restoring the group), those are ignored and will be
+        deleted as part of disabling the permission.
+        """
         if self.permission_service.is_system_permission(name):
             self.ui.disable_permission_failed_system_permission(name)
             return
@@ -82,15 +89,16 @@ class DisablePermission(object):
             self.ui.disable_permission_failed_permission_denied(name)
             return
 
-        # Check if this permission is still granted to any groups or service accounts.
+        # Check if this permission is still granted to any active groups or service accounts.
         group_grants = self.permission_service.group_grants_for_permission(name)
         service_grants = self.permission_service.service_account_grants_for_permission(name)
         if group_grants or service_grants:
             self.ui.disable_permission_failed_existing_grants(name, group_grants, service_grants)
             return
 
-        # Everything looks good.  Disable the permission.
+        # Everything looks good.  Disable the permission.  Any remaining inactive grants will be
+        # revoked here.
         authorization = Authorization(self.actor)
         with self.transaction_service.transaction():
-            self.permission_service.disable_permission(name, authorization)
+            self.permission_service.disable_permission_and_revoke_grants(name, authorization)
         self.ui.disabled_permission(name)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -79,6 +79,18 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
+    def log_revoke_service_account_permission_grant(
+        self,
+        service_account,  # type: str
+        permission,  # type: str
+        argument,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        pass
+
+    @abstractmethod
     def log_user_group_request_status_change(self, request, status, authorization, date=None):
         # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         pass
@@ -136,7 +148,7 @@ class PermissionInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def disable_permission(self, name, authorization):
+    def disable_permission_and_revoke_grants(self, name, authorization):
         # type: (str, Authorization) -> None
         pass
 

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -67,6 +67,18 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
+    def log_revoke_group_permission_grant(
+        self,
+        group,  # type: str
+        permission,  # type: str
+        argument,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        pass
+
+    @abstractmethod
     def log_user_group_request_status_change(self, request, status, authorization, date=None):
         # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
         pass

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -58,7 +58,6 @@ def user_permissions(session, user):
             GroupEdge.active == True,
             user.enabled == True,
             Group.enabled == True,
-            Permission.enabled == True,
             or_(GroupEdge.expiration > now, GroupEdge.expiration == None),
         )
         .order_by(asc("name"), asc("argument"), asc("groupname"))

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -55,6 +55,14 @@ class BasePage(BaseFinder):
         button = self.find_element_by_xpath("//div[contains(@class, 'search-input')]//button[1]")
         button.click()
 
+    def has_alert(self, text):
+        # type: (str) -> bool
+        alerts = self.find_elements_by_class_name("alert")
+        for alert in alerts:
+            if text in alert.text:
+                return True
+        return False
+
     def has_text(self, text):
         return text in self.root.page_source
 

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -15,7 +15,6 @@ from grouper.constants import (
     PERMISSION_AUDITOR,
     PERMISSION_GRANT,
     PERMISSION_VALIDATION,
-    SYSTEM_PERMISSIONS,
 )
 from grouper.fe.forms import ValidateRegex
 from grouper.models.async_notification import AsyncNotification
@@ -24,14 +23,12 @@ from grouper.models.permission_map import PermissionMap
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
 from grouper.permissions import (
-    CannotDisableASystemPermission,
     create_permission,
     disable_permission,
     filter_grantable_permissions,
     get_all_permissions,
     get_grantable_permissions,
     get_groups_by_permission,
-    get_or_create_permission,
     get_owner_arg_list,
     get_owners_by_grantable_permission,
     get_permission,
@@ -628,80 +625,6 @@ def test_grant_and_revoke(
 
     graph.update_from_db(session)
     assert not _check_graph_for_perm(graph), "permissions revoked successfully"
-
-
-@pytest.mark.gen_test
-def test_disabling_permission(
-    session, groups, standard_graph, graph, http_client, base_url  # noqa: F811
-):
-    """
-    This tests disabling via the front-end route, including checking
-    that the user is authorized to disable permissions.
-    """
-    perm_name = "sudo"
-    nonpriv_user_name = "oliver@a.co"  # user without PERMISSION_ADMIN
-    nonpriv_headers = {"X-Grouper-User": nonpriv_user_name}
-    priv_user_name = "cbguder@a.co"  # user with PERMISSION_ADMIN
-    priv_headers = {"X-Grouper-User": priv_user_name}
-    disable_url = url(base_url, "/permissions/{}/disable".format(perm_name))
-    disable_url_non_exist_perm = url(base_url, "/permissions/no.exists/disable")
-
-    assert "sudo:shell" in get_user_permissions(graph, "gary@a.co")
-    assert "sudo:shell" in get_user_permissions(graph, "oliver@a.co")
-
-    # attempt to disable the permission -> should fail cuz actor
-    # doesn't have PERMISSION_ADMIN
-    with pytest.raises(HTTPError) as exc:
-        yield http_client.fetch(disable_url, method="POST", headers=nonpriv_headers, body="")
-    assert exc.value.code == 403
-    # check that no change
-    assert get_permission(session, perm_name).enabled
-    graph.update_from_db(session)
-    assert "sudo:shell" in get_user_permissions(graph, "gary@a.co")
-    assert "sudo:shell" in get_user_permissions(graph, "oliver@a.co")
-
-    # an actor with PERMISSION_ADMIN is allowed to disable the
-    # permission
-    resp = yield http_client.fetch(disable_url, method="POST", headers=priv_headers, body="")
-    assert resp.code == 200
-    assert not get_permission(session, perm_name).enabled
-    graph.update_from_db(session)
-    assert "sudo:shell" not in get_user_permissions(graph, "gary@a.co")
-    assert "sudo:shell" not in get_user_permissions(graph, "oliver@a.co")
-
-    with pytest.raises(HTTPError) as exc:
-        yield http_client.fetch(
-            disable_url_non_exist_perm, method="POST", headers=priv_headers, body=""
-        )
-    assert exc.value.code == 404
-
-    #
-    # make sure that when disabling the permission, all mappings of
-    # it, i.e., with different arguments, are disabled
-    #
-
-    # the standard_graph grants 'ssh' with args '*' and 'shell' to two
-    # different groups
-    assert "ssh:*" in get_group_permissions(graph, "team-sre")
-    assert "ssh:shell" in get_group_permissions(graph, "tech-ops")
-    # disable the perm
-    disable_url_ssh_pem = url(base_url, "/permissions/ssh/disable")
-    resp = yield http_client.fetch(
-        disable_url_ssh_pem, method="POST", headers=priv_headers, body=""
-    )
-    assert resp.code == 200
-    assert not get_permission(session, "ssh").enabled
-    graph.update_from_db(session)
-    assert "ssh:*" not in get_group_permissions(graph, "team-sre")
-    assert "ssh:shell" not in get_group_permissions(graph, "tech-ops")
-
-
-@pytest.mark.parametrize("perm_name", (entry[0] for entry in SYSTEM_PERMISSIONS))
-def test_reject_disabling_system_permissions(perm_name, session, permissions):  # noqa: F811
-    get_or_create_permission(session, perm_name)
-    with pytest.raises(CannotDisableASystemPermission) as exc:
-        disable_permission(session, perm_name, 0)
-    assert exc.value.name == perm_name
 
 
 def test_exclude_disabled_permissions(

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -192,6 +192,18 @@ class SetupTest(object):
         group_service = self.service_factory.create_group_service()
         group_service.grant_permission_to_group(permission, argument, group)
 
+    def revoke_permission_from_group(self, permission, argument, group):
+        # type: (str, str, str) -> None
+        permission_obj = Permission.get(self.session, name=permission)
+        assert permission_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+        self.session.query(PermissionMap).filter(
+            PermissionMap.permission_id == permission_obj.id,
+            PermissionMap.group_id == group_obj.id,
+            PermissionMap.argument == argument,
+        ).delete()
+
     def create_group_request(self, user, group, role="member"):
         # type: (str, str, str) -> None
         self.create_user(user)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -31,7 +31,8 @@ from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GroupEdge
+from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.permission import Permission
 from grouper.models.service_account import ServiceAccount
 from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
@@ -223,6 +224,9 @@ class SetupTest(object):
     def create_service_account(self, service_account, owner, description="", machine_set=""):
         # type: (str, str, str, str) -> None
         self.create_group(owner)
+        group_obj = Group.get(self.session, name=owner)
+        assert group_obj
+
         if User.get(self.session, name=service_account):
             return
         user = User(username=service_account)
@@ -232,6 +236,12 @@ class SetupTest(object):
         )
         service_account_obj.add(self.session)
         user.is_service_account = True
+
+        self.session.flush()
+        owner_map = GroupServiceAccount(
+            group_id=group_obj.id, service_account_id=service_account_obj.id
+        )
+        owner_map.add(self.session)
 
     def grant_permission_to_service_account(self, permission, argument, service_account):
         # type: (str, str, str) -> None
@@ -247,3 +257,9 @@ class SetupTest(object):
             argument=argument,
         )
         grant.add(self.session)
+
+    def disable_group(self, group):
+        # type: (str) -> None
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+        group_obj.enabled = False

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -31,9 +31,10 @@ from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.permission import Permission
+from grouper.models.permission_map import PermissionMap
 from grouper.models.service_account import ServiceAccount
 from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.user import User

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -71,29 +71,17 @@ def test_permission_disable_existing_grants(setup):
         setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
         setup.add_user_to_group("gary@a.co", "admins")
         setup.grant_permission_to_group("some-permission", "argument", "some-group")
-
-    mock_ui = MagicMock()
-    usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
-    usecase.disable_permission("some-permission")
-    group_grants = [GroupPermissionGrant("some-group", "some-permission", "argument")]
-    assert mock_ui.mock_calls == [
-        call.disable_permission_failed_existing_group_grants("some-permission", group_grants)
-    ]
-
-    with setup.transaction():
         setup.create_service_account("service@svc.localhost", "some-group")
         setup.grant_permission_to_service_account("some-permission", "", "service@svc.localhost")
-        setup.revoke_permission_from_group("some-permission", "argument", "some-group")
 
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_disable_permission_usecase("gary@a.co", mock_ui)
     usecase.disable_permission("some-permission")
-    service_grants = [
-        ServiceAccountPermissionGrant("service@svc.localhost", "some-permission", "")
-    ]
     assert mock_ui.mock_calls == [
-        call.disable_permission_failed_existing_service_account_grants(
-            "some-permission", service_grants
+        call.disable_permission_failed_existing_grants(
+            "some-permission",
+            [GroupPermissionGrant("some-group", "some-permission", "argument")],
+            [ServiceAccountPermissionGrant("service@svc.localhost", "some-permission", "")],
         )
     ]
 


### PR DESCRIPTION
Since disabling a permission is currently irreversible in the UI,
require that people manually remove all existing permission grants
before disabling the permission.  This also solves some data
consistency issues by ensuring there will not be grants of a
disabled permission, which then has to be handled in other code.

Remove some old tests that now duplicate the usecase test.

To fully establish the invariant that disabled permissions are not
granted to anything, we have to handle the case of disabled groups.
(Service accounts delete all of their permission grants when
disabled, so are not affected.)  For enabled groups, we require the
person disabling the permission revoke all the grants first, but it
doesn't make sense to ask them to do this for disabled groups, which
are invisible in the UI.

Semantically, it makes sense to silently revoke the permission from
all disabled groups, since their grants are retained only to preserve
the group state if disabling it was a mistake, and removing grants of
a separately-disabled permission is not a mistake.

Do that on disable, and add a test that it happens properly.