### PR TITLE
Update sshpubkeys to 3.1.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-dateutil==2.4.2
 pytz==2017.2
 setuptools==40.8.0
 six==1.12.0
-sshpubkeys==2.2.0
+sshpubkeys==3.1.0
 tornado==4.5.3
 typing==3.6.4
 wtforms-tornado==0.0.2


### PR DESCRIPTION
The API of sshpubkeys 2 is supposed to be the same as version 3. DSA key lengths are more strictly enforced, but I don't think Grouper cares about that.