### PR TITLE
Rework grouper-ctl sync_db and start on schema service

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -56,6 +56,9 @@ SYSTEM_PERMISSIONS = [
     (USER_DISABLE, "Ability to disable an enabled user."),
 ]
 
+# Name of the administrators group created automatically by sync-db.
+DEFAULT_ADMIN_GROUP = "grouper-administrators"
+
 # Used to construct name tuples in notification engine.
 ILLEGAL_NAME_CHARACTER = "|"
 

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.permission import PermissionCommand
+from grouper.ctl.sync_db import SyncDbCommand
 from grouper.ctl.user import UserCommand
 from grouper.ctl.user_proxy import UserProxyCommand
 
@@ -32,6 +33,8 @@ class CtlCommandFactory(object):
         """
         parser = subparsers.add_parser("permission", help="Manipulate permissions")
         PermissionCommand.add_arguments(parser)
+        parser = subparsers.add_parser("sync_db", help="Create database schema")
+        SyncDbCommand.add_arguments(parser)
         parser = subparsers.add_parser("user", help="Manipulate users")
         UserCommand.add_arguments(parser)
         parser = subparsers.add_parser("user_proxy", help="Start a development reverse proxy")
@@ -46,6 +49,8 @@ class CtlCommandFactory(object):
         # type: (str) -> CtlCommand
         if command == "permission":
             return self.construct_permission_command()
+        elif command == "sync_db":
+            return self.construct_sync_db_command()
         elif command == "user":
             return self.construct_user_command()
         elif command == "user_proxy":
@@ -56,6 +61,10 @@ class CtlCommandFactory(object):
     def construct_permission_command(self):
         # type: () -> PermissionCommand
         return PermissionCommand(self.usecase_factory)
+
+    def construct_sync_db_command(self):
+        # type: () -> SyncDbCommand
+        return SyncDbCommand(self.settings, self.usecase_factory)
 
     def construct_user_command(self):
         # type: () -> UserCommand

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -9,88 +9,94 @@ from grouper.constants import (
     SYSTEM_PERMISSIONS,
     USER_ADMIN,
 )
+from grouper.ctl.base import CtlCommand
 from grouper.ctl.util import make_session
-from grouper.models.base.model_base import Model
-from grouper.models.base.session import get_db_engine
 from grouper.models.group import Group
 from grouper.permissions import create_permission, get_permission, grant_permission
 from grouper.util import get_auditors_group_name
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from argparse import ArgumentParser, Namespace
     from grouper.ctl.settings import CtlSettings
+    from grouper.usecases.factory import UseCaseFactory
 
 
-def sync_db_command(args, settings):
-    # type: (Namespace, CtlSettings) -> None
-    # Models not implicitly or explictly imported above are explicitly imported here
-    from grouper.models.perf_profile import PerfProfile  # noqa: F401
-    from grouper.models.user_token import UserToken  # noqa: F401
+class SyncDbCommand(CtlCommand):
+    """Commands to initialize the database."""
 
-    db_engine = get_db_engine(settings.database_url)
-    Model.metadata.create_all(db_engine)
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        return
 
-    # Add some basic database structures we know we will need if they don't exist.
-    session = make_session(settings)
+    def __init__(self, settings, usecase_factory):
+        # type: (CtlSettings, UseCaseFactory) -> None
+        self.settings = settings
+        self.usecase_factory = usecase_factory
 
-    for name, description in SYSTEM_PERMISSIONS:
-        test = get_permission(session, name)
-        if test:
-            continue
-        try:
-            create_permission(session, name, description)
-            session.flush()
-        except IntegrityError:
-            session.rollback()
-            raise Exception("Failed to create permission: %s" % (name,))
-        session.commit()
+    def run(self, args):
+        # type: (Namespace) -> None
+        usecase = self.usecase_factory.create_initialize_schema_usecase()
+        usecase.initialize_schema()
 
-    # This group is needed to bootstrap a Grouper installation.
-    admin_group = Group.get(session, name="grouper-administrators")
-    if not admin_group:
-        admin_group = Group(
-            groupname="grouper-administrators",
-            description="Administrators of the Grouper system.",
-            canjoin="nobody",
-        )
+        # TODO(rra): The code below will move into use cases later.
 
-        try:
-            admin_group.add(session)
-            session.flush()
-        except IntegrityError:
-            session.rollback()
-            raise Exception("Failed to create group: grouper-administrators")
+        # Add some basic database structures we know we will need if they don't exist.
+        session = make_session(self.settings)
 
-        for permission_name in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-            permission = get_permission(session, permission_name)
+        for name, description in SYSTEM_PERMISSIONS:
+            test = get_permission(session, name)
+            if test:
+                continue
+            try:
+                create_permission(session, name, description)
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                raise Exception("Failed to create permission: %s" % (name,))
+            session.commit()
+
+        # This group is needed to bootstrap a Grouper installation.
+        admin_group = Group.get(session, name="grouper-administrators")
+        if not admin_group:
+            admin_group = Group(
+                groupname="grouper-administrators",
+                description="Administrators of the Grouper system.",
+                canjoin="nobody",
+            )
+
+            try:
+                admin_group.add(session)
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                raise Exception("Failed to create group: grouper-administrators")
+
+            for permission_name in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
+                permission = get_permission(session, permission_name)
+                assert permission, "Permission should have been created earlier!"
+                grant_permission(session, admin_group.id, permission.id)
+
+            session.commit()
+
+        auditors_group_name = get_auditors_group_name(self.settings)
+        auditors_group = Group.get(session, name=auditors_group_name)
+        if not auditors_group:
+            auditors_group = Group(
+                groupname=auditors_group_name,
+                description="Group for auditors, who can be owners of audited groups.",
+                canjoin="canjoin",
+            )
+
+            try:
+                auditors_group.add(session)
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                raise Exception("Failed to create group: {}".format(self.settings.auditors_group))
+
+            permission = get_permission(session, PERMISSION_AUDITOR)
             assert permission, "Permission should have been created earlier!"
-            grant_permission(session, admin_group.id, permission.id)
+            grant_permission(session, auditors_group.id, permission.id)
 
-        session.commit()
-
-    auditors_group_name = get_auditors_group_name(settings)
-    auditors_group = Group.get(session, name=auditors_group_name)
-    if not auditors_group:
-        auditors_group = Group(
-            groupname=auditors_group_name,
-            description="Group for auditors, who can be owners of audited groups.",
-            canjoin="canjoin",
-        )
-
-        try:
-            auditors_group.add(session)
-            session.flush()
-        except IntegrityError:
-            session.rollback()
-            raise Exception("Failed to create group: {}".format(settings.auditors_group))
-
-        permission = get_permission(session, PERMISSION_AUDITOR)
-        assert permission, "Permission should have been created earlier!"
-        grant_permission(session, auditors_group.id, permission.id)
-
-        session.commit()
-
-
-def add_parser(subparsers):
-    sync_db_parser = subparsers.add_parser("sync_db", help="Apply database schema to database.")
-    sync_db_parser.set_defaults(func=sync_db_command)
+            session.commit()

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.exc import IntegrityError
 
 from grouper.constants import (
+    DEFAULT_ADMIN_GROUP,
     GROUP_ADMIN,
     PERMISSION_ADMIN,
     PERMISSION_AUDITOR,
@@ -57,10 +58,10 @@ class SyncDbCommand(CtlCommand):
             session.commit()
 
         # This group is needed to bootstrap a Grouper installation.
-        admin_group = Group.get(session, name="grouper-administrators")
+        admin_group = Group.get(session, name=DEFAULT_ADMIN_GROUP)
         if not admin_group:
             admin_group = Group(
-                groupname="grouper-administrators",
+                groupname=DEFAULT_ADMIN_GROUP,
                 description="Administrators of the Grouper system.",
                 canjoin="nobody",
             )

--- a/grouper/models/base/session.py
+++ b/grouper/models/base/session.py
@@ -1,8 +1,12 @@
 import functools
 import logging
+from typing import TYPE_CHECKING
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session as _Session, sessionmaker
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
 
 
 def flush_transaction(method):
@@ -26,6 +30,7 @@ def flush_transaction(method):
 
 
 def get_db_engine(url):
+    # type: (str) -> Engine
     return create_engine(url, pool_recycle=300)
 
 

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -12,6 +12,7 @@ from grouper.repositories.permission_grant import (
     GraphPermissionGrantRepository,
     SQLPermissionGrantRepository,
 )
+from grouper.repositories.schema import SchemaRepository
 from grouper.repositories.service_account import ServiceAccountRepository
 from grouper.repositories.transaction import TransactionRepository
 from grouper.repositories.user import UserRepository
@@ -95,6 +96,10 @@ class GraphRepositoryFactory(RepositoryFactory):
         # type: () -> ServiceAccountRepository
         return ServiceAccountRepository(self.session)
 
+    def create_schema_repository(self):
+        # type: () -> SchemaRepository
+        return SchemaRepository(self.settings)
+
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
         return TransactionRepository(self.session)
@@ -155,6 +160,10 @@ class SQLRepositoryFactory(RepositoryFactory):
     def create_permission_grant_repository(self):
         # type: () -> PermissionGrantRepository
         return SQLPermissionGrantRepository(self.session)
+
+    def create_schema_repository(self):
+        # type: () -> SchemaRepository
+        return SchemaRepository(self.settings)
 
     def create_service_account_repository(self):
         # type: () -> ServiceAccountRepository

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.repositories.checkpoint import CheckpointRepository
     from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.schema import SchemaRepository
     from grouper.repositories.service_account import ServiceAccountRepository
     from grouper.repositories.transaction import TransactionRepository
     from grouper.repositories.user import UserRepository
@@ -104,6 +105,11 @@ class RepositoryFactory(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def create_permission_grant_repository(self):
         # type: () -> PermissionGrantRepository
+        pass
+
+    @abstractmethod
+    def create_schema_repository(self):
+        # type: () -> SchemaRepository
         pass
 
     @abstractmethod

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -1,0 +1,56 @@
+"""Manage the database schema.
+
+SQLAlchemy schema operations through the ORM determine the list of tables through metaclasses when
+a class representing a database table is created.  This means that every underlying model must be
+imported when performing global schema operations, such as initializing or dropping the schema, so
+that SQLAlchemy will know what tables to create or delete.
+
+This class therefore imports *every* model to ensure SQLAlchemy has a complete view.  If any new
+models are added, be sure to also add them to the import list.
+"""
+
+from typing import TYPE_CHECKING
+
+from grouper.models.async_notification import AsyncNotification  # noqa: F401
+from grouper.models.audit import Audit  # noqa: F401
+from grouper.models.audit_log import AuditLog  # noqa: F401
+from grouper.models.audit_member import AuditMember  # noqa: F401
+from grouper.models.base.model_base import Model
+from grouper.models.base.session import get_db_engine
+from grouper.models.comment import Comment  # noqa: F401
+from grouper.models.counter import Counter  # noqa: F401
+from grouper.models.group import Group  # noqa: F401
+from grouper.models.group_edge import GroupEdge  # noqa: F401
+from grouper.models.group_service_accounts import GroupServiceAccount  # noqa: F401
+from grouper.models.perf_profile import PerfProfile  # noqa: F401
+from grouper.models.permission import Permission  # noqa: F401
+from grouper.models.permission_map import PermissionMap  # noqa: F401
+from grouper.models.permission_request import PermissionRequest  # noqa: F401
+from grouper.models.permission_request_status_change import (  # noqa: F401
+    PermissionRequestStatusChange,
+)
+from grouper.models.public_key import PublicKey  # noqa: F401
+from grouper.models.request import Request  # noqa: F401
+from grouper.models.request_status_change import RequestStatusChange  # noqa: F401
+from grouper.models.service_account import ServiceAccount  # noqa: F401
+from grouper.models.service_account_permission_map import ServiceAccountPermissionMap  # noqa: F401
+from grouper.models.user import User  # noqa: F401
+from grouper.models.user_metadata import UserMetadata  # noqa: F401
+from grouper.models.user_password import UserPassword  # noqa: F401
+from grouper.models.user_token import UserToken  # noqa: F401
+
+if TYPE_CHECKING:
+    from grouper.settings import Settings
+
+
+class SchemaRepository(object):
+    """Manipulate the database schema."""
+
+    def __init__(self, settings):
+        # type: (Settings) -> None
+        self.settings = settings
+
+    def initialize_schema(self):
+        # type: () -> None
+        db_engine = get_db_engine(self.settings.database_url)
+        Model.metadata.create_all(db_engine)

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -50,6 +50,12 @@ class SchemaRepository(object):
         # type: (Settings) -> None
         self.settings = settings
 
+    def drop_schema(self):
+        # type: () -> None
+        """Not exposed via a service, used primarily for tests."""
+        db_engine = get_db_engine(self.settings.database_url)
+        Model.metadata.drop_all(db_engine)
+
     def initialize_schema(self):
         # type: () -> None
         db_engine = get_db_engine(self.settings.database_url)

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from grouper.services.audit_log import AuditLogService
 from grouper.services.group_request import GroupRequestService
 from grouper.services.permission import PermissionService
+from grouper.services.schema import SchemaService
 from grouper.services.service_account import ServiceAccountService
 from grouper.services.transaction import TransactionService
 from grouper.services.user import UserService
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
         AuditLogInterface,
         GroupRequestInterface,
         PermissionInterface,
+        SchemaInterface,
         ServiceAccountInterface,
         TransactionInterface,
         UserInterface,
@@ -45,6 +47,11 @@ class ServiceFactory(object):
         return PermissionService(
             audit_log_service, permission_repository, permission_grant_repository
         )
+
+    def create_schema_service(self):
+        # type: () -> SchemaInterface
+        schema_repository = self.repository_factory.create_schema_repository()
+        return SchemaService(schema_repository)
 
     def create_service_account_service(self):
         # type: () -> ServiceAccountInterface

--- a/grouper/services/schema.py
+++ b/grouper/services/schema.py
@@ -1,0 +1,18 @@
+from typing import TYPE_CHECKING
+
+from grouper.usecases.interfaces import SchemaInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.schema import SchemaRepository
+
+
+class SchemaService(SchemaInterface):
+    """Manage the schema of the storage layer."""
+
+    def __init__(self, schema_repository):
+        # type: (SchemaRepository) -> None
+        self.schema_repository = schema_repository
+
+    def initialize_schema(self):
+        # type: () -> None
+        self.schema_repository.initialize_schema()

--- a/grouper/services/transaction.py
+++ b/grouper/services/transaction.py
@@ -1,11 +1,11 @@
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from grouper.repositories.transaction import TransactionRepository
 from grouper.usecases.interfaces import TransactionInterface
 
 if TYPE_CHECKING:
     from grouper.repositories.checkpoint import CheckpointRepository
+    from grouper.repositories.transaction import TransactionRepository
     from typing import Iterator
 
 

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
+from grouper.usecases.initialize_schema import InitializeSchema
 from grouper.usecases.list_permissions import ListPermissions
 from grouper.usecases.view_permission import ViewPermission
 
@@ -47,6 +48,11 @@ class UseCaseFactory(object):
         permission_service = self.service_factory.create_permission_service()
         user_service = self.service_factory.create_user_service()
         return ListPermissions(ui, permission_service, user_service)
+
+    def create_initialize_schema_usecase(self):
+        # type: () -> InitializeSchema
+        schema_service = self.service_factory.create_schema_service()
+        return InitializeSchema(schema_service)
 
     def create_view_permission_usecase(self, ui):
         # type: (ViewPermissionUI) -> ViewPermission

--- a/grouper/usecases/initialize_schema.py
+++ b/grouper/usecases/initialize_schema.py
@@ -1,0 +1,16 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from grouper.usecases.interfaces import SchemaInterface
+
+
+class InitializeSchema(object):
+    """Initialize the schema for a fresh database."""
+
+    def __init__(self, schema_service):
+        # type: (SchemaInterface) -> None
+        self.schema_service = schema_service
+
+    def initialize_schema(self):
+        # type: () -> None
+        self.schema_service.initialize_schema()

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -124,6 +124,15 @@ class PermissionInterface(with_metaclass(ABCMeta, object)):
         pass
 
 
+class SchemaInterface(with_metaclass(ABCMeta, object)):
+    """Abstract base class for low-level schema manipulation."""
+
+    @abstractmethod
+    def initialize_schema(self):
+        # type: () -> None
+        pass
+
+
 class ServiceAccountInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for service account operations and queries."""
 

