### PR TITLE
Default to listening to the network in API and frontend

### DIFF
--- a/grouper/api/settings.py
+++ b/grouper/api/settings.py
@@ -23,7 +23,7 @@ class ApiSettings(Settings):
         super(ApiSettings, self).__init__()
 
         # Keep attributes here in the same order as in config/dev.yaml.
-        self.address = "127.0.0.1"
+        self.address = None  # type: Optional[str]
         self.debug = False
         self.num_processes = 1
         self.port = 8990

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -23,7 +23,7 @@ class FrontendSettings(Settings):
         super(FrontendSettings, self).__init__()
 
         # Keep attributes here in the same order as in config/dev.yaml.
-        self.address = "127.0.0.1"
+        self.address = None  # type: Optional[str]
         self.port = 8989
         self.cdnjs_prefix = "//cdnjs.cloudflare.com"
         self.debug = False


### PR DESCRIPTION
The settings refactor accidentally changed the default to listen
to localhost.  Restore the previous default of listening to the
network.