### PR TITLE
Move the rest of sync_db into a usecase

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -56,7 +56,8 @@ SYSTEM_PERMISSIONS = [
     (USER_DISABLE, "Ability to disable an enabled user."),
 ]
 
-# Name of the administrators group created automatically by sync-db.
+# The name of the administrator group that's created during schema initialization.  (Grouper
+# doesn't depend on the name of this group and is happy for it to be renamed later.)
 DEFAULT_ADMIN_GROUP = "grouper-administrators"
 
 # Used to construct name tuples in notification engine.

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -64,7 +64,7 @@ class CtlCommandFactory(object):
 
     def construct_sync_db_command(self):
         # type: () -> SyncDbCommand
-        return SyncDbCommand(self.settings, self.usecase_factory)
+        return SyncDbCommand(self.usecase_factory)
 
     def construct_user_command(self):
         # type: () -> UserCommand

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -1,20 +1,6 @@
 from typing import TYPE_CHECKING
 
-from sqlalchemy.exc import IntegrityError
-
-from grouper.constants import (
-    DEFAULT_ADMIN_GROUP,
-    GROUP_ADMIN,
-    PERMISSION_ADMIN,
-    PERMISSION_AUDITOR,
-    SYSTEM_PERMISSIONS,
-    USER_ADMIN,
-)
 from grouper.ctl.base import CtlCommand
-from grouper.models.group import Group
-from grouper.permissions import create_permission, get_permission, grant_permission
-from grouper.repositories.factory import SessionFactory
-from grouper.util import get_auditors_group_name
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
@@ -39,65 +25,3 @@ class SyncDbCommand(CtlCommand):
         # type: (Namespace) -> None
         usecase = self.usecase_factory.create_initialize_schema_usecase()
         usecase.initialize_schema()
-
-        # TODO(rra): The code below will move into use cases later.
-
-        # Add some basic database structures we know we will need if they don't exist.
-        session = SessionFactory(self.settings).create_session()
-
-        for name, description in SYSTEM_PERMISSIONS:
-            test = get_permission(session, name)
-            if test:
-                continue
-            try:
-                create_permission(session, name, description)
-                session.flush()
-            except IntegrityError:
-                session.rollback()
-                raise Exception("Failed to create permission: %s" % (name,))
-            session.commit()
-
-        # This group is needed to bootstrap a Grouper installation.
-        admin_group = Group.get(session, name=DEFAULT_ADMIN_GROUP)
-        if not admin_group:
-            admin_group = Group(
-                groupname=DEFAULT_ADMIN_GROUP,
-                description="Administrators of the Grouper system.",
-                canjoin="nobody",
-            )
-
-            try:
-                admin_group.add(session)
-                session.flush()
-            except IntegrityError:
-                session.rollback()
-                raise Exception("Failed to create group: grouper-administrators")
-
-            for permission_name in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-                permission = get_permission(session, permission_name)
-                assert permission, "Permission should have been created earlier!"
-                grant_permission(session, admin_group.id, permission.id)
-
-            session.commit()
-
-        auditors_group_name = get_auditors_group_name(self.settings)
-        auditors_group = Group.get(session, name=auditors_group_name)
-        if not auditors_group:
-            auditors_group = Group(
-                groupname=auditors_group_name,
-                description="Group for auditors, who can be owners of audited groups.",
-                canjoin="canjoin",
-            )
-
-            try:
-                auditors_group.add(session)
-                session.flush()
-            except IntegrityError:
-                session.rollback()
-                raise Exception("Failed to create group: {}".format(self.settings.auditors_group))
-
-            permission = get_permission(session, PERMISSION_AUDITOR)
-            assert permission, "Permission should have been created earlier!"
-            grant_permission(session, auditors_group.id, permission.id)
-
-            session.commit()

--- a/grouper/ctl/sync_db.py
+++ b/grouper/ctl/sync_db.py
@@ -4,7 +4,6 @@ from grouper.ctl.base import CtlCommand
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
-    from grouper.ctl.settings import CtlSettings
     from grouper.usecases.factory import UseCaseFactory
 
 
@@ -16,9 +15,8 @@ class SyncDbCommand(CtlCommand):
         # type: (ArgumentParser) -> None
         return
 
-    def __init__(self, settings, usecase_factory):
-        # type: (CtlSettings, UseCaseFactory) -> None
-        self.settings = settings
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
         self.usecase_factory = usecase_factory
 
     def run(self, args):

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -8,7 +8,9 @@ class GroupJoinPolicy(Enum):
     NOBODY = "nobody"
 
 
-Group = NamedTuple("Group", [("name", str), ("description", str), ("can_join", GroupJoinPolicy)])
+Group = NamedTuple(
+    "Group", [("name", str), ("description", str), ("join_policy", GroupJoinPolicy)]
+)
 
 
 class GroupNotFoundException(Exception):

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -1,3 +1,16 @@
+from enum import Enum
+from typing import NamedTuple
+
+
+class GroupJoinPolicy(Enum):
+    CAN_JOIN = "canjoin"
+    CAN_ASK = "canask"
+    NOBODY = "nobody"
+
+
+Group = NamedTuple("Group", [("name", str), ("description", str), ("can_join", GroupJoinPolicy)])
+
+
 class GroupNotFoundException(Exception):
     """Attempt to operate on a group not found in the storage layer."""
 

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import NamedTuple
 