--- a/tests/ctl/group_test.py
+++ b/tests/ctl/group_test.py
@@ -13,7 +13,7 @@ from tests.fixtures import graph, groups, permissions, session, standard_graph, 
 
 
 @patch("grouper.ctl.group.make_session")
-def test_group_add_remove_member(make_session, session, users, groups):  # noqa: F811
+def test_group_add_remove_member(make_session, session, tmpdir, users, groups):  # noqa: F811
     make_session.return_value = session
 
     username = "oliver@a.co"
@@ -21,21 +21,21 @@ def test_group_add_remove_member(make_session, session, users, groups):  # noqa:
 
     # add
     assert (u"User", username) not in groups[groupname].my_members()
-    call_main(session, "group", "add_member", "--member", groupname, username)
+    call_main(session, tmpdir, "group", "add_member", "--member", groupname, username)
     all_members = Group.get(session, name=groupname).my_members()
     assert (u"User", username) in all_members
     _, _, _, role, _, _ = all_members[(u"User", username)]
     assert GROUP_EDGE_ROLES[role] == "member"
 
     # remove
-    call_main(session, "group", "remove_member", groupname, username)
+    call_main(session, tmpdir, "group", "remove_member", groupname, username)
     assert (u"User", username) not in Group.get(session, name=groupname).my_members()
 
 
 @patch("grouper.group_member.get_plugin_proxy")
 @patch("grouper.ctl.group.make_session")
 def test_group_add_remove_owner(
-    make_session, get_plugin_proxy, session, users, groups  # noqa: F811
+    make_session, get_plugin_proxy, session, tmpdir, users, groups  # noqa: F811
 ):
     make_session.return_value = session
     get_plugin_proxy.return_value = PluginProxy([GroupOwnershipPolicyPlugin()])
