### PR TITLE
Further simplify database URL handling

### DIFF
--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -58,7 +58,7 @@ def start_server(args, settings, sentry_client):
     logging.debug("configure database session")
     if args.database_url:
         settings.database = args.database_url
-    Session.configure(bind=get_db_engine(settings.database_url))
+    Session.configure(bind=get_db_engine(settings.database))
 
     with closing(Session()) as session:
         graph = Graph()

--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -128,10 +128,10 @@ class BackgroundProcessor(object):
 
     def run(self):
         # type: () -> None
-        initial_url = self.settings.database_url
+        initial_url = self.settings.database
         while True:
             try:
-                if self.settings.database_url != initial_url:
+                if self.settings.database != initial_url:
                     self.crash()
                 with closing(Session()) as session:
                     self.logger.info("Expiring edges....")

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -57,7 +57,7 @@ def start_processor(args, settings, sentry_client):
 
     # setup database
     logging.debug("configure database session")
-    Session.configure(bind=get_db_engine(settings.database_url))
+    Session.configure(bind=get_db_engine(settings.database))
 
     background = BackgroundProcessor(settings, sentry_client)
     background.run()

--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def dump_sql_command(args, settings, session_factory):
     # type: (Namespace, CtlSettings, SessionFactory) -> None
-    db_engine = get_db_engine(settings.database_url)
+    db_engine = get_db_engine(settings.database)
     for table in Model.metadata.sorted_tables:
         print(CreateTable(table).compile(db_engine))
         for index in table.indexes:

--- a/grouper/database.py
+++ b/grouper/database.py
@@ -38,11 +38,11 @@ class DbRefreshThread(Thread):
 
     def run(self):
         # type () -> None
-        initial_url = self.settings.database_url
+        initial_url = self.settings.database
         while True:
             self.logger.debug("Updating Graph from Database.")
             try:
-                if self.settings.database_url != initial_url:
+                if self.settings.database != initial_url:
                     self.crash()
                 with closing(Session()) as session:
                     self.graph.update_from_db(session)

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -73,7 +73,7 @@ def start_server(args, settings, sentry_client):
     logging.debug("configure database session")
     if args.database_url:
         settings.database = args.database_url
-    Session.configure(bind=get_db_engine(settings.database_url))
+    Session.configure(bind=get_db_engine(settings.database))
 
     application = create_fe_application(settings, args.deployment_name)
 

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -41,7 +41,7 @@ def print_date(date):
         return ""
     if date.tzinfo is None:
         date = date.replace(tzinfo=UTC)
-    date = date.astimezone(settings().timezone_object)
+    date = date.astimezone(settings().timezone)
     return date.strftime(settings().date_format)
 
 

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -156,7 +156,7 @@ class GrouperHandler(RequestHandler):
         except sqlalchemy.exc.OperationalError:
             # Failed to connect to database or create user, try to reconfigure the db. This invokes
             # the fetcher to try to see if our URL string has changed.
-            Session.configure(bind=get_db_engine(settings().database_url))
+            Session.configure(bind=get_db_engine(settings().database))
             raise DatabaseFailure()
 
         # service accounts are, by definition, not interactive users

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -43,7 +43,7 @@ class SessionFactory(object):
 
     def create_session(self):
         # type: () -> Session
-        db_engine = get_db_engine(self.settings.database_url)
+        db_engine = get_db_engine(self.settings.database)
         Session.configure(bind=db_engine)
         return Session()
 

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -53,10 +53,10 @@ class SchemaRepository(object):
     def drop_schema(self):
         # type: () -> None
         """Not exposed via a service, used primarily for tests."""
-        db_engine = get_db_engine(self.settings.database_url)
+        db_engine = get_db_engine(self.settings.database)
         Model.metadata.drop_all(db_engine)
 
     def initialize_schema(self):
         # type: () -> None
-        db_engine = get_db_engine(self.settings.database_url)
+        db_engine = get_db_engine(self.settings.database)
         Model.metadata.create_all(db_engine)

--- a/tests/fe/util_test.py
+++ b/tests/fe/util_test.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import pytz
 from pytz import UTC
 
 from grouper.fe.template_util import expires_when_str, long_ago_str, print_date
@@ -49,7 +48,6 @@ def test_print_date():
     settings = Settings()
     settings.date_format = "%Y-%m-%d %I:%M %p"
     settings.timezone = "US/Pacific"