+from grouper.constants import NAME_VALIDATION
+
 
 class GroupJoinPolicy(Enum):
     CAN_JOIN = "canjoin"
@@ -20,3 +22,12 @@ class GroupNotFoundException(Exception):
         # type: (str) -> None
         msg = "Group {} not found".format(name)
         super(GroupNotFoundException, self).__init__(msg)
+
+
+class InvalidGroupNameException(Exception):
+    """A group name does not match the validation regex."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Group name {} does not match validation regex {}".format(name, NAME_VALIDATION)
+        super(InvalidGroupNameException, self).__init__(msg)

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -32,8 +32,8 @@ def create_graph_usecase_factory(
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = GraphRepositoryFactory(settings, plugins, session_factory, graph)
-    service_factory = ServiceFactory(settings, repository_factory)
-    return UseCaseFactory(service_factory)
+    service_factory = ServiceFactory(repository_factory)
+    return UseCaseFactory(settings, service_factory)
 
 
 def create_sql_usecase_factory(settings, plugins, session_factory=None):
@@ -46,5 +46,5 @@ def create_sql_usecase_factory(settings, plugins, session_factory=None):
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = SQLRepositoryFactory(settings, plugins, session_factory)
-    service_factory = ServiceFactory(settings, repository_factory)
-    return UseCaseFactory(service_factory)
+    service_factory = ServiceFactory(repository_factory)
+    return UseCaseFactory(settings, service_factory)

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -32,7 +32,7 @@ def create_graph_usecase_factory(
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = GraphRepositoryFactory(settings, plugins, session_factory, graph)
-    service_factory = ServiceFactory(repository_factory)
+    service_factory = ServiceFactory(settings, repository_factory)
     return UseCaseFactory(service_factory)
 
 
@@ -46,5 +46,5 @@ def create_sql_usecase_factory(settings, plugins, session_factory=None):
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = SQLRepositoryFactory(settings, plugins, session_factory)
-    service_factory = ServiceFactory(repository_factory)
+    service_factory = ServiceFactory(settings, repository_factory)
     return UseCaseFactory(service_factory)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -4,7 +4,7 @@ from grouper.graph import Graph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
-from grouper.repositories.group import SQLGroupRepository
+from grouper.repositories.group import GroupRepository
 from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
 from grouper.repositories.group_request import GroupRequestRepository
 from grouper.repositories.interfaces import RepositoryFactory
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from grouper.plugin.proxy import PluginProxy
     from grouper.repositories.interfaces import (
         GroupEdgeRepository,
-        GroupRepository,
         PermissionRepository,
         PermissionGrantRepository,
     )
@@ -119,7 +118,7 @@ class GraphRepositoryFactory(RepositoryFactory):
 
     def create_group_repository(self):
         # type: () -> GroupRepository
-        return SQLGroupRepository(self.session)
+        return GroupRepository(self.session)
 
     def create_group_request_repository(self):
         # type: () -> GroupRequestRepository
@@ -194,7 +193,7 @@ class SQLRepositoryFactory(RepositoryFactory):
 
     def create_group_repository(self):
         # type: () -> GroupRepository
-        return SQLGroupRepository(self.session)
+        return GroupRepository(self.session)
 
     def create_group_request_repository(self):
         # type: () -> GroupRequestRepository

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -4,6 +4,7 @@ from grouper.graph import Graph
 from grouper.models.base.session import get_db_engine, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
+from grouper.repositories.group import SQLGroupRepository
 from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
 from grouper.repositories.group_request import GroupRequestRepository
 from grouper.repositories.interfaces import RepositoryFactory
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from grouper.plugin.proxy import PluginProxy
     from grouper.repositories.interfaces import (
         GroupEdgeRepository,
+        GroupRepository,
         PermissionRepository,
         PermissionGrantRepository,
     )
@@ -115,6 +117,10 @@ class GraphRepositoryFactory(RepositoryFactory):
         # type: () -> GroupEdgeRepository
         return GraphGroupEdgeRepository(self.graph)
 
+    def create_group_repository(self):
+        # type: () -> GroupRepository
+        return SQLGroupRepository(self.session)
+
     def create_group_request_repository(self):
         # type: () -> GroupRequestRepository
         return GroupRequestRepository(self.session)
@@ -185,6 +191,10 @@ class SQLRepositoryFactory(RepositoryFactory):
     def create_group_edge_repository(self):
         # type: () -> GroupEdgeRepository
         return SQLGroupEdgeRepository(self.session)
+
+    def create_group_repository(self):
+        # type: () -> GroupRepository
+        return SQLGroupRepository(self.session)
 
     def create_group_request_repository(self):
         # type: () -> GroupRequestRepository

--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -2,14 +2,13 @@ from typing import TYPE_CHECKING
 
 from grouper.entities.group import Group, GroupJoinPolicy
 from grouper.models.group import Group as SQLGroup
-from grouper.repositories.interfaces import GroupRepository
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from typing import Optional
 
 
-class SQLGroupRepository(GroupRepository):
+class GroupRepository(object):
     """Storage layer for groups."""
 
     def __init__(self, session):

--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.group import Group, GroupJoinPolicy
+from grouper.models.group import Group as SQLGroup
+from grouper.repositories.interfaces import GroupRepository
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Optional
+
+
+class SQLGroupRepository(GroupRepository):
+    """Storage layer for groups."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def create_group(self, name, description, can_join):
+        # type: (str, str, GroupJoinPolicy) -> None
+        group = SQLGroup(groupname=name, description=description, canjoin=can_join.value)
+        group.add(self.session)
+
+    def get_group(self, name):
+        # type: (str) -> Optional[Group]
+        group = SQLGroup.get(self.session, name=name)
+        if not group:
+            return None
+        return Group(
+            name=group.groupname,
+            description=group.description,
+            can_join=GroupJoinPolicy(group.canjoin),
+        )