@@ -45,53 +45,53 @@ def test_group_add_remove_owner(
 
     # add
     assert (u"User", username) not in groups[groupname].my_members()
-    call_main(session, "group", "add_member", "--owner", groupname, username)
+    call_main(session, tmpdir, "group", "add_member", "--owner", groupname, username)
     all_members = Group.get(session, name=groupname).my_members()
     assert (u"User", username) in all_members
     _, _, _, role, _, _ = all_members[(u"User", username)]
     assert GROUP_EDGE_ROLES[role] == "owner"
 
     # remove (fails)
-    call_main(session, "group", "remove_member", groupname, username)
+    call_main(session, tmpdir, "group", "remove_member", groupname, username)
     assert (u"User", username) in Group.get(session, name=groupname).my_members()
 
 
 @patch("grouper.ctl.group.make_session")
-def test_group_bulk_add_remove(make_session, session, users, groups):  # noqa: F811
+def test_group_bulk_add_remove(make_session, session, tmpdir, users, groups):  # noqa: F811
     make_session.return_value = session
 
     groupname = "team-sre"
 
     # bulk add
     usernames = {"oliver@a.co", "testuser@a.co", "zebu@a.co"}
-    call_main(session, "group", "add_member", "--member", groupname, *usernames)
+    call_main(session, tmpdir, "group", "add_member", "--member", groupname, *usernames)
     members = {u for _, u in Group.get(session, name=groupname).my_members()}
     assert usernames.issubset(members)
 
     # bulk remove
-    call_main(session, "group", "remove_member", groupname, *usernames)
+    call_main(session, tmpdir, "group", "remove_member", groupname, *usernames)
     members = {u for _, u in Group.get(session, name=groupname).my_members()}
     assert not members.intersection(usernames)
 
 
 @patch("grouper.ctl.group.make_session")
-def test_group_name_checks(make_session, session, users, groups):  # noqa: F811
+def test_group_name_checks(make_session, session, tmpdir, users, groups):  # noqa: F811
     make_session.return_value = session
 
     username = "oliver@a.co"
     groupname = "team-sre"
 
     # check user/group name
-    call_main(session, "group", "add_member", "--member", "invalid group name", username)
+    call_main(session, tmpdir, "group", "add_member", "--member", "invalid group name", username)
     assert (u"User", username) not in Group.get(session, name=groupname).my_members()
 
     bad_username = "not_a_valid_username"
-    call_main(session, "group", "add_member", "--member", groupname, bad_username)
+    call_main(session, tmpdir, "group", "add_member", "--member", groupname, bad_username)
     assert (u"User", bad_username) not in Group.get(session, name=groupname).my_members()
 
 
 @patch("grouper.ctl.group.make_session")
-def test_group_logdump(make_session, session, users, groups, tmpdir):  # noqa: F811
+def test_group_logdump(make_session, session, tmpdir, users, groups):  # noqa: F811
     make_session.return_value = session
 
     groupname = "team-sre"
@@ -100,7 +100,9 @@ def test_group_logdump(make_session, session, users, groups, tmpdir):  # noqa: F
     yesterday = date.today() - timedelta(days=1)
     fn = tmpdir.join("out.csv").strpath
 
-    call_main(session, "group", "log_dump", groupname, yesterday.isoformat(), "--outfile", fn)
+    call_main(
+        session, tmpdir, "group", "log_dump", groupname, yesterday.isoformat(), "--outfile", fn
+    )
     with open(fn, "r") as fh:
         out = fh.read()
 
@@ -111,7 +113,9 @@ def test_group_logdump(make_session, session, users, groups, tmpdir):  # noqa: F
     )
     session.commit()
 
