### PR TITLE
Move creating the session into the repository

### DIFF
--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -10,10 +10,11 @@ from grouper.models.base.session import get_db_engine
 if TYPE_CHECKING:
     from argparse import _SubParsersAction, Namespace
     from grouper.ctl.settings import CtlSettings
+    from grouper.repositories.factory import SessionFactory
 
 
-def dump_sql_command(args, settings):
-    # type: (Namespace, CtlSettings) -> None
+def dump_sql_command(args, settings, session_factory):
+    # type: (Namespace, CtlSettings, SessionFactory) -> None
     db_engine = get_db_engine(settings.database_url)
     for table in Model.metadata.sorted_tables:
         print(CreateTable(table).compile(db_engine))

--- a/grouper/ctl/oneoff.py
+++ b/grouper/ctl/oneoff.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from types import MethodType
 from typing import TYPE_CHECKING
 
-from grouper.ctl.util import make_session
 from grouper.oneoff import BaseOneOff
 from grouper.plugin.load import load_plugins
 
@@ -12,6 +11,7 @@ if TYPE_CHECKING:
     from argparse import Namespace
     from grouper.ctl.settings import CtlSettings
     from grouper.models.session import Session
+    from grouper.repositories.factory import SessionFactory
     from typing import Any, Iterator, Tuple
 
 
@@ -61,9 +61,9 @@ def key_value_arg_type(arg):
     return (k, v)
 
 