--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -16,9 +16,9 @@ class SQLGroupRepository(GroupRepository):
         # type: (Session) -> None
         self.session = session
 
-    def create_group(self, name, description, can_join):
+    def create_group(self, name, description, join_policy):
         # type: (str, str, GroupJoinPolicy) -> None
-        group = SQLGroup(groupname=name, description=description, canjoin=can_join.value)
+        group = SQLGroup(groupname=name, description=description, canjoin=join_policy.value)
         group.add(self.session)
 
     def get_group(self, name):
@@ -29,5 +29,5 @@ class SQLGroupRepository(GroupRepository):
         return Group(
             name=group.groupname,
             description=group.description,
-            can_join=GroupJoinPolicy(group.canjoin),
+            join_policy=GroupJoinPolicy(group.canjoin),
         )

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from six import with_metaclass
 
 if TYPE_CHECKING:
-    from grouper.entities.group import Group, GroupJoinPolicy
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
@@ -14,6 +13,7 @@ if TYPE_CHECKING:
     )
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.repositories.checkpoint import CheckpointRepository
+    from grouper.repositories.group import GroupRepository
     from grouper.repositories.group_request import GroupRequestRepository
     from grouper.repositories.schema import SchemaRepository
     from grouper.repositories.service_account import ServiceAccountRepository
@@ -21,20 +21,6 @@ if TYPE_CHECKING:
     from grouper.repositories.user import UserRepository
     from grouper.usecases.list_permissions import ListPermissionsSortKey
     from typing import List, Optional
-
-
-class GroupRepository(with_metaclass(ABCMeta, object)):
-    """Abstract base class for group repositories."""
-
-    @abstractmethod
-    def create_group(self, name, description, join_policy):
-        # type: (str, str, GroupJoinPolicy) -> None
-        pass
-
-    @abstractmethod
-    def get_group(self, name):
-        # type: (str) -> Optional[Group]
-        pass
 
 
 class GroupEdgeRepository(with_metaclass(ABCMeta, object)):

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from six import with_metaclass
 
 if TYPE_CHECKING:
+    from grouper.entities.group import Group, GroupJoinPolicy
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
@@ -22,6 +23,20 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
+class GroupRepository(with_metaclass(ABCMeta, object)):
+    """Abstract base class for group repositories."""
+
+    @abstractmethod
+    def create_group(self, name, description, can_join):
+        # type: (str, str, GroupJoinPolicy) -> None
+        pass
+
+    @abstractmethod
+    def get_group(self, name):
+        # type: (str) -> Optional[Group]
+        pass
+
+
 class GroupEdgeRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for group edge repositories."""
 
@@ -35,13 +50,18 @@ class PermissionRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission repositories."""
 
     @abstractmethod
-    def get_permission(self, name):
-        # type: (str) -> Optional[Permission]
+    def create_permission(self, name, description):
+        # type: (str, str) -> None
         pass
 
     @abstractmethod
     def disable_permission(self, name):
         # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def get_permission(self, name):
+        # type: (str) -> Optional[Permission]
         pass
 
     @abstractmethod
@@ -54,12 +74,17 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission grant repositories."""
 
     @abstractmethod
+    def grant_permission_to_group(self, group, permission, argument):
+        # type: (str, str, str) -> None
+        pass
+
+    @abstractmethod
     def group_grants_for_permission(self, name):
         # type: (str) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod
-    def permission_grants_for_user(self, name):
+    def permission_grants_for_user(self, user):
         # type: (str) -> List[PermissionGrant]
         pass
 
@@ -90,6 +115,11 @@ class RepositoryFactory(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def create_group_edge_repository(self):
         # type: () -> GroupEdgeRepository
+        pass
+
+    @abstractmethod
+    def create_group_repository(self):
+        # type: () -> GroupRepository
         pass
 
     @abstractmethod

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -27,7 +27,7 @@ class GroupRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for group repositories."""
 
     @abstractmethod