-    call_main(session, "group", "log_dump", groupname, yesterday.isoformat(), "--outfile", fn)
+    call_main(
+        session, tmpdir, "group", "log_dump", groupname, yesterday.isoformat(), "--outfile", fn
+    )
     with open(fn, "r") as fh:
         entries = [x for x in csv.reader(fh)]
 

--- a/tests/ctl/misc_test.py
+++ b/tests/ctl/misc_test.py
@@ -1,8 +1,6 @@
 import pytest
 from mock import patch
 
-from grouper.constants import GROUP_ADMIN, PERMISSION_ADMIN, PERMISSION_AUDITOR, USER_ADMIN
-from grouper.models.base.model_base import Model
 from grouper.models.group import Group
 from grouper.models.user import User
 from grouper.public_key import get_public_keys_of_user
@@ -16,27 +14,27 @@ def noop(*k):
 
 
 @patch("grouper.ctl.user.make_session")
-def test_user_create(make_session, session, users):  # noqa: F811
+def test_user_create(make_session, session, tmpdir, users):  # noqa: F811
     make_session.return_value = session
 
     # simple
     username = "john@a.co"
-    call_main(session, "user", "create", username)
+    call_main(session, tmpdir, "user", "create", username)
     assert User.get(session, name=username), "non-existent user should be created"
 
     # check username
     bad_username = "not_a_valid_username"
