### PR TITLE
Start injecting PluginProxy where needed

### DIFF
--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -17,8 +17,9 @@ from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.graph import Graph
 from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
-from grouper.plugin import initialize_plugins
+from grouper.plugin import set_global_plugin_proxy
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+from grouper.plugin.proxy import PluginProxy
 from grouper.setup import build_arg_parser, setup_logging
 
 if TYPE_CHECKING:
@@ -47,7 +48,8 @@ def start_server(args, settings, sentry_client):
     ), "debug mode does not support multiple processes"
 
     try:
-        initialize_plugins(settings.plugin_dirs, settings.plugin_module_paths, "grouper_api")
+        plugins = PluginProxy.load_plugins(settings, "grouper-api")
+        set_global_plugin_proxy(plugins)
     except PluginsDirectoryDoesNotExist as e:
         logging.fatal("Plugin directory does not exist: {}".format(e))
         sys.exit(1)
@@ -66,7 +68,7 @@ def start_server(args, settings, sentry_client):
     refresher.daemon = True
     refresher.start()
 
-    usecase_factory = create_graph_usecase_factory(settings, graph=graph)
+    usecase_factory = create_graph_usecase_factory(settings, plugins, graph=graph)
     application = create_api_application(graph, settings, usecase_factory)
 
     address = args.address or settings.address

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -8,8 +8,9 @@ from grouper.background.background_processor import BackgroundProcessor
 from grouper.background.settings import BackgroundSettings
 from grouper.error_reporting import get_sentry_client, setup_signal_handlers
 from grouper.models.base.session import get_db_engine, Session
-from grouper.plugin import initialize_plugins
+from grouper.plugin import set_global_plugin_proxy
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+from grouper.plugin.proxy import PluginProxy
 from grouper.settings import default_settings_path
 from grouper.setup import setup_logging
 
@@ -48,9 +49,8 @@ def start_processor(args, settings, sentry_client):
     logging.info("begin. log_level={}".format(log_level))
 
     try:
-        initialize_plugins(
-            settings.plugin_dirs, settings.plugin_module_paths, "grouper-background"
-        )
+        plugins = PluginProxy.load_plugins(settings, "grouper-background")
+        set_global_plugin_proxy(plugins)
     except PluginsDirectoryDoesNotExist as e:
         logging.fatal("Plugin directory does not exist: {}".format(e))
         sys.exit(1)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -8,8 +8,9 @@ from grouper.ctl import dump_sql, group, oneoff, service_account, shell, sync_db
 from grouper.ctl.factory import CtlCommandFactory
 from grouper.ctl.settings import CtlSettings
 from grouper.initialization import create_sql_usecase_factory
-from grouper.plugin import initialize_plugins
+from grouper.plugin import set_global_plugin_proxy
 from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+from grouper.plugin.proxy import PluginProxy
 from grouper.settings import default_settings_path
 from grouper.util import get_loglevel
 
@@ -59,16 +60,19 @@ def main(sys_argv=sys.argv, session=None):
     log_level = get_loglevel(args, base=logging.INFO)
     logging.basicConfig(level=log_level, format=settings.log_format)
 
-    try:
-        initialize_plugins(settings.plugin_dirs, settings.plugin_module_paths, "grouper-ctl")
-    except PluginsDirectoryDoesNotExist as e:
-        logging.fatal("Plugin directory does not exist: {}".format(e))
-        sys.exit(1)
-
     if log_level < 0:
         sa_log.setLevel(logging.INFO)
 
-    usecase_factory = create_sql_usecase_factory(settings, session)
+    # Initialize plugins.  The global plugin proxy is used by legacy code.
+    try:
+        plugins = PluginProxy.load_plugins(settings, "grouper-ctl")
+    except PluginsDirectoryDoesNotExist as e:
+        logging.fatal("Plugin directory does not exist: {}".format(e))
+        sys.exit(1)
+    set_global_plugin_proxy(plugins)
+
+    # Set up factories.
+    usecase_factory = create_sql_usecase_factory(settings, plugins, session)
     command_factory = CtlCommandFactory(settings, usecase_factory)
 
     # Old-style subcommands store a func in callable when setting up their arguments.  New-style