-    def create_group(self, name, description, can_join):
+    def create_group(self, name, description, join_policy):
         # type: (str, str, GroupJoinPolicy) -> None
         pass
 
@@ -74,7 +74,7 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission grant repositories."""
 
     @abstractmethod
-    def grant_permission_to_group(self, group, permission, argument):
+    def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
         pass
 

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_
 
+from grouper.entities.group import GroupNotFoundException
 from grouper.entities.group_edge import GROUP_EDGE_ROLES
+from grouper.entities.permission import PermissionNotFoundException
 from grouper.entities.permission_grant import (
     GroupPermissionGrant,
     PermissionGrant,
@@ -32,6 +34,10 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         # type: (GroupGraph, PermissionGrantRepository) -> None
         self.graph = graph
         self.repository = repository
+
+    def grant_permission_to_group(self, group, permission, argument):
+        # type: (str, str, str) -> None
+        self.repository.grant_permission_to_group(group, permission, argument)
 
     def group_grants_for_permission(self, name):
         # type: (str) -> List[GroupPermissionGrant]
@@ -66,6 +72,20 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
     def __init__(self, session):
         # type: (Session) -> None
         self.session = session
+
+    def grant_permission_to_group(self, group, permission, argument):
+        # type: (str, str, str) -> None
+        sql_group = Group.get(self.session, name=group)
+        if not sql_group:
+            raise GroupNotFoundException(group)
+        sql_permission = Permission.get(self.session, name=permission)
+        if not sql_permission:
+            raise PermissionNotFoundException(permission)
+
+        mapping = PermissionMap(
+            permission_id=sql_permission.id, group_id=sql_group.id, argument=argument
+        )
+        mapping.add(self.session)
 
     def group_grants_for_permission(self, name):
         # type: (str) -> List[GroupPermissionGrant]

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -35,9 +35,9 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         self.graph = graph
         self.repository = repository
 
-    def grant_permission_to_group(self, group, permission, argument):
+    def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
-        self.repository.grant_permission_to_group(group, permission, argument)
+        self.repository.grant_permission_to_group(permission, argument, group)
 
     def group_grants_for_permission(self, name):
         # type: (str) -> List[GroupPermissionGrant]
@@ -73,7 +73,7 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
         # type: (Session) -> None
         self.session = session
 
-    def grant_permission_to_group(self, group, permission, argument):
+    def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
         sql_group = Group.get(self.session, name=group)
         if not sql_group:

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -11,7 +11,6 @@ from grouper.services.user import UserService
 
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import RepositoryFactory
-    from grouper.settings import Settings
     from grouper.usecases.interfaces import (
         AuditLogInterface,
         GroupInterface,
@@ -27,9 +26,8 @@ if TYPE_CHECKING:
 class ServiceFactory(object):
     """Construct backend services."""
 
-    def __init__(self, settings, repository_factory):
-        # type: (Settings, RepositoryFactory) -> None
-        self.settings = settings
+    def __init__(self, repository_factory):
+        # type: (RepositoryFactory) -> None
         self.repository_factory = repository_factory
 
     def create_audit_log_service(self):
@@ -47,7 +45,7 @@ class ServiceFactory(object):
         # type: () -> GroupInterface
         group_repository = self.repository_factory.create_group_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
-        return GroupService(self.settings, group_repository, permission_grant_repository)
+        return GroupService(group_repository, permission_grant_repository)
 
     def create_permission_service(self):
         # type: () -> PermissionInterface

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.services.audit_log import AuditLogService
+from grouper.services.group import GroupService
 from grouper.services.group_request import GroupRequestService
 from grouper.services.permission import PermissionService
 from grouper.services.schema import SchemaService
@@ -10,8 +11,10 @@ from grouper.services.user import UserService
 
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import RepositoryFactory
+    from grouper.settings import Settings
     from grouper.usecases.interfaces import (
         AuditLogInterface,
+        GroupInterface,
         GroupRequestInterface,
         PermissionInterface,
         SchemaInterface,
@@ -24,8 +27,9 @@ if TYPE_CHECKING:
 class ServiceFactory(object):
     """Construct backend services."""
 
-    def __init__(self, repository_factory):
-        # type: (RepositoryFactory) -> None
+    def __init__(self, settings, repository_factory):
+        # type: (Settings, RepositoryFactory) -> None
+        self.settings = settings
         self.repository_factory = repository_factory
 
     def create_audit_log_service(self):
@@ -38,6 +42,12 @@ class ServiceFactory(object):
         audit_log_service = self.create_audit_log_service()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return GroupRequestService(group_request_repository, audit_log_service)
+
+    def create_group_service(self):
+        # type: () -> GroupInterface
+        group_repository = self.repository_factory.create_group_repository()
+        permission_grant_repository = self.repository_factory.create_permission_grant_repository()
+        return GroupService(self.settings, group_repository, permission_grant_repository)
 
     def create_permission_service(self):
         # type: () -> PermissionInterface

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -1,31 +1,26 @@
+import re
 from typing import TYPE_CHECKING
 
-from grouper.constants import (
-    DEFAULT_ADMIN_GROUP,
-    GROUP_ADMIN,
-    PERMISSION_ADMIN,
-    PERMISSION_AUDITOR,
-    USER_ADMIN,
-)
-from grouper.entities.group import GroupJoinPolicy
+from grouper.constants import NAME_VALIDATION
+from grouper.entities.group import GroupJoinPolicy, InvalidGroupNameException
 from grouper.usecases.interfaces import GroupInterface
 
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import GroupRepository, PermissionGrantRepository
-    from grouper.settings import Settings
 
 
 class GroupService(GroupInterface):
     """High-level logic to manipulate groups."""
 
-    def __init__(self, settings, group_repository, permission_grant_repository):
-        # type: (Settings, GroupRepository, PermissionGrantRepository) -> None
-        self.settings = settings
+    def __init__(self, group_repository, permission_grant_repository):
+        # type: (GroupRepository, PermissionGrantRepository) -> None
         self.group_repository = group_repository
         self.permission_grant_repository = permission_grant_repository
 
     def create_group(self, name, description, join_policy):
         # type: (str, str, GroupJoinPolicy) -> None
+        if not self.is_valid_group_name(name):
+            raise InvalidGroupNameException(name)
         self.group_repository.create_group(name, description, join_policy)
 
     def grant_permission_to_group(self, permission, argument, group):
@@ -36,23 +31,6 @@ class GroupService(GroupInterface):
         # type: (str) -> bool
         return True if self.group_repository.get_group(name) else False
 
-    def initialize_administrator_group(self):
-        # type: () -> None
-        if not self.group_exists(DEFAULT_ADMIN_GROUP):
-            self.create_group(
-                DEFAULT_ADMIN_GROUP, "Administrators of the Grouper system", GroupJoinPolicy.NOBODY
-            )
-            for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-                self.grant_permission_to_group(permission, "", DEFAULT_ADMIN_GROUP)
-
-    def initialize_auditors_group(self):
-        # type: () -> None
-        if not self.settings.auditors_group:
-            return
-        if not self.group_exists(self.settings.auditors_group):
-            self.create_group(
-                self.settings.auditors_group,
-                "Allows members to own groups with audited permissions",
-                GroupJoinPolicy.CAN_ASK,
-            )
-            self.grant_permission_to_group(PERMISSION_AUDITOR, "", self.settings.auditors_group)
+    def is_valid_group_name(self, name):
+        # type: (str) -> bool
+        return re.match("^{}$".format(NAME_VALIDATION), name) is not None

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -6,7 +6,8 @@ from grouper.entities.group import GroupJoinPolicy, InvalidGroupNameException
 from grouper.usecases.interfaces import GroupInterface
 
 if TYPE_CHECKING:
-    from grouper.repositories.interfaces import GroupRepository, PermissionGrantRepository
+    from grouper.repositories.group import GroupRepository
+    from grouper.repositories.interfaces import PermissionGrantRepository
 
 
 class GroupService(GroupInterface):

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -24,6 +24,14 @@ class GroupService(GroupInterface):
         self.group_repository = group_repository
         self.permission_grant_repository = permission_grant_repository
 
+    def create_group(self, name, description, join_policy):
+        # type: (str, str, GroupJoinPolicy) -> None
+        self.group_repository.create_group(name, description, join_policy)
+
+    def grant_permission_to_group(self, permission, argument, group):
+        # type: (str, str, str) -> None
+        self.permission_grant_repository.grant_permission_to_group(permission, argument, group)
+
     def group_exists(self, name):
         # type: (str) -> bool
         return True if self.group_repository.get_group(name) else False
@@ -31,24 +39,20 @@ class GroupService(GroupInterface):
     def initialize_administrator_group(self):
         # type: () -> None
         if not self.group_exists(DEFAULT_ADMIN_GROUP):
-            self.group_repository.create_group(
+            self.create_group(
                 DEFAULT_ADMIN_GROUP, "Administrators of the Grouper system", GroupJoinPolicy.NOBODY
             )
             for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
-                self.permission_grant_repository.grant_permission_to_group(
-                    DEFAULT_ADMIN_GROUP, permission, ""
-                )
+                self.grant_permission_to_group(permission, "", DEFAULT_ADMIN_GROUP)
 
     def initialize_auditors_group(self):
         # type: () -> None
         if not self.settings.auditors_group:
             return
         if not self.group_exists(self.settings.auditors_group):
-            self.group_repository.create_group(
+            self.create_group(
                 self.settings.auditors_group,
                 "Allows members to own groups with audited permissions",
                 GroupJoinPolicy.CAN_ASK,
             )
-            self.permission_grant_repository.grant_permission_to_group(
-                self.settings.auditors_group, PERMISSION_AUDITOR, ""
-            )
+            self.grant_permission_to_group(PERMISSION_AUDITOR, "", self.settings.auditors_group)

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import (
+    DEFAULT_ADMIN_GROUP,
+    GROUP_ADMIN,
+    PERMISSION_ADMIN,
+    PERMISSION_AUDITOR,
+    USER_ADMIN,
+)
+from grouper.entities.group import GroupJoinPolicy
+from grouper.usecases.interfaces import GroupInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.interfaces import GroupRepository, PermissionGrantRepository
+    from grouper.settings import Settings
+
+
+class GroupService(GroupInterface):
+    """High-level logic to manipulate groups."""
+
+    def __init__(self, settings, group_repository, permission_grant_repository):
+        # type: (Settings, GroupRepository, PermissionGrantRepository) -> None
+        self.settings = settings
+        self.group_repository = group_repository
+        self.permission_grant_repository = permission_grant_repository
+
+    def group_exists(self, name):
+        # type: (str) -> bool
+        return True if self.group_repository.get_group(name) else False
+
+    def initialize_administrator_group(self):
+        # type: () -> None
+        if not self.group_exists(DEFAULT_ADMIN_GROUP):
+            self.group_repository.create_group(
+                DEFAULT_ADMIN_GROUP, "Administrators of the Grouper system", GroupJoinPolicy.NOBODY
+            )
+            for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
+                self.permission_grant_repository.grant_permission_to_group(
+                    DEFAULT_ADMIN_GROUP, permission, ""
+                )
+
+    def initialize_auditors_group(self):
+        # type: () -> None
+        if not self.settings.auditors_group:
+            return
+        if not self.group_exists(self.settings.auditors_group):
+            self.group_repository.create_group(
+                self.settings.auditors_group,
+                "Allows members to own groups with audited permissions",
+                GroupJoinPolicy.CAN_ASK,
+            )
+            self.permission_grant_repository.grant_permission_to_group(
+                self.settings.auditors_group, PERMISSION_AUDITOR, ""
+            )

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -27,6 +27,16 @@ class PermissionService(PermissionInterface):
         self.permission_repository = permission_repository
         self.permission_grant_repository = permission_grant_repository
 
+    def create_permission(self, name, description=""):
+        # type: (str, str) -> None
+        self.permission_repository.create_permission(name, description)
+
+    def create_system_permissions(self):
+        # type: () -> None
+        for name, description in SYSTEM_PERMISSIONS:
+            if not self.permission_exists(name):
+                self.create_permission(name, description)
+
     def disable_permission(self, name, authorization):
         # type: (str, Authorization) -> None
         self.permission_repository.disable_permission(name)

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -8,6 +8,7 @@ from grouper.usecases.view_permission import ViewPermission
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from grouper.settings import Settings
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.list_permissions import ListPermissionsUI
@@ -17,8 +18,9 @@ if TYPE_CHECKING:
 class UseCaseFactory(object):
     """Create use cases with dependency injection."""
 
-    def __init__(self, service_factory):
-        # type: (Session) -> None
+    def __init__(self, settings, service_factory):
+        # type: (Settings, Session) -> None
+        self.settings = settings
         self.service_factory = service_factory
 
     def create_convert_user_to_service_account_usecase(self, actor, ui):
@@ -56,7 +58,7 @@ class UseCaseFactory(object):
         permission_service = self.service_factory.create_permission_service()
         transaction_service = self.service_factory.create_transaction_service()
         return InitializeSchema(
-            schema_service, group_service, permission_service, transaction_service
+            self.settings, schema_service, group_service, permission_service, transaction_service
         )
 
     def create_view_permission_usecase(self, ui):

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -52,7 +52,12 @@ class UseCaseFactory(object):
     def create_initialize_schema_usecase(self):
         # type: () -> InitializeSchema
         schema_service = self.service_factory.create_schema_service()
-        return InitializeSchema(schema_service)
+        group_service = self.service_factory.create_group_service()
+        permission_service = self.service_factory.create_permission_service()
+        transaction_service = self.service_factory.create_transaction_service()
+        return InitializeSchema(
+            schema_service, group_service, permission_service, transaction_service
+        )
 
     def create_view_permission_usecase(self, ui):
         # type: (ViewPermissionUI) -> ViewPermission

--- a/grouper/usecases/initialize_schema.py
+++ b/grouper/usecases/initialize_schema.py
@@ -1,6 +1,16 @@
 from typing import TYPE_CHECKING
 
+from grouper.constants import (
+    DEFAULT_ADMIN_GROUP,
+    GROUP_ADMIN,
+    PERMISSION_ADMIN,
+    PERMISSION_AUDITOR,
+    USER_ADMIN,
+)
+from grouper.entities.group import GroupJoinPolicy
+
 if TYPE_CHECKING:
+    from grouper.settings import Settings
     from grouper.usecases.interfaces import GroupInterface
     from grouper.usecases.interfaces import PermissionInterface
     from grouper.usecases.interfaces import SchemaInterface
@@ -12,12 +22,14 @@ class InitializeSchema(object):
 
     def __init__(
         self,
+        settings,  # type: Settings
         schema_service,  # type: SchemaInterface
         group_service,  # type: GroupInterface
         permission_service,  # type: PermissionInterface
         transaction_service,  # type: TransactionInterface
     ):
         # type: (...) -> None
+        self.settings = settings
         self.schema_service = schema_service
         self.group_service = group_service
         self.permission_service = permission_service
@@ -28,5 +40,23 @@ class InitializeSchema(object):
         self.schema_service.initialize_schema()
         with self.transaction_service.transaction():
             self.permission_service.create_system_permissions()
-            self.group_service.initialize_administrator_group()
-            self.group_service.initialize_auditors_group()
+            if not self.group_service.group_exists(DEFAULT_ADMIN_GROUP):
+                self.group_service.create_group(
+                    DEFAULT_ADMIN_GROUP,
+                    "Administrators of the Grouper system",
+                    GroupJoinPolicy.NOBODY,
+                )
+                for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
+                    self.group_service.grant_permission_to_group(
+                        permission, "", DEFAULT_ADMIN_GROUP
+                    )
+            if self.settings.auditors_group:
+                if not self.group_service.group_exists(self.settings.auditors_group):
+                    self.group_service.create_group(
+                        self.settings.auditors_group,
+                        "Allows members to own groups with audited permissions",
+                        GroupJoinPolicy.CAN_ASK,
+                    )
+                self.group_service.grant_permission_to_group(
+                    PERMISSION_AUDITOR, "", self.settings.auditors_group
+                )

--- a/grouper/usecases/initialize_schema.py
+++ b/grouper/usecases/initialize_schema.py
@@ -1,16 +1,32 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from grouper.usecases.interfaces import GroupInterface
+    from grouper.usecases.interfaces import PermissionInterface
     from grouper.usecases.interfaces import SchemaInterface
+    from grouper.usecases.interfaces import TransactionInterface
 
 
 class InitializeSchema(object):
     """Initialize the schema for a fresh database."""
 
-    def __init__(self, schema_service):
-        # type: (SchemaInterface) -> None
+    def __init__(
+        self,
+        schema_service,  # type: SchemaInterface
+        group_service,  # type: GroupInterface
+        permission_service,  # type: PermissionInterface
+        transaction_service,  # type: TransactionInterface
+    ):
+        # type: (...) -> None
         self.schema_service = schema_service
+        self.group_service = group_service
+        self.permission_service = permission_service
+        self.transaction_service = transaction_service
 
     def initialize_schema(self):
         # type: () -> None
         self.schema_service.initialize_schema()
+        with self.transaction_service.transaction():
+            self.permission_service.create_system_permissions()
+            self.group_service.initialize_administrator_group()
+            self.group_service.initialize_auditors_group()

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -76,6 +76,25 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
         pass
 
 
+class GroupInterface(with_metaclass(ABCMeta, object)):
+    """Abstract base class for group operations and queries."""
+
+    @abstractmethod
+    def group_exists(self, name):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def initialize_administrator_group(self):
+        # type: () -> None
+        pass
+
+    @abstractmethod
+    def initialize_auditors_group(self):
+        # type: () -> None
+        pass
+
+
 class GroupRequestInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for requests for group membership."""
 