-    call_main(session, "user", "create", bad_username)
+    call_main(session, tmpdir, "user", "create", bad_username)
     assert not User.get(session, name=bad_username), "bad user should not be created"
 
     # bulk
     usernames = ["mary@a.co", "sam@a.co", "tina@a.co"]
-    call_main(session, "user", "create", *usernames)
+    call_main(session, tmpdir, "user", "create", *usernames)
     users = [User.get(session, name=u) for u in usernames]
     assert all(users), "all users created"
 
     usernames_with_one_bad = ["kelly@a.co", "brad@a.co", "not_valid_user"]
-    call_main(session, "user", "create", *usernames_with_one_bad)
+    call_main(session, tmpdir, "user", "create", *usernames_with_one_bad)
     users = [User.get(session, name=u) for u in usernames_with_one_bad]
     assert not any(users), "one bad seed means no users created"
 
@@ -44,7 +42,7 @@ def test_user_create(make_session, session, users):  # noqa: F811
 @patch("grouper.ctl.user.make_session")
 @patch("grouper.ctl.group.make_session")
 def test_user_status_changes(
-    make_user_session, make_group_session, session, users, groups  # noqa: F811
+    make_user_session, make_group_session, session, tmpdir, users, groups  # noqa: F811
 ):
     make_user_session.return_value = session
     make_group_session.return_value = session