-def oneoff_command(args, settings):
-    # type: (Namespace, CtlSettings) -> None
-    session = make_session(settings)
+def oneoff_command(args, settings, session_factory):
+    # type: (Namespace, CtlSettings, SessionFactory) -> None
+    session = session_factory.create_session()
 
     oneoffs = load_plugins(
         BaseOneOff, settings.oneoff_dirs, settings.oneoff_module_paths, "grouper-ctl"

--- a/grouper/ctl/service_account.py
+++ b/grouper/ctl/service_account.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TYPE_CHECKING
 
-from grouper.ctl.util import ensure_valid_service_account_name, make_session
+from grouper.ctl.util import ensure_valid_service_account_name
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
@@ -10,12 +10,13 @@ from grouper.service_account import create_service_account
 if TYPE_CHECKING:
     from argparse import Namespace
     from grouper.ctl.settings import CtlSettings
+    from grouper.repositories.factory import SessionFactory
 
 
 @ensure_valid_service_account_name
-def service_account_command(args, settings):
-    # type: (Namespace, CtlSettings) -> None
-    session = make_session(settings)
+def service_account_command(args, settings, session_factory):
+    # type: (Namespace, CtlSettings, SessionFactory) -> None
+    session = session_factory.create_session()
     actor_user = User.get(session, name=args.actor_name)
     if not actor_user:
         logging.fatal('Actor user "{}" is not a valid Grouper user'.format(args.actor_name))

--- a/grouper/ctl/shell.py
+++ b/grouper/ctl/shell.py
@@ -1,12 +1,18 @@
 import code
 from pprint import pprint
+from typing import TYPE_CHECKING
 
-from grouper.ctl.util import make_session
 from grouper.graph import GroupGraph
 
+if TYPE_CHECKING:
+    from argparse import Namespace
+    from grouper.ctl.settings import CtlSettings
+    from grouper.repositories.factory import SessionFactory
 
-def shell_command(args):
-    session = make_session()
+
+def shell_command(args, settings, session_factory):
+    # type: (Namespace, CtlSettings, SessionFactory) -> None
+    session = session_factory.create_session()
     graph = GroupGraph.from_db(session)
     pp = pprint
 

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -11,9 +11,9 @@ from grouper.constants import (
     USER_ADMIN,
 )
 from grouper.ctl.base import CtlCommand
-from grouper.ctl.util import make_session
 from grouper.models.group import Group
 from grouper.permissions import create_permission, get_permission, grant_permission
+from grouper.repositories.factory import SessionFactory
 from grouper.util import get_auditors_group_name
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ class SyncDbCommand(CtlCommand):
         # TODO(rra): The code below will move into use cases later.
 
         # Add some basic database structures we know we will need if they don't exist.
-        session = make_session(self.settings)
+        session = SessionFactory(self.settings).create_session()
 
         for name, description in SYSTEM_PERMISSIONS:
             test = get_permission(session, name)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -23,6 +23,7 @@ from grouper.models.base.session import get_db_engine, Session
 from grouper.models.user import User
 from grouper.perf_profile import record_trace
 from grouper.plugin import get_plugin_proxy
+from grouper.repositories.factory import SingletonSessionFactory
 from grouper.user_permissions import user_permissions
 
 if TYPE_CHECKING:
@@ -68,7 +69,10 @@ class GrouperHandler(RequestHandler):
         self.session = kwargs["session"]()  # type: Session
         self.template_env = kwargs["template_env"]  # type: Environment
         self.plugins = get_plugin_proxy()
-        self.usecase_factory = create_graph_usecase_factory(settings(), self.plugins, self.session)
+        session_factory = SingletonSessionFactory(self.session)
+        self.usecase_factory = create_graph_usecase_factory(
+            settings(), self.plugins, session_factory
+        )
 
         if self.get_argument("_profile", False):
             self.perf_collector = Collector()

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -2,37 +2,49 @@
 
 from typing import TYPE_CHECKING
 
-from grouper.repositories.factory import GraphRepositoryFactory, SQLRepositoryFactory
+from grouper.repositories.factory import (
+    GraphRepositoryFactory,
+    SessionFactory,
+    SQLRepositoryFactory,
+)
 from grouper.services.factory import ServiceFactory
 from grouper.usecases.factory import UseCaseFactory
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
-    from grouper.models.base.session import Session
     from grouper.plugin.proxy import PluginProxy
     from grouper.settings import Settings
     from typing import Optional
 
 
-def create_graph_usecase_factory(settings, plugins, session=None, graph=None):
-    # type: (Settings, PluginProxy, Optional[Session], Optional[GroupGraph]) -> UseCaseFactory
+def create_graph_usecase_factory(
+    settings,  # type: Settings
+    plugins,  # type: PluginProxy
+    session_factory=None,  # type: Optional[SessionFactory]
+    graph=None,  # type: Optional[GroupGraph]
+):
+    # type: (...) -> UseCaseFactory
     """Create a graph-backed UseCaseFactory, with optional injection of a Session and GroupGraph.
 
-    Session and graph injection is supported primarily for tests.  If not injected, they will be
-    created on demand.
+    Session factory and graph injection is supported primarily for tests.  If not injected, they
+    will be created on demand.
     """
-    repository_factory = GraphRepositoryFactory(settings, plugins, session, graph)
+    if not session_factory:
+        session_factory = SessionFactory(settings)
+    repository_factory = GraphRepositoryFactory(settings, plugins, session_factory, graph)
     service_factory = ServiceFactory(repository_factory)
     return UseCaseFactory(service_factory)
 
 
-def create_sql_usecase_factory(settings, plugins, session=None):
-    # type: (Settings, PluginProxy, Optional[Session]) -> UseCaseFactory
+def create_sql_usecase_factory(settings, plugins, session_factory=None):
+    # type: (Settings, PluginProxy, Optional[SessionFactory]) -> UseCaseFactory
     """Create a SQL-backed UseCaseFactory, with optional injection of a Session.
 
-    Session injection is supported primarily for tests.  If not injected, it will be created on
-    demand.
+    Session factory injection is supported primarily for tests.  If not injected, it will be
+    created on demand.
     """
-    repository_factory = SQLRepositoryFactory(settings, plugins, session)
+    if not session_factory:
+        session_factory = SessionFactory(settings)
+    repository_factory = SQLRepositoryFactory(settings, plugins, session_factory)
     service_factory = ServiceFactory(repository_factory)
     return UseCaseFactory(service_factory)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.graph import Graph
+from grouper.models.base.session import get_db_engine, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
@@ -18,7 +19,6 @@ from grouper.repositories.user import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
-    from grouper.models.base.session import Session
     from grouper.plugin.proxy import PluginProxy
     from grouper.repositories.interfaces import (
         GroupEdgeRepository,
@@ -27,6 +27,42 @@ if TYPE_CHECKING:
     )
     from grouper.settings import Settings
     from typing import Optional
+
+
+class SessionFactory(object):
+    """Create database sessions.
+
+    Eventually this will be used only by the RepositoryFactory to get a session to inject into
+    other repositories.  For now, it's also used by legacy code that hasn't been rewritten as
+    usecases.
+    """
+
+    def __init__(self, settings):
+        # type: (Settings) -> None
+        self.settings = settings
+
+    def create_session(self):
+        # type: () -> Session
+        db_engine = get_db_engine(self.settings.database_url)
+        Session.configure(bind=db_engine)
+        return Session()
+
+
+class SingletonSessionFactory(SessionFactory):
+    """Always returns the database session with which it was initialized.
+
+    This is used primarily for testing to force all parts of a test case to use the same session,
+    which avoids some data desynchronization between sessions when using a persistent store.  It is
+    also used in legacy code when session injection is needed.
+    """
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def create_session(self):
+        # type: () -> Session
+        return self.session
 
 
 class GraphRepositoryFactory(RepositoryFactory):
@@ -45,12 +81,13 @@ class GraphRepositoryFactory(RepositoryFactory):
     commands are instantiated.
     """
 
-    def __init__(self, settings, plugins, session=None, graph=None):
-        # type: (Settings, PluginProxy, Optional[Session], Optional[GroupGraph]) -> None
+    def __init__(self, settings, plugins, session_factory, graph=None):
+        # type: (Settings, PluginProxy, SessionFactory, Optional[GroupGraph]) -> None
         self.settings = settings
         self.plugins = plugins
-        self._session = session
+        self.session_factory = session_factory
         self._graph = graph
+        self._session = None  # type: Optional[Session]
 
     @property
     def graph(self):
@@ -63,8 +100,7 @@ class GraphRepositoryFactory(RepositoryFactory):
     def session(self):
         # type: () -> Session
         if not self._session:
-            schema_repository = self.create_schema_repository()
-            self._session = schema_repository.create_session()
+            self._session = self.session_factory.create_session()
         return self._session
 
     def create_audit_log_repository(self):
@@ -124,18 +160,18 @@ class SQLRepositoryFactory(RepositoryFactory):
     instantiated.
     """
 
-    def __init__(self, settings, plugins, session=None):
-        # type: (Settings, PluginProxy, Optional[Session]) -> None
+    def __init__(self, settings, plugins, session_factory):
+        # type: (Settings, PluginProxy, SessionFactory) -> None
         self.settings = settings
         self.plugins = plugins
-        self._session = session
+        self.session_factory = session_factory
+        self._session = None  # type: Optional[Session]
 
     @property
     def session(self):
         # type: () -> Session
         if not self._session:
-            schema_repository = self.create_schema_repository()
-            self._session = schema_repository.create_session()
+            self._session = self.session_factory.create_session()
         return self._session
 
     def create_audit_log_repository(self):

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 from grouper.graph import Graph
-from grouper.models.base.session import get_db_engine, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
@@ -19,6 +18,7 @@ from grouper.repositories.user import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
     from grouper.plugin.proxy import PluginProxy
     from grouper.repositories.interfaces import (
         GroupEdgeRepository,
@@ -63,9 +63,8 @@ class GraphRepositoryFactory(RepositoryFactory):
     def session(self):
         # type: () -> Session
         if not self._session:
-            db_engine = get_db_engine(self.settings.database_url)
-            Session.configure(bind=db_engine)
-            self._session = Session()
+            schema_repository = self.create_schema_repository()
+            self._session = schema_repository.create_session()
         return self._session
 
     def create_audit_log_repository(self):
@@ -135,9 +134,8 @@ class SQLRepositoryFactory(RepositoryFactory):
     def session(self):
         # type: () -> Session
         if not self._session:
-            db_engine = get_db_engine(self.settings.database_url)
-            Session.configure(bind=db_engine)
-            self._session = Session()
+            schema_repository = self.create_schema_repository()
+            self._session = schema_repository.create_session()
         return self._session
 
     def create_audit_log_repository(self):

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -16,7 +16,7 @@ from grouper.models.audit import Audit  # noqa: F401
 from grouper.models.audit_log import AuditLog  # noqa: F401
 from grouper.models.audit_member import AuditMember  # noqa: F401
 from grouper.models.base.model_base import Model
-from grouper.models.base.session import get_db_engine, Session
+from grouper.models.base.session import get_db_engine
 from grouper.models.comment import Comment  # noqa: F401
 from grouper.models.counter import Counter  # noqa: F401
 from grouper.models.group import Group  # noqa: F401
@@ -44,17 +44,11 @@ if TYPE_CHECKING:
 
 
 class SchemaRepository(object):
-    """Manipulate the database schema and manage database sessions."""
+    """Manipulate the database schema."""
 
     def __init__(self, settings):
         # type: (Settings) -> None
         self.settings = settings
-
-    def create_session(self):
-        # type: () -> Session
-        db_engine = get_db_engine(self.settings.database_url)
-        Session.configure(bind=db_engine)
-        return Session()
 
     def drop_schema(self):
         # type: () -> None

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -16,7 +16,7 @@ from grouper.models.audit import Audit  # noqa: F401
 from grouper.models.audit_log import AuditLog  # noqa: F401
 from grouper.models.audit_member import AuditMember  # noqa: F401
 from grouper.models.base.model_base import Model
-from grouper.models.base.session import get_db_engine
+from grouper.models.base.session import get_db_engine, Session
 from grouper.models.comment import Comment  # noqa: F401
 from grouper.models.counter import Counter  # noqa: F401
 from grouper.models.group import Group  # noqa: F401
@@ -44,11 +44,17 @@ if TYPE_CHECKING:
 
 
 class SchemaRepository(object):
-    """Manipulate the database schema."""
+    """Manipulate the database schema and manage database sessions."""
 
     def __init__(self, settings):
         # type: (Settings) -> None
         self.settings = settings
+
+    def create_session(self):
+        # type: () -> Session
+        db_engine = get_db_engine(self.settings.database_url)
+        Session.configure(bind=db_engine)
+        return Session()
 
     def drop_schema(self):
         # type: () -> None

--- a/tests/ctl/group_test.py
+++ b/tests/ctl/group_test.py
@@ -12,10 +12,7 @@ from tests.ctl_util import call_main
 from tests.fixtures import graph, groups, permissions, session, standard_graph, users  # noqa: F401
 
 
-@patch("grouper.ctl.group.make_session")
-def test_group_add_remove_member(make_session, session, tmpdir, users, groups):  # noqa: F811
-    make_session.return_value = session
-
+def test_group_add_remove_member(session, tmpdir, users, groups):  # noqa: F811
     username = "oliver@a.co"
     groupname = "team-sre"
 
@@ -33,11 +30,7 @@ def test_group_add_remove_member(make_session, session, tmpdir, users, groups): 
 
 
 @patch("grouper.group_member.get_plugin_proxy")
-@patch("grouper.ctl.group.make_session")
-def test_group_add_remove_owner(
-    make_session, get_plugin_proxy, session, tmpdir, users, groups  # noqa: F811
-):
-    make_session.return_value = session
+def test_group_add_remove_owner(get_plugin_proxy, session, tmpdir, users, groups):  # noqa: F811
     get_plugin_proxy.return_value = PluginProxy([GroupOwnershipPolicyPlugin()])
 
     username = "oliver@a.co"
@@ -56,10 +49,7 @@ def test_group_add_remove_owner(
     assert (u"User", username) in Group.get(session, name=groupname).my_members()
 
 
-@patch("grouper.ctl.group.make_session")
-def test_group_bulk_add_remove(make_session, session, tmpdir, users, groups):  # noqa: F811
-    make_session.return_value = session
-
+def test_group_bulk_add_remove(session, tmpdir, users, groups):  # noqa: F811
     groupname = "team-sre"
 
     # bulk add
@@ -74,10 +64,7 @@ def test_group_bulk_add_remove(make_session, session, tmpdir, users, groups):  #
     assert not members.intersection(usernames)
 
 
-@patch("grouper.ctl.group.make_session")
-def test_group_name_checks(make_session, session, tmpdir, users, groups):  # noqa: F811
-    make_session.return_value = session
-
+def test_group_name_checks(session, tmpdir, users, groups):  # noqa: F811
     username = "oliver@a.co"
     groupname = "team-sre"
 
@@ -90,10 +77,7 @@ def test_group_name_checks(make_session, session, tmpdir, users, groups):  # noq
     assert (u"User", bad_username) not in Group.get(session, name=groupname).my_members()
 
 
-@patch("grouper.ctl.group.make_session")
-def test_group_logdump(make_session, session, tmpdir, users, groups):  # noqa: F811
-    make_session.return_value = session
-
+def test_group_logdump(session, tmpdir, users, groups):  # noqa: F811
     groupname = "team-sre"
     group_id = groups[groupname].id
 

--- a/tests/ctl/misc_test.py
+++ b/tests/ctl/misc_test.py
@@ -13,10 +13,7 @@ def noop(*k):
     None
 
 
-@patch("grouper.ctl.user.make_session")
-def test_user_create(make_session, session, tmpdir, users):  # noqa: F811
-    make_session.return_value = session
-
+def test_user_create(session, tmpdir, users):  # noqa: F811
     # simple
     username = "john@a.co"
     call_main(session, tmpdir, "user", "create", username)
@@ -39,14 +36,7 @@ def test_user_create(make_session, session, tmpdir, users):  # noqa: F811
     assert not any(users), "one bad seed means no users created"
 
 
-@patch("grouper.ctl.user.make_session")
-@patch("grouper.ctl.group.make_session")
-def test_user_status_changes(
-    make_user_session, make_group_session, session, tmpdir, users, groups  # noqa: F811
-):
-    make_user_session.return_value = session
-    make_group_session.return_value = session
-
+def test_user_status_changes(session, tmpdir, users, groups):  # noqa: F811
     username = "zorkian@a.co"
     groupname = "team-sre"
 
@@ -77,10 +67,7 @@ def test_user_status_changes(
     assert (u"User", username) not in groups[groupname].my_members()
 
 
-@patch("grouper.ctl.user.make_session")
-def test_user_public_key(make_session, session, tmpdir, users):  # noqa: F811
-    make_session.return_value = session
-
+def test_user_public_key(session, tmpdir, users):  # noqa: F811
     # good key
     username = "zorkian@a.co"
     call_main(session, tmpdir, "user", "add_public_key", username, SSH_KEY_1)
@@ -106,9 +93,7 @@ def test_user_public_key(make_session, session, tmpdir, users):  # noqa: F811
 
 
 @patch("grouper.ctl.oneoff.load_plugins")
-@patch("grouper.ctl.oneoff.make_session")
-def test_oneoff(mock_make_session, mock_load_plugins, session, tmpdir):  # noqa: F811
-    mock_make_session.return_value = session
+def test_oneoff(mock_load_plugins, session, tmpdir):  # noqa: F811
     username = "fake_user@a.co"
     other_username = "fake_user2@a.co"
     groupname = "fake_group"

--- a/tests/ctl/service_account_test.py
+++ b/tests/ctl/service_account_test.py
@@ -1,5 +1,3 @@
-from mock import patch
-
 from grouper.group_service_account import get_service_accounts
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
@@ -14,12 +12,7 @@ from tests.fixtures import (  # noqa: F401
 )
 
 
-@patch("grouper.ctl.service_account.make_session")
-def test_service_account_create(
-    make_session, groups, service_accounts, session, tmpdir, users  # noqa: F811
-):
-    make_session.return_value = session
-
+def test_service_account_create(groups, service_accounts, session, tmpdir, users):  # noqa: F811
     machine_set = "foo +bar -(org)"
     description = "this is a service account.\n\n it is for testing"
     security_team_group = Group.get(session, name="security-team")

--- a/tests/ctl/user_test.py
+++ b/tests/ctl/user_test.py
@@ -8,19 +8,7 @@ from tests.fixtures import graph, groups, permissions, session, standard_graph, 
 
 
 @patch("grouper.user.get_plugin_proxy")
-@patch("grouper.ctl.group.make_session")
-@patch("grouper.ctl.user.make_session")
-def test_group_disable_group_owner(
-    user_make_session,
-    group_make_session,
-    get_plugin_proxy,
-    session,  # noqa: F811
-    tmpdir,
-    users,  # noqa: F811
-    groups,  # noqa: F811
-):
-    group_make_session.return_value = session
-    user_make_session.return_value = session
+def test_group_disable_group_owner(get_plugin_proxy, session, tmpdir, users, groups):  # noqa: F811
     get_plugin_proxy.return_value = PluginProxy([GroupOwnershipPolicyPlugin()])
 
     username = "oliver@a.co"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,6 +28,7 @@ from grouper.models.user import User
 from grouper.permissions import enable_permission_auditing
 from grouper.plugin import set_global_plugin_proxy
 from grouper.plugin.proxy import PluginProxy
+from grouper.repositories.factory import SingletonSessionFactory
 from grouper.service_account import create_service_account
 from grouper.settings import set_global_settings, Settings
 from tests.path_util import db_url
@@ -314,7 +315,10 @@ def api_app(session, standard_graph):
     # type: (Session, GroupGraph) -> GrouperApplication
     settings = ApiSettings()
     set_global_settings(settings)
-    usecase_factory = create_graph_usecase_factory(settings, session, standard_graph)
+    session_factory = SingletonSessionFactory(session)
+    usecase_factory = create_graph_usecase_factory(
+        settings, PluginProxy([]), session_factory, standard_graph
+    )
     return create_api_application(standard_graph, settings, usecase_factory)
 
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING
 
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
-from grouper.models.base.session import get_db_engine, Session
 from grouper.models.group import Group
 from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
 from grouper.models.permission import Permission
@@ -46,6 +45,7 @@ from grouper.usecases.factory import UseCaseFactory
 from tests.path_util import db_url
 
 if TYPE_CHECKING:
+    from grouper.models.base.session import Session
     from py.local import LocalPath
     from typing import Iterator, Optional
 
@@ -81,7 +81,6 @@ class SetupTest(object):
 
     def create_session(self):
         # type: () -> Session
-        db_engine = get_db_engine(self.settings.database_url)
         schema_repository = SchemaRepository(self.settings)
 
         # Reinitialize the global plugin proxy with an empty set of plugins in case a previous test
@@ -93,12 +92,9 @@ class SetupTest(object):
         if "MEROU_TEST_DATABASE" in os.environ:
             schema_repository.drop_schema()
 
-        # Create the database schema.
+        # Create the database schema and the session.
         schema_repository.initialize_schema()
-
-        # Configure and create the session.
-        Session.configure(bind=db_engine)
-        return Session()
+        return schema_repository.create_session()
 
     def close(self):
         # type: () -> None


### PR DESCRIPTION
Creating the database session requires similar calls to initializing
or dropping the schema, so move that into the SchemaRepository as
well.