@@ -87,6 +106,16 @@ class GroupRequestInterface(with_metaclass(ABCMeta, object)):
 
 class PermissionInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission operations and queries."""
+
+    @abstractmethod
+    def create_permission(self, name, description=""):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def create_system_permissions(self):
+        # type: () -> None
+        pass
 
     @abstractmethod
     def disable_permission(self, name, authorization):

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -19,6 +19,7 @@ from six import with_metaclass
 if TYPE_CHECKING:
     from datetime import datetime
     from grouper.entities.audit_log_entry import AuditLogEntry
+    from grouper.entities.group import GroupJoinPolicy
     from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission, PermissionAccess
@@ -78,6 +79,16 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
 
 class GroupInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for group operations and queries."""
+
+    @abstractmethod
+    def create_group(self, name, description, join_policy):
+        # type: (str, str, GroupJoinPolicy) -> None
+        pass
+
+    @abstractmethod
+    def grant_permission_to_group(self, permission, argument, group):
+        # type: (str, str, str) -> None
+        pass
 
     @abstractmethod
     def group_exists(self, name):

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -96,13 +96,8 @@ class GroupInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def initialize_administrator_group(self):
-        # type: () -> None
-        pass
-
-    @abstractmethod
-    def initialize_auditors_group(self):
-        # type: () -> None
+    def is_valid_group_name(self, name):
+        # type: (str) -> bool
         pass
 
 