@@ -53,39 +51,39 @@ def test_user_status_changes(
     groupname = "team-sre"
 
     # add user to a group
-    call_main(session, "group", "add_member", "--member", groupname, username)
+    call_main(session, tmpdir, "group", "add_member", "--member", groupname, username)
 
     # disable the account
-    call_main(session, "user", "disable", username)
+    call_main(session, tmpdir, "user", "disable", username)
     assert not User.get(session, name=username).enabled
 
     # double disabling is a no-op
-    call_main(session, "user", "disable", username)
+    call_main(session, tmpdir, "user", "disable", username)
     assert not User.get(session, name=username).enabled
 
     # re-enable the account, preserving memberships
-    call_main(session, "user", "enable", "--preserve-membership", username)
+    call_main(session, tmpdir, "user", "enable", "--preserve-membership", username)
     assert User.get(session, name=username).enabled
     assert (u"User", username) in groups[groupname].my_members()
 
     # enabling an active account is a no-op
-    call_main(session, "user", "enable", username)
+    call_main(session, tmpdir, "user", "enable", username)
     assert User.get(session, name=username).enabled
 
     # disable and re-enable without the --preserve-membership flag
-    call_main(session, "user", "disable", username)
-    call_main(session, "user", "enable", username)
+    call_main(session, tmpdir, "user", "disable", username)
+    call_main(session, tmpdir, "user", "enable", username)
     assert User.get(session, name=username).enabled
     assert (u"User", username) not in groups[groupname].my_members()
 
 
 @patch("grouper.ctl.user.make_session")
-def test_user_public_key(make_session, session, users):  # noqa: F811
+def test_user_public_key(make_session, session, tmpdir, users):  # noqa: F811
     make_session.return_value = session
 
     # good key
     username = "zorkian@a.co"
-    call_main(session, "user", "add_public_key", username, SSH_KEY_1)
+    call_main(session, tmpdir, "user", "add_public_key", username, SSH_KEY_1)
 
     user = User.get(session, name=username)
     keys = get_public_keys_of_user(session, user.id)
@@ -93,53 +91,23 @@ def test_user_public_key(make_session, session, users):  # noqa: F811
     assert keys[0].public_key == SSH_KEY_1
 
     # duplicate key
-    call_main(session, "user", "add_public_key", username, SSH_KEY_1)
+    call_main(session, tmpdir, "user", "add_public_key", username, SSH_KEY_1)
 
     keys = get_public_keys_of_user(session, user.id)
     assert len(keys) == 1
     assert keys[0].public_key == SSH_KEY_1
 
     # bad key
-    call_main(session, "user", "add_public_key", username, SSH_KEY_BAD)
+    call_main(session, tmpdir, "user", "add_public_key", username, SSH_KEY_BAD)
 
     keys = get_public_keys_of_user(session, user.id)
     assert len(keys) == 1
     assert keys[0].public_key == SSH_KEY_1
 
 
-@patch("grouper.ctl.sync_db.make_session")
-@patch("grouper.ctl.sync_db.get_auditors_group_name", return_value="my-auditors")
-@patch("grouper.ctl.sync_db.get_db_engine", new=noop)
-@patch.object(Model.metadata, "create_all", new=noop)
-def test_sync_db_default_group(
-    mock_get_auditors_group_name, make_session, session, users, groups  # noqa: F811
-):
-    make_session.return_value = session
-
-    auditors_group = Group.get(session, name="my-auditors")
-    assert not auditors_group, "Auditors group should not exist yet"
-
-    call_main(session, "sync_db")
-    admin_group = Group.get(session, name="grouper-administrators")
-    assert admin_group, "Group should have been autocreated"
-
-    admin_group_permission_names = [perm[1] for perm in admin_group.my_permissions()]
-    for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-        assert permission in admin_group_permission_names, (
-            "Expected permission missing: %s" % permission
-        )
-
-    auditors_group = Group.get(session, name="my-auditors")
-    assert auditors_group, "Auditors group should have been autocreated"
-    auditors_group_permission_names = [perm[1] for perm in auditors_group.my_permissions()]
-    assert PERMISSION_AUDITOR in auditors_group_permission_names, (
-        "Expected permission missing: %s" % PERMISSION_AUDITOR
-    )
-
-
 @patch("grouper.ctl.oneoff.load_plugins")
 @patch("grouper.ctl.oneoff.make_session")
-def test_oneoff(mock_make_session, mock_load_plugins, session):  # noqa: F811
+def test_oneoff(mock_make_session, mock_load_plugins, session, tmpdir):  # noqa: F811
     mock_make_session.return_value = session
     username = "fake_user@a.co"
     other_username = "fake_user2@a.co"
@@ -163,26 +131,26 @@ def test_oneoff(mock_make_session, mock_load_plugins, session):  # noqa: F811
     mock_load_plugins.return_value = [FakeOneOff()]
 
     # dry_run
-    call_main(session, "oneoff", "run", "FakeOneOff")
+    call_main(session, tmpdir, "oneoff", "run", "FakeOneOff")
     assert User.get(session, name=username) is None, "default dry_run means no writes"
     assert User.get(session, name=other_username) is None, '"valuewith= not in arg'
     assert Group.get(session, name=groupname) is None, '"group" not in arg so no group created'
 
     # not dry_run, create a user
-    call_main(session, "oneoff", "run", "--no-dry_run", "FakeOneOff")
+    call_main(session, tmpdir, "oneoff", "run", "--no-dry_run", "FakeOneOff")
     assert User.get(session, name=username) is not None, "dry_run off means writes"
     assert User.get(session, name=other_username) is None, '"valuewith= not in arg'
     assert Group.get(session, name=groupname) is None, '"group" not in arg so no group created'
 
     # not dry_run, use kwarg to create a group
-    call_main(session, "oneoff", "run", "--no-dry_run", "FakeOneOff", "group=1")
+    call_main(session, tmpdir, "oneoff", "run", "--no-dry_run", "FakeOneOff", "group=1")
     assert User.get(session, name=username) is not None, "dry_run off means writes"
     assert User.get(session, name=other_username) is None, '"valuewith= not in arg'
     assert Group.get(session, name=groupname) is not None, '"group" in arg so group created'
 
     # invalid format for argument should result in premature system exit
     with pytest.raises(SystemExit):
-        call_main(session, "oneoff", "run", "--no-dry_run", "FakeOneOff", "bad_arg")
+        call_main(session, tmpdir, "oneoff", "run", "--no-dry_run", "FakeOneOff", "bad_arg")
 
-    call_main(session, "oneoff", "run", "--no-dry_run", "FakeOneOff", "key=valuewith=")
+    call_main(session, tmpdir, "oneoff", "run", "--no-dry_run", "FakeOneOff", "key=valuewith=")
     assert User.get(session, name=other_username) is not None, '"valuewith= in arg, create user2'

--- a/tests/ctl/service_account_test.py
+++ b/tests/ctl/service_account_test.py
@@ -16,7 +16,7 @@ from tests.fixtures import (  # noqa: F401
 
 @patch("grouper.ctl.service_account.make_session")
 def test_service_account_create(
-    make_session, groups, service_accounts, session, users  # noqa: F811
+    make_session, groups, service_accounts, session, tmpdir, users  # noqa: F811
 ):
     make_session.return_value = session
 
@@ -31,6 +31,7 @@ def test_service_account_create(
     # no-op if non-existing actor
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         "no-such-actor@a.co",
@@ -43,6 +44,7 @@ def test_service_account_create(
     # ... or if bad account name
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         good_actor_username,
@@ -55,6 +57,7 @@ def test_service_account_create(
     # ... or non-existing owner group
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         good_actor_username,
@@ -71,6 +74,7 @@ def test_service_account_create(
     # now it works
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         good_actor_username,
@@ -90,6 +94,7 @@ def test_service_account_create(
     # no-op if account name already exists
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         good_actor_username,
@@ -109,6 +114,7 @@ def test_service_account_create(
     # actor can be a service account as well
     call_main(
         session,
+        tmpdir,
         "service_account",
         "--actor",
         "service@a.co",

--- a/tests/ctl/sync_db_test.py
+++ b/tests/ctl/sync_db_test.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import (
+    GROUP_ADMIN,
+    PERMISSION_ADMIN,
+    PERMISSION_AUDITOR,
+    SYSTEM_PERMISSIONS,
+    USER_ADMIN,
+)
+from grouper.models.group import Group
+from grouper.settings import Settings
+from tests.ctl_util import run_ctl
+from tests.path_util import src_path
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_sync_db(setup):
+    # type: (SetupTest) -> None
+    run_ctl(setup, "sync_db")
+
+    # System permissions should be created.
+    permission_service = setup.service_factory.create_permission_service()
+    for permission, _ in SYSTEM_PERMISSIONS:
+        assert permission_service.permission_exists(permission)
+
+    # The admin group should exist and have a selection of administrative permissions.
+    admin_group = Group.get(setup.session, name="grouper-administrators")
+    assert admin_group
+    admin_group_permissions = [p.name for p in admin_group.my_permissions()]
+    for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
+        assert permission in admin_group_permissions
+
+    # We reuse config/dev.yaml when testing, but someone may have changed the auditors_group
+    # setting there.  Figure out the current setting.
+    dev_settings = Settings()
+    dev_settings.update_from_config(src_path("config", "dev.yaml"))
+
+    # The auditors group should exist and have the auditor permission.
+    if dev_settings.auditors_group:
+        auditors_group = Group.get(setup.session, name=dev_settings.auditors_group)
+        assert auditors_group
+        auditors_group_permissions = [p.name for p in auditors_group.my_permissions()]
+        assert PERMISSION_AUDITOR in auditors_group_permissions

--- a/tests/ctl/user_test.py
+++ b/tests/ctl/user_test.py
@@ -11,7 +11,13 @@ from tests.fixtures import graph, groups, permissions, session, standard_graph, 
 @patch("grouper.ctl.group.make_session")
 @patch("grouper.ctl.user.make_session")
 def test_group_disable_group_owner(
-    user_make_session, group_make_session, get_plugin_proxy, session, users, groups  # noqa: F811
+    user_make_session,
+    group_make_session,
+    get_plugin_proxy,
+    session,  # noqa: F811
+    tmpdir,
+    users,  # noqa: F811
+    groups,  # noqa: F811
 ):
     group_make_session.return_value = session
     user_make_session.return_value = session
@@ -21,9 +27,9 @@ def test_group_disable_group_owner(
     groupname = "team-sre"
 
     # add
-    call_main(session, "group", "add_member", "--owner", groupname, username)
+    call_main(session, tmpdir, "group", "add_member", "--owner", groupname, username)
     assert (u"User", username) in Group.get(session, name=groupname).my_members()
 
     # disable (fails)
-    call_main(session, "user", "disable", username)
+    call_main(session, tmpdir, "user", "disable", username)
     assert (u"User", username) in Group.get(session, name=groupname).my_members()

--- a/tests/ctl_util.py
+++ b/tests/ctl_util.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 def call_main(session, tmpdir, *args):
     # type: (Session, LocalPath, *str) -> None
+    """Legacy test driver, use run_ctl instead for all new code."""
     argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml"), "-d", db_url(tmpdir)] + list(args)
     main(sys_argv=argv, session=session)
 

--- a/tests/ctl_util.py
+++ b/tests/ctl_util.py
@@ -1,20 +1,27 @@
 from typing import TYPE_CHECKING
 
 from grouper.ctl.main import main
-from tests.path_util import src_path
+from tests.path_util import db_url, src_path
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from py.path import LocalPath
     from tests.setup import SetupTest
 
 
-def call_main(session, *args):
-    # type: (Session, *str) -> None
-    argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml")] + list(args)
+def call_main(session, tmpdir, *args):
+    # type: (Session, LocalPath, *str) -> None
+    argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml"), "-d", db_url(tmpdir)] + list(args)
     main(sys_argv=argv, session=session)
 
 
 def run_ctl(setup, *args):
     # type: (SetupTest, *str) -> None
-    argv = ["grouper-ctl", "-c", src_path("config", "dev.yaml")] + list(args)
+    argv = [
+        "grouper-ctl",
+        "-c",
+        src_path("config", "dev.yaml"),
+        "-d",
+        setup.settings.database,
+    ] + list(args)
     main(sys_argv=argv, session=setup.session)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -39,6 +39,7 @@ from grouper.models.service_account_permission_map import ServiceAccountPermissi
 from grouper.models.user import User
 from grouper.plugin import initialize_plugins
 from grouper.repositories.factory import GraphRepositoryFactory
+from grouper.repositories.schema import SchemaRepository
 from grouper.services.factory import ServiceFactory
 from grouper.settings import Settings
 from grouper.usecases.factory import UseCaseFactory
@@ -86,13 +87,11 @@ class SetupTest(object):
         if "MEROU_TEST_DATABASE" in os.environ:
             Model.metadata.drop_all(db_engine)
 
-        # TODO(rra): Temporary hack to ensure models used by tests are imported and therefore
-        # created.  Will be replaced with a proper repository.
-        from grouper.models.permission_request import PermissionRequest  # noqa: F401
-        from grouper.models.user_token import UserToken  # noqa: F401
+        # Create the database schema.
+        schema_repository = SchemaRepository(self.settings)
+        schema_repository.initialize_schema()
 
-        # Create the database schema and the corresponding session.
-        Model.metadata.create_all(db_engine)
+        # Configure and create the session.
         Session.configure(bind=db_engine)
         return Session()
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING
 
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
-from grouper.models.base.model_base import Model
 from grouper.models.base.session import get_db_engine, Session
 from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
@@ -79,16 +78,16 @@ class SetupTest(object):
     def create_session(self):
         # type: () -> Session
         db_engine = get_db_engine(self.settings.database_url)
+        schema_repository = SchemaRepository(self.settings)
 
         # Reinitialize plugins in case a previous test configured some.
         initialize_plugins([], [], "tests")
 
         # If using a persistent database, clear the database first.
         if "MEROU_TEST_DATABASE" in os.environ:
-            Model.metadata.drop_all(db_engine)
+            schema_repository.drop_schema()
 
         # Create the database schema.
-        schema_repository = SchemaRepository(self.settings)
         schema_repository.initialize_schema()
 
         # Configure and create the session.


### PR DESCRIPTION
Move initialization of the schema into a usecase, and rework the
sync_db grouper-ctl command as a new-style CtlCommand.  Not all of
its functions have moved to usecases yet, but it's a start.

This uncovered a problem with grouper-ctl testing: we were passing
in the config/dev.yaml configuration file, but it uses a different
database URL than tests.  Fix this by adding a -d flag to
grouper-ctl to specify a database URL, consistent with the API
and frontend servers, and have the test suite pass that in to
override the database URL.  This required adding a new parameter
to the legacy run_main test method.

Reorganize the test suite to separate sync_db into its own test and
test more of its functionality.