### PR TITLE
Use configuration settings for user_proxy auth header

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -111,6 +111,14 @@ common:
     # Type: str
     url: "http://127.0.0.1:8888"
 
+    # Header that contains the authenticated username of a Grouper user to
+    # the frontend server. This must be provided by an upstream web proxy
+    # that does authentication. Grouper itself has no mechanism to
+    # authenticate users.
+    #
+    # Type: str
+    user_auth_header: "X-Grouper-User"
+
 api:
     # The IP address to listen to requests on, or leave empty to listen to all
     # addresses.
@@ -242,10 +250,3 @@ fe:
     #
     # Type: List[Dict[str, str]]
     site_docs: []
-
-    # Header that contains the authenticated username of a Grouper user. This
-    # must be provided by an upstream web proxy that does authentication.
-    # Grouper itself has no mechanism to authenticate users.
-    #
-    # Type: str
-    user_auth_header: "X-Grouper-User"

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -72,4 +72,4 @@ class CtlCommandFactory(object):
 
     def construct_user_proxy_command(self):
         # type: () -> UserProxyCommand
-        return UserProxyCommand()
+        return UserProxyCommand(self.settings)

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -36,7 +36,6 @@ class FrontendSettings(Settings):
             [["/bin/false", "Shell support in Grouper has not been setup by the administrator"]],
         )
         self.site_docs = []  # type: List[Dict[str, str]]
-        self.user_auth_header = "X-Grouper-User"
 
     def update_from_config(self, filename=None, section="fe"):
         # type: (Optional[str], Optional[str]) -> None

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -88,6 +88,7 @@ class Settings(object):
         self.service_account_email_domain = "svc.localhost"
         self.timezone = "UTC"
         self.url = "http://127.0.0.1:8888"
+        self.user_auth_header = "X-Grouper-User"
 
     @property
     def database(self):


### PR DESCRIPTION
grouper-ctl user_proxy was hardcoding the default value of the
authentication header, and therefore wouldn't work if it were
changed in the configuration.  Instead, pass the configuration
down into the user proxy code and get the authentication header
value from there.

This requires moving the authentication header from the fe section
to the general section of the configuration.