--- a/tests/services/group_test.py
+++ b/tests/services/group_test.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grouper.constants import DEFAULT_ADMIN_GROUP, ILLEGAL_NAME_CHARACTER
+from grouper.entities.group import GroupJoinPolicy, InvalidGroupNameException
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_invalid_group_name(setup):
+    # type: (SetupTest) -> None
+    group_service = setup.service_factory.create_group_service()
+    assert group_service.is_valid_group_name(DEFAULT_ADMIN_GROUP)
+    assert not group_service.is_valid_group_name("group name")
+    assert not group_service.is_valid_group_name("group{}name".format(ILLEGAL_NAME_CHARACTER))
+    with pytest.raises(InvalidGroupNameException):
+        group_service.create_group("group name", "", GroupJoinPolicy.NOBODY)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -88,8 +88,8 @@ class SetupTest(object):
         self.repository_factory = GraphRepositoryFactory(
             self.settings, PluginProxy([]), SingletonSessionFactory(self.session), self.graph
         )
-        self.service_factory = ServiceFactory(self.settings, self.repository_factory)
-        self.usecase_factory = UseCaseFactory(self.service_factory)
+        self.service_factory = ServiceFactory(self.repository_factory)
+        self.usecase_factory = UseCaseFactory(self.settings, self.service_factory)
         self._transaction_service = self.service_factory.create_transaction_service()
 
     def initialize_database(self):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -88,7 +88,7 @@ class SetupTest(object):
         self.repository_factory = GraphRepositoryFactory(
             self.settings, PluginProxy([]), SingletonSessionFactory(self.session), self.graph
         )
-        self.service_factory = ServiceFactory(self.repository_factory)
+        self.service_factory = ServiceFactory(self.settings, self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.service_factory)
         self._transaction_service = self.service_factory.create_transaction_service()
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -26,13 +26,13 @@ from datetime import datetime
 from time import time
 from typing import TYPE_CHECKING
 
+from grouper.entities.group import GroupJoinPolicy
 from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
 from grouper.models.group_edge import GroupEdge
 from grouper.models.permission import Permission
-from grouper.models.permission_map import PermissionMap
 from grouper.models.service_account import ServiceAccount
 from grouper.models.service_account_permission_map import ServiceAccountPermissionMap
 from grouper.models.user import User
@@ -114,13 +114,12 @@ class SetupTest(object):
             yield
         self.graph.update_from_db(self.session)
 
-    def create_group(self, name):
-        # type: (str) -> None
+    def create_group(self, name, description="", join_policy=GroupJoinPolicy.CAN_ASK):
+        # type: (str, str, GroupJoinPolicy) -> None
         """Create a group, does nothing if it already exists."""
-        if Group.get(self.session, name=name):
-            return
-        group = Group(groupname=name)
-        group.add(self.session)
+        group_service = self.service_factory.create_group_service()
+        if not group_service.group_exists(name):
+            group_service.create_group(name, description, join_policy)
 
     def create_permission(
         self, name, description="", audited=False, enabled=True, created_on=None
@@ -190,14 +189,8 @@ class SetupTest(object):
         # type: (str, str, str) -> None
         self.create_group(group)
         self.create_permission(permission)
-        permission_obj = Permission.get(self.session, name=permission)
-        assert permission_obj
-        group_obj = Group.get(self.session, name=group)
-        assert group_obj
-        grant = PermissionMap(
-            permission_id=permission_obj.id, group_id=group_obj.id, argument=argument
-        )
-        grant.add(self.session)
+        group_service = self.service_factory.create_group_service()
+        group_service.grant_permission_to_group(permission, argument, group)
 
     def create_group_request(self, user, group, role="member"):
         # type: (str, str, str) -> None

--- a/tests/usecases/initialize_schema_test.py
+++ b/tests/usecases/initialize_schema_test.py
@@ -8,17 +8,16 @@ from grouper.constants import (
     USER_ADMIN,
 )
 from grouper.models.group import Group
-from grouper.settings import Settings
-from tests.ctl_util import run_ctl
-from tests.path_util import src_path
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest
 
 
-def test_sync_db(setup):
+def test_initialize_schema(setup):
     # type: (SetupTest) -> None
-    run_ctl(setup, "sync_db")
+    setup.settings.auditors_group = "auditors"
+    usecase = setup.usecase_factory.create_initialize_schema_usecase()
+    usecase.initialize_schema()
 
     # System permissions should be created.
     permission_service = setup.service_factory.create_permission_service()
@@ -32,14 +31,8 @@ def test_sync_db(setup):
     for permission in (GROUP_ADMIN, PERMISSION_ADMIN, USER_ADMIN):
         assert permission in admin_group_permissions
 
-    # We reuse config/dev.yaml when testing, but someone may have changed the auditors_group
-    # setting there.  Figure out the current setting.
-    dev_settings = Settings()
-    dev_settings.update_from_config(src_path("config", "dev.yaml"))
-
     # The auditors group should exist and have the auditor permission.
-    if dev_settings.auditors_group:
-        auditors_group = Group.get(setup.session, name=dev_settings.auditors_group)
-        assert auditors_group
-        auditors_group_permissions = [p.name for p in auditors_group.my_permissions()]
-        assert PERMISSION_AUDITOR in auditors_group_permissions
+    auditors_group = Group.get(setup.session, name="auditors")
+    assert auditors_group
+    auditors_group_permissions = [p.name for p in auditors_group.my_permissions()]
+    assert PERMISSION_AUDITOR in auditors_group_permissions


### PR DESCRIPTION
The InitializeSchema usecase now does all of the work of sync_db,
including creating the administrator and auditors groups and the
system permissions.  This required creating a GroupService and
plumbing Settings through to ServiceFactory.