-    settings._timezone_object = pytz.timezone("US/Pacific")
     set_global_settings(settings)
 
     for date_, expected, msg in [

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -24,15 +24,22 @@ CONFIG_BOGUS = """
 common:
     _logger: bar
     foo: bar
-    timezone_object: UTC
-    database_url: blah
 """
+
+
+def test_timezone():
+    # type: () -> None
+    settings = Settings()
+
+    # mypy 0.700 thinks setting timezone to a str is a type mismatch because it doesn't understand
+    # the type magic, so work around the type error by using setattr.
+    setattr(settings, "timezone", "US/Eastern")
+    assert settings.timezone == pytz.timezone("US/Eastern")
 
 
 def test_update_from_config(tmpdir):
     # type: (LocalPath) -> None
     settings = Settings()
-    assert not settings.database
 
     # Create a config file that sets database to different values in different sections.
     config_path = str(tmpdir.join("test.yaml"))
@@ -45,12 +52,12 @@ def test_update_from_config(tmpdir):
     settings.update_from_config(config_path, section="other")
     assert settings.database == "bar"
 
-    # The special timezone_object attribute should be initialized and kept in sync.
-    assert settings.timezone_object == pytz.timezone("UTC")
+    # The timezone attribute is special and should be converted to a timezone on setting.
+    assert settings.timezone == pytz.timezone("UTC")
     with open(config_path, "w") as config:
         config.write("common:\n  timezone: US/Pacific\n")
     settings.update_from_config(config_path)
-    assert settings.timezone_object == pytz.timezone("US/Pacific")
+    assert settings.timezone == pytz.timezone("US/Pacific")
 
     # Create a config file that tries to set unknown or internal attributes.
     with open(config_path, "w") as config:
@@ -58,30 +65,35 @@ def test_update_from_config(tmpdir):
     settings.update_from_config(config_path)
     assert settings._logger != "bar"
     assert not hasattr(settings, "foo")
-    assert settings.timezone_object == pytz.timezone("US/Pacific")
-    assert settings.database_url == "bar"
+
+    # A configuration that doesn't set database or database_source should raise an exception.
+    settings = Settings()
+    with open(config_path, "w") as config:
+        config.write("common:\n  auditors_group: some-group\n")
+    with pytest.raises(InvalidSettingsError):
+        settings.update_from_config(config_path)
 
 
-def test_database_url():
+def test_database():
     # type: () -> None
     settings = Settings()
 
     # The default is uninitialized and should throw an error until we load a configuration.
     with pytest.raises(InvalidSettingsError):
-        assert settings.database_url
+        assert settings.database
 
     # If database is set, it should be used.
     settings.database = "sqlite:///grouper.sqlite"
-    assert settings.database_url == "sqlite:///grouper.sqlite"
+    assert settings.database == "sqlite:///grouper.sqlite"
     settings.database_source = "/bin/false"
-    assert settings.database_url == "sqlite:///grouper.sqlite"
+    assert settings.database == "sqlite:///grouper.sqlite"
 
     # If only database_source is set, it should be run to get a URL.
     settings.database = ""
     settings.database_source = "/path/to/program"
     with patch("subprocess.check_output") as mock_subprocess:
         mock_subprocess.return_value = "sqlite:///other.sqlite\n"
-        assert settings.database_url == "sqlite:///other.sqlite"
+        assert settings.database == "sqlite:///other.sqlite"
         assert mock_subprocess.call_args_list == [
             call(["/path/to/program"], stderr=subprocess.STDOUT)
         ]
@@ -93,7 +105,7 @@ def test_database_url():
         with patch("subprocess.check_output") as mock_subprocess:
             exception = subprocess.CalledProcessError(1, "/path/to/program")
             mock_subprocess.side_effect = [exception, "sqlite:///third.sqlite"]
-            assert settings.database_url == "sqlite:///third.sqlite"
+            assert settings.database == "sqlite:///third.sqlite"
             assert mock_subprocess.call_count == 2
 
     # Commands that return an empty URL should also be retried.
@@ -102,7 +114,7 @@ def test_database_url():
     with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
         with patch("subprocess.check_output") as mock_subprocess:
             mock_subprocess.side_effect = ["", "sqlite:///notempty.sqlite"]
-            assert settings.database_url == "sqlite:///notempty.sqlite"
+            assert settings.database == "sqlite:///notempty.sqlite"
             assert mock_subprocess.call_count == 2
 
     # Too many retries should raise an exception.
@@ -112,4 +124,4 @@ def test_database_url():
         with patch("subprocess.check_output") as mock_subprocess:
             mock_subprocess.return_value = ""
             with pytest.raises(DatabaseSourceException):
-                assert settings.database_url
+                assert settings.database

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -77,6 +77,11 @@ class SetupTest(object):
 
         self.initialize_database()
 
+        # Reinitialize the global plugin proxy with an empty set of plugins in case a previous test
+        # initialized plugins.  This can go away once a plugin proxy is injected into everything
+        # that needs it instead of maintained as a global.
+        set_global_plugin_proxy(PluginProxy([]))
+
         self.session = SessionFactory(self.settings).create_session()
         self.graph = GroupGraph()
         self.repository_factory = GraphRepositoryFactory(
@@ -89,11 +94,6 @@ class SetupTest(object):
     def initialize_database(self):
         # type: () -> Session
         schema_repository = SchemaRepository(self.settings)
-
-        # Reinitialize the global plugin proxy with an empty set of plugins in case a previous test
-        # initialized plugins.  This can go away once a plugin proxy is injected into everything
-        # that needs it instead of maintained as a global.
-        set_global_plugin_proxy(PluginProxy([]))
 
         # If using a persistent database, clear the database first.
         if "MEROU_TEST_DATABASE" in os.environ:


### PR DESCRIPTION
The database URL code was still making the problem too complicated
given that we decided to always run the database_source command.
Simplify further to not cache the results and just run the command
directly and return its stripped output.

Use properties and setters to further streamline the code and make
assigning directly to the timezone attribute work properly.  This
allows us to get rid of the special timezone_object and database_url
attributes and have all code use timezone and database, further
hiding the behind-the-scenes magic.