### PR TITLE
Move GROUP_EDGE_ROLES constants

### DIFF
--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -17,10 +17,11 @@ from grouper.email_util import (
     notify_nonauditor_promoted,
     process_async_emails,
 )
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES
 from grouper.graph import Graph
 from grouper.models.base.session import Session
 from grouper.models.group import Group
-from grouper.models.group_edge import APPROVER_ROLE_INDICES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.user import User
 from grouper.perf_profile import prune_old_traces
 

--- a/grouper/entities/group_edge.py
+++ b/grouper/entities/group_edge.py
@@ -1,0 +1,20 @@
+# TODO(rra): This should be an enum, but quite a lot of code currently uses it as a lookup table by
+# index, using the index as the database representation of the role.  THE ORDER IS SIGNIFICANT,
+# since it determines the database representation.  Any new role MUST be added to the end, and
+# added to relevant tests.
+GROUP_EDGE_ROLES = (
+    "member",  # Belongs to the group. Nothing more.
+    "manager",  # Make changes to the group / Approve requests.
+    "owner",  # Same as manager plus enable/disable group and make Users owner.
+    "np-owner",  # Same as owner but don't inherit permissions.
+)
+
+# Numeric indices into GROUP_EDGE_ROLES that can act as group owner.
+OWNER_ROLE_INDICES = {GROUP_EDGE_ROLES.index("owner"), GROUP_EDGE_ROLES.index("np-owner")}
+
+# Numeric indices into GROUP_EDGE_ROLES that can approve membership requests.
+APPROVER_ROLE_INDICES = {
+    GROUP_EDGE_ROLES.index("owner"),
+    GROUP_EDGE_ROLES.index("np-owner"),
+    GROUP_EDGE_ROLES.index("manager"),
+}

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -15,7 +15,7 @@ from wtforms.validators import ValidationError
 from wtforms_tornado import Form
 
 from grouper import constants
-from grouper.models.group_edge import GROUP_EDGE_ROLES
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 
 GROUP_CANJOIN_CHOICES = [("canjoin", "Anyone"), ("canask", "Must Ask"), ("nobody", "Nobody")]
 

--- a/grouper/fe/handlers/audits_create.py
+++ b/grouper/fe/handlers/audits_create.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 
 from grouper.constants import AUDIT_MANAGER
 from grouper.email_util import send_async_email, send_email
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.fe.forms import AuditCreateForm
 from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
@@ -13,7 +14,6 @@ from grouper.models.audit import Audit
 from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.models.audit_member import AuditMember
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES
 from grouper.user_permissions import user_has_permission
 
 if TYPE_CHECKING:

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -3,12 +3,12 @@ from typing import TYPE_CHECKING
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES, GROUP_EDGE_ROLES
 from grouper.fe.forms import GroupJoinForm
 from grouper.fe.settings import settings
 from grouper.fe.util import Alert, GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group, GROUP_JOIN_CHOICES
-from grouper.models.group_edge import APPROVER_ROLE_INDICES, GROUP_EDGE_ROLES
 from grouper.models.user import User
 from grouper.user_group import get_groups_by_user
 

--- a/grouper/fe/handlers/group_requests.py
+++ b/grouper/fe/handlers/group_requests.py
@@ -1,8 +1,8 @@
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.fe.util import GrouperHandler
 from grouper.group_requests import get_requests_by_group
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.group import Group
-from grouper.models.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.models.request import Request
 from grouper.user import user_role, user_role_index
 

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 
 from grouper.constants import USER_METADATA_SHELL_KEY
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.fe.util import Alert
 from grouper.graph import NoSuchGroup, NoSuchUser
 from grouper.group_requests import count_requests_by_group
 from grouper.group_service_account import get_service_accounts
 from grouper.models.audit_member import AUDIT_STATUS_CHOICES
-from grouper.models.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.permissions import get_owner_arg_list, get_pending_request_by_group, get_requests
 from grouper.public_key import get_public_keys_of_user
 from grouper.role_user import can_manage_role_user

--- a/grouper/fe/template_util.py
+++ b/grouper/fe/template_util.py
@@ -5,7 +5,9 @@ from dateutil.relativedelta import relativedelta
 from jinja2 import Environment, PackageLoader, select_autoescape
 from pytz import UTC
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.fe.settings import settings
+from grouper.models.base.constants import OBJ_TYPES_IDX
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Dict, Optional
@@ -95,11 +97,6 @@ def get_template_env(
     extra_globals=None,  # type: Optional[Dict[str, Any]]
 ):
     # type: (...) -> Environment