--- a/grouper/ctl/oneoff.py
+++ b/grouper/ctl/oneoff.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from grouper.ctl.util import make_session
 from grouper.oneoff import BaseOneOff
-from grouper.plugin import load_plugins
+from grouper.plugin.load import load_plugins
 
 if TYPE_CHECKING:
     from argparse import Namespace

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -22,6 +22,7 @@ from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
 from grouper.models.user import User
 from grouper.perf_profile import record_trace
+from grouper.plugin import get_plugin_proxy
 from grouper.user_permissions import user_permissions
 
 if TYPE_CHECKING:
@@ -66,7 +67,8 @@ class GrouperHandler(RequestHandler):
         self.graph = Graph()
         self.session = kwargs["session"]()  # type: Session
         self.template_env = kwargs["template_env"]  # type: Environment
-        self.usecase_factory = create_graph_usecase_factory(settings(), self.session)
+        self.plugins = get_plugin_proxy()
+        self.usecase_factory = create_graph_usecase_factory(settings(), self.plugins, self.session)
 
         if self.get_argument("_profile", False):
             self.perf_collector = Collector()

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -9,29 +9,30 @@ from grouper.usecases.factory import UseCaseFactory
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
+    from grouper.plugin.proxy import PluginProxy
     from grouper.settings import Settings
     from typing import Optional
 
 
-def create_graph_usecase_factory(settings, session=None, graph=None):
-    # type: (Settings, Optional[Session], Optional[GroupGraph]) -> UseCaseFactory
+def create_graph_usecase_factory(settings, plugins, session=None, graph=None):
+    # type: (Settings, PluginProxy, Optional[Session], Optional[GroupGraph]) -> UseCaseFactory
     """Create a graph-backed UseCaseFactory, with optional injection of a Session and GroupGraph.
 
     Session and graph injection is supported primarily for tests.  If not injected, they will be
     created on demand.
     """
-    repository_factory = GraphRepositoryFactory(settings, session, graph)
+    repository_factory = GraphRepositoryFactory(settings, plugins, session, graph)
     service_factory = ServiceFactory(repository_factory)
     return UseCaseFactory(service_factory)
 
 
-def create_sql_usecase_factory(settings, session=None):
-    # type: (Settings, Optional[Session]) -> UseCaseFactory
+def create_sql_usecase_factory(settings, plugins, session=None):
+    # type: (Settings, PluginProxy, Optional[Session]) -> UseCaseFactory
     """Create a SQL-backed UseCaseFactory, with optional injection of a Session.
 
     Session injection is supported primarily for tests.  If not injected, it will be created on
     demand.
     """
-    repository_factory = SQLRepositoryFactory(settings, session)
+    repository_factory = SQLRepositoryFactory(settings, plugins, session)
     service_factory = ServiceFactory(repository_factory)
     return UseCaseFactory(service_factory)

--- a/grouper/plugin/__init__.py
+++ b/grouper/plugin/__init__.py
@@ -1,65 +1,15 @@
-import inspect
-import os
-from importlib import import_module
-from typing import Callable, List, Type, TypeVar
-
-from annex import Annex
-
-from grouper.plugin.base import BasePlugin
-from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.plugin.proxy import PluginProxy
-
-T = TypeVar("T")
 
 _plugin_proxy = PluginProxy([])
 
 
-def initialize_plugins(plugin_dirs, plugin_module_paths, service_name):
-    # type: (List[str], List[str], str) -> None
-    plugins = load_plugins(BasePlugin, plugin_dirs, plugin_module_paths, service_name)
-
+def set_global_plugin_proxy(plugin_proxy):
+    # type: (PluginProxy) -> None
     global _plugin_proxy
-    _plugin_proxy = PluginProxy(plugins)
+    _plugin_proxy = plugin_proxy
 
 
 def get_plugin_proxy():
     # type: () -> PluginProxy
     global _plugin_proxy
     return _plugin_proxy
-
-
-def load_plugins(base_plugin, plugin_dirs, plugin_module_paths, service_name):
-    # type: (Type[T], List[str], List[str], str) -> List[T]
-    """Load plugins from a list of directories and modules"""
-    for plugin_dir in plugin_dirs:
-        if not os.path.exists(plugin_dir):
-            raise PluginsDirectoryDoesNotExist("{} doesn't exist".format(plugin_dir))
-
-    plugins = Annex(
-        base_plugin=base_plugin,
-        plugin_dirs=plugin_dirs,
-        raise_exceptions=True,
-        additional_plugin_callback=_load_plugin_modules(base_plugin, plugin_module_paths),
-    )
-
-    for plugin in plugins:
-        plugin.configure(service_name)
-
-    return list(plugins)
-
-
-def _load_plugin_modules(base_plugin, plugin_module_paths):
-    # type: (Type[T], List[str]) -> Callable
-    def callback():
-        plugins = []
-
-        for module_path in plugin_module_paths:
-            module = import_module(module_path)
-            for name in dir(module):
-                obj = getattr(module, name)
-                if inspect.isclass(obj) and issubclass(obj, base_plugin) and obj != base_plugin:
-                    plugins.append(obj)
-
-        return plugins
-
-    return callback

--- a/grouper/plugin/load.py
+++ b/grouper/plugin/load.py
@@ -1,0 +1,50 @@
+import inspect
+import os
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+from annex import Annex
+
+from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
+
+if TYPE_CHECKING:
+    from typing import Callable, List, Type, TypeVar
+
+    T = TypeVar("T")
+
+
+def load_plugins(base_plugin, plugin_dirs, plugin_module_paths, service_name):
+    # type: (Type[T], List[str], List[str], str) -> List[T]
+    """Load plugins from a list of directories and modules"""
+    for plugin_dir in plugin_dirs:
+        if not os.path.exists(plugin_dir):
+            raise PluginsDirectoryDoesNotExist("{} doesn't exist".format(plugin_dir))
+
+    plugins = Annex(
+        base_plugin=base_plugin,
+        plugin_dirs=plugin_dirs,
+        raise_exceptions=True,
+        additional_plugin_callback=_load_plugin_modules(base_plugin, plugin_module_paths),
+    )
+
+    for plugin in plugins:
+        plugin.configure(service_name)
+
+    return list(plugins)
+
+
+def _load_plugin_modules(base_plugin, plugin_module_paths):
+    # type: (Type[T], List[str]) -> Callable
+    def callback():
+        plugins = []
+
+        for module_path in plugin_module_paths:
+            module = import_module(module_path)
+            for name in dir(module):
+                obj = getattr(module, name)
+                if inspect.isclass(obj) and issubclass(obj, base_plugin) and obj != base_plugin:
+                    plugins.append(obj)
+
+        return plugins
+
+    return callback

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -1,10 +1,13 @@
 from typing import TYPE_CHECKING
 
+from grouper.plugin.base import BasePlugin
+from grouper.plugin.load import load_plugins
+
 if TYPE_CHECKING:
     from grouper.models.audit_log import AuditLog
     from grouper.models.group import Group
     from grouper.models.user import User
-    from grouper.plugin.base import BasePlugin
+    from grouper.settings import Settings
     from sshpubkeys import SSHKey
     from ssl import SSLContext
     from sqlalchemy.orm import Session
@@ -13,6 +16,16 @@ if TYPE_CHECKING:
 
 
 class PluginProxy(object):
+    """Wrapper to proxy a plugin method call to all loaded plugins."""
+
+    @classmethod
+    def load_plugins(cls, settings, service_name):
+        # type: (Settings, str) -> PluginProxy
+        plugins = load_plugins(
+            BasePlugin, settings.plugin_dirs, settings.plugin_module_paths, service_name
+        )
+        return cls(plugins)
+
     def __init__(self, plugins):
         # type: (List[BasePlugin]) -> None
         self._plugins = plugins

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -11,10 +11,10 @@ from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.models.group import Group
 from grouper.models.permission import Permission
 from grouper.models.user import User
-from grouper.plugin import get_plugin_proxy
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from grouper.plugin.proxy import PluginProxy
     from grouper.usecases.authorization import Authorization
     from typing import List, Optional
 
@@ -22,9 +22,10 @@ if TYPE_CHECKING:
 class AuditLogRepository(object):
     """SQL storage layer for audit log entries."""
 
-    def __init__(self, session):
-        # type: (Session) -> None
+    def __init__(self, session, plugins):
+        # type: (Session, PluginProxy) -> None
         self.session = session
+        self.plugins = plugins
 
     def entries_affecting_permission(self, permission, limit):
         # type: (str, int) -> List[AuditLogEntry]
@@ -82,7 +83,7 @@ class AuditLogRepository(object):
         # This should happen at the service layer, not the repository layer, but the API for the
         # plugin currently takes a SQL object.  This can move to the service layer once a data
         # transfer object is defined instead.
-        get_plugin_proxy().log_auditlog_entry(entry)
+        self.plugins.log_auditlog_entry(entry)
 
     def _id_for_group(self, group):
         # type: (str) -> int

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -18,6 +18,7 @@ from grouper.repositories.user import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
+    from grouper.plugin.proxy import PluginProxy
     from grouper.repositories.interfaces import (
         GroupEdgeRepository,
         PermissionRepository,
@@ -43,9 +44,10 @@ class GraphRepositoryFactory(RepositoryFactory):
     commands are instantiated.
     """
 
-    def __init__(self, settings, session=None, graph=None):
-        # type: (Settings, Optional[Session], Optional[GroupGraph]) -> None
+    def __init__(self, settings, plugins, session=None, graph=None):
+        # type: (Settings, PluginProxy, Optional[Session], Optional[GroupGraph]) -> None
         self.settings = settings
+        self.plugins = plugins
         self._session = session
         self._graph = graph
 
@@ -67,7 +69,7 @@ class GraphRepositoryFactory(RepositoryFactory):
 
     def create_audit_log_repository(self):
         # type: () -> AuditLogRepository
-        return AuditLogRepository(self.session)
+        return AuditLogRepository(self.session, self.plugins)
 
     def create_checkpoint_repository(self):
         # type: () -> CheckpointRepository
@@ -118,9 +120,10 @@ class SQLRepositoryFactory(RepositoryFactory):
     instantiated.
     """
 
-    def __init__(self, settings, session=None):
-        # type: (Settings, Optional[Session]) -> None
+    def __init__(self, settings, plugins, session=None):
+        # type: (Settings, PluginProxy, Optional[Session]) -> None
         self.settings = settings
+        self.plugins = plugins
         self._session = session
 
     @property
@@ -134,7 +137,7 @@ class SQLRepositoryFactory(RepositoryFactory):
 
     def create_audit_log_repository(self):
         # type: () -> AuditLogRepository
-        return AuditLogRepository(self.session)
+        return AuditLogRepository(self.session, self.plugins)
 
     def create_checkpoint_repository(self):
         # type: () -> CheckpointRepository

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,7 +26,8 @@ from grouper.models.group import Group
 from grouper.models.permission import Permission
 from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing
-from grouper.plugin import initialize_plugins
+from grouper.plugin import set_global_plugin_proxy
+from grouper.plugin.proxy import PluginProxy
 from grouper.service_account import create_service_account
 from grouper.settings import set_global_settings, Settings
 from tests.path_util import db_url
@@ -173,7 +174,7 @@ def session(request, tmpdir):
     set_global_settings(settings)
 
     # Reinitialize plugins in case a previous test configured some.
-    initialize_plugins(settings.plugin_dirs, settings.plugin_module_paths, "tests")
+    set_global_plugin_proxy(PluginProxy([]))
 
     db_engine = get_db_engine(db_url(tmpdir))
 


### PR DESCRIPTION
Start the process of migrating away from a global PluginProxy
object to dependency injection.  Move the main entry point for
loading plugins to a static method on PluginProxy, use it to
create a PluginProxy object in each executable, and (for now)
explicitly set it as the global plugin proxy.  Similarly set
an empty one in test initialization.

Move the plugin loading code out of the __init__.py file to
avoid a circular dependency with grouper.plugin.proxy, and also
because code in __init__.py is confusing.  Now only the legacy
global object handling is there.

PluginProxy objects are created by each executable rather than
by the global factory functions because they take the executable
name as a parameter.  Use hyphens instead of underscores for
grouper-api and grouper-fe (a backward-incompatible change) for
consistency (and because Dropbox internal plugins were rewriting
the underscore back to a hyphen anyway).