-    # TODO(herb): get around circular depdendencies; long term remove call to
-    # send_async_email() from grouper.models
-    from grouper.models.base.constants import OBJ_TYPES_IDX
-    from grouper.models.group_edge import GROUP_EDGE_ROLES
-
     filters = {
         "print_date": print_date,
         "expires_when_str": expires_when_str,

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -10,9 +10,10 @@ from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import label, literal
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.counter import Counter
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.permission import MappedPermission, Permission
 from grouper.models.permission_map import PermissionMap

--- a/grouper/group_member.py
+++ b/grouper/group_member.py
@@ -3,10 +3,11 @@ from typing import TYPE_CHECKING
 
 from six import iteritems
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.comment import Comment
 from grouper.models.counter import Counter
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.request import Request
 from grouper.models.request_status_change import RequestStatusChange
 from grouper.plugin import get_plugin_proxy

--- a/grouper/models/group.py
+++ b/grouper/models/group.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm.util import aliased
 from sqlalchemy.sql import label, literal
 
 from grouper.constants import MAX_NAME_LENGTH
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.group_member import persist_group_member_changes
 from grouper.models.audit import Audit
 from grouper.models.audit_log import AuditLog
@@ -20,7 +21,7 @@ from grouper.models.base.model_base import Model
 from grouper.models.base.session import flush_transaction
 from grouper.models.comment import CommentObjectMixin
 from grouper.models.counter import Counter
-from grouper.models.group_edge import APPROVER_ROLE_INDICES, GroupEdge, OWNER_ROLE_INDICES
+from grouper.models.group_edge import GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.user import User

--- a/grouper/models/group_edge.py
+++ b/grouper/models/group_edge.py
@@ -5,6 +5,7 @@ from six import iteritems
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, SmallInteger
 from sqlalchemy.orm import relationship
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES, OWNER_ROLE_INDICES
 from grouper.expiration import add_expiration, cancel_expiration
 from grouper.models.base.constants import OBJ_TYPES_IDX
 from grouper.models.base.model_base import Model
@@ -12,23 +13,6 @@ from grouper.models.user import User
 
 if TYPE_CHECKING:
     from typing import Any, Dict
-
-# Note: the order of the GROUP_EDGE_ROLES tuple matters! New roles must be
-# appended!  When adding a new role, be sure to update the regression test.
-GROUP_EDGE_ROLES = (
-    "member",  # Belongs to the group. Nothing more.
-    "manager",  # Make changes to the group / Approve requests.
-    "owner",  # Same as manager plus enable/disable group and make Users owner.
-    "np-owner",  # Same as owner but don't inherit permissions.
-)
-
-OWNER_ROLE_INDICES = {GROUP_EDGE_ROLES.index("owner"), GROUP_EDGE_ROLES.index("np-owner")}
-
-APPROVER_ROLE_INDICES = {
-    GROUP_EDGE_ROLES.index("owner"),
-    GROUP_EDGE_ROLES.index("np-owner"),
-    GROUP_EDGE_ROLES.index("manager"),
-}
 
 
 class GroupEdge(Model):

--- a/grouper/repositories/group_edge.py
+++ b/grouper/repositories/group_edge.py
@@ -3,9 +3,10 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.user import User
 from grouper.repositories.interfaces import GroupEdgeRepository
 

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import or_
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.entities.permission_grant import (
     GroupPermissionGrant,
     PermissionGrant,
@@ -10,7 +11,7 @@ from grouper.entities.permission_grant import (
 )
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.service_account import ServiceAccount

--- a/grouper/user.py
+++ b/grouper/user.py
@@ -4,17 +4,13 @@ from typing import TYPE_CHECKING
 from sqlalchemy import or_
 from sqlalchemy.sql import label, literal
 
+from grouper.entities.group_edge import APPROVER_ROLE_INDICES, GROUP_EDGE_ROLES, OWNER_ROLE_INDICES
 from grouper.models.audit import Audit
 from grouper.models.audit_log import AuditLog
 from grouper.models.comment import Comment
 from grouper.models.counter import Counter
 from grouper.models.group import Group
-from grouper.models.group_edge import (
-    APPROVER_ROLE_INDICES,
-    GROUP_EDGE_ROLES,
-    GroupEdge,
-    OWNER_ROLE_INDICES,
-)
+from grouper.models.group_edge import GroupEdge
 from grouper.models.request import Request
 from grouper.models.request_status_change import RequestStatusChange
 from grouper.models.user import User

--- a/plugins/group_ownership_policy.py
+++ b/plugins/group_ownership_policy.py
@@ -1,8 +1,9 @@
 from sqlalchemy.sql import label
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES, OWNER_ROLE_INDICES
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge, OWNER_ROLE_INDICES
+from grouper.models.group_edge import GroupEdge
 from grouper.models.user import User
 from grouper.plugin.base import BasePlugin
 from grouper.plugin.exceptions import (

--- a/tests/ctl/group_test.py
+++ b/tests/ctl/group_test.py
@@ -3,9 +3,9 @@ from datetime import date, timedelta
 
 from mock import patch
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES
 from grouper.plugin.proxy import PluginProxy
 from plugins.group_ownership_policy import GroupOwnershipPolicyPlugin
 from tests.ctl_util import call_main

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,5 +1,5 @@
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES
 from grouper.permissions import get_groups_by_permission, get_permission
 from tests.fixtures import (  # noqa: F401
     graph,

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -26,10 +26,11 @@ from datetime import datetime
 from time import time
 from typing import TYPE_CHECKING
 
+from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
-from grouper.models.group_edge import GROUP_EDGE_ROLES, GroupEdge
+from grouper.models.group_edge import GroupEdge
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.service_account import ServiceAccount


### PR DESCRIPTION
To avoid circular dependencies between the models and other code,
move GROUP_EDGE_ROLES and related constants to grouper.entities.
These constants are still poorly-structured and need further work,
but that's a major refactoring, so defer that for later.

Move another deferred import in get_template_env that doesn't
create a circular dependency and therefore can be a normal import.