### PR TITLE
Use SRI for all external JavaScript and CSS

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -196,7 +196,7 @@ fe:
     # prefer.
     #
     # Type: str
-    cdnjs_prefix: "//cdnjs.cloudflare.com"
+    cdnjs_prefix: "https://cdnjs.cloudflare.com"
 
     # Passing debug option down Tornado. Useful for development to automatically
     # reload code.

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -4,24 +4,14 @@
 
         <title>Grouper{% block subtitle %}{% endblock %}</title>
 
-        <link href="{{cdnjs_prefix}}/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css"
+        {% for resource in external_css %}
+        <link href="{{cdnjs_prefix}}{{resource.url}}"
+              integrity="{{resource.integrity}}"
+              crossorigin="anonymous"
               rel="stylesheet"
               media="screen">
-        <link href="{{cdnjs_prefix}}/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css"
-              rel="stylesheet"
-              media="screen">
-        <link href="{{cdnjs_prefix}}/ajax/libs/bootstrap-datetimepicker/3.0.0/css/bootstrap-datetimepicker.min.css"
-              rel="stylesheet"
-              media="screen">
-        <link href="{{cdnjs_prefix}}/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css"
-              rel="stylesheet"
-              media="screen">
-        {# chosen.css covers the basic Chosen UI; chosen.bootstrap.min.css adds the
-           extra classes to make it look compatible with Bootstrap. Both are required.  #}
-        <link href="{{cdnjs_prefix}}/ajax/libs/chosen/1.4.2/chosen.css"
-              rel="stylesheet"
-              media="screen">
-        <link href="/static/css/ext/chosen-bootstrap-1.0.4/chosen.bootstrap.min.css"
+        {% endfor %}
+        <link href="{{ static_url("css/ext/chosen-bootstrap-1.0.4/chosen.bootstrap.min.css") }}"
               rel="stylesheet"
               media="screen">
         <link href="{{ static_url("css/grouper.css") }}" rel="stylesheet" media="screen">

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -13,7 +13,7 @@
         <link href="{{cdnjs_prefix}}/ajax/libs/bootstrap-datetimepicker/3.0.0/css/bootstrap-datetimepicker.min.css"
               rel="stylesheet"
               media="screen">
-        <link href="/{{cdnjs_prefix}}/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css"
+        <link href="{{cdnjs_prefix}}/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css"
               rel="stylesheet"
               media="screen">
         {# chosen.css covers the basic Chosen UI; chosen.bootstrap.min.css adds the

--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -103,13 +103,11 @@
           </div>
         </footer>
 
-        <script src="{{cdnjs_prefix}}/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/lodash.js/2.4.1/lodash.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/moment.js/2.7.0/moment.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/bootstrap-datetimepicker/3.0.0/js/bootstrap-datetimepicker.min.js"></script>
-        <script src="{{cdnjs_prefix}}/ajax/libs/chosen/1.4.2/chosen.jquery.min.js"></script>
+        {% for resource in external_js %}
+        <script src="{{cdnjs_prefix}}{{resource.url}}"
+                integrity="{{resource.integrity}}"
+                crossorigin="anonymous"></script>
+        {% endfor %}
         <script src="{{ static_url("js/grouper.js") }}"></script>
     </body>
 </html>

--- a/grouper/fe/templating.py
+++ b/grouper/fe/templating.py
@@ -8,6 +8,30 @@ if TYPE_CHECKING:
 # An external web resource with SRI.
 ExternalResource = NamedTuple("ExternalResource", [("url", str), ("integrity", str)])
 
+# External CSS loaded on every Grouper page.  All URLs are relative to a CDNJS mirror.
+EXTERNAL_CSS = [
+    ExternalResource(
+        url="/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css",
+        integrity="sha256-6VA0SGkrc43SYPvX98q/LhHwm2APqX5us6Vuulsafps=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css",
+        integrity="sha256-t2kyTgkh+fZJYRET5l9Sjrrl4UDain5jxdbqe8ejO8A=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/bootstrap-datetimepicker/3.0.0/css/bootstrap-datetimepicker.min.css",
+        integrity="sha256-Ov0GCM7wZ2/frH8veSLcBKbKthwLhC5WasvbBuJ2okc=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css",
+        integrity="sha256-z84A8SU1XXNN76l7Y+r65zvMYxgGD4v5wqg90I24Prw=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/chosen/1.4.2/chosen.min.css",
+        integrity="sha256-VGpryMO0mXR1A03airrHc3/J1YldD3xKadKpXXktWY8=",
+    ),
+]
+
 # External JavaScript loaded on every Grouper page.  All URLs are relative to a CDNJS mirror.
 EXTERNAL_JS = [
     ExternalResource(
@@ -50,6 +74,7 @@ class FrontendTemplateEngine(BaseTemplateEngine):
         template_globals = {
             "cdnjs_prefix": settings.cdnjs_prefix,
             "deployment_name": deployment_name,
+            "external_css": EXTERNAL_CSS,
             "external_js": EXTERNAL_JS,
         }
         self.environment.globals.update(template_globals)

--- a/grouper/fe/templating.py
+++ b/grouper/fe/templating.py
@@ -1,9 +1,44 @@
-from typing import TYPE_CHECKING
+from typing import NamedTuple, TYPE_CHECKING
 
 from grouper.templating import BaseTemplateEngine
 
 if TYPE_CHECKING:
     from grouper.fe.settings import FrontendSettings
+
+# An external web resource with SRI.
+ExternalResource = NamedTuple("ExternalResource", [("url", str), ("integrity", str)])
+
+# External JavaScript loaded on every Grouper page.  All URLs are relative to a CDNJS mirror.
+EXTERNAL_JS = [
+    ExternalResource(
+        url="/ajax/libs/jquery/2.1.1/jquery.min.js",
+        integrity="sha256-wNQJi8izTG+Ho9dyOYiugSFKU6C7Sh1NNqZ2QPmO0Hk=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/lodash.js/2.4.1/lodash.min.js",
+        integrity="sha256-gOpnA1vUitDpr6qV2ONTzFxXQKgnwvBCOklJH6hHqyE=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js",
+        integrity="sha256-iY0FoX8s/FEg3c26R6iFw3jAtGbzDwcA5QJ1fiS0A6E=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/moment.js/2.7.0/moment.min.js",
+        integrity="sha256-FQODX4G5IRIuYRmkc+gFKbr7DXrrqFrPjZkLVJSDQZQ=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js",
+        integrity="sha256-YKbJo9/cZwgjue3I4jsFKdE+oGkrSpqZz6voxlmn2Fo=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/bootstrap-datetimepicker/3.0.0/js/bootstrap-datetimepicker.min.js",
+        integrity="sha256-8e6Htoin9PzZslStDJ7tnwZa9lIIaXCQy2sDOA2P6WI=",
+    ),
+    ExternalResource(
+        url="/ajax/libs/chosen/1.4.2/chosen.jquery.min.js",
+        integrity="sha256-nOTrbQXdTPaimxT0mqnbsQGNDis1wmMPxII8apvxt3I=",
+    ),
+]
 
 
 class FrontendTemplateEngine(BaseTemplateEngine):
@@ -15,5 +50,6 @@ class FrontendTemplateEngine(BaseTemplateEngine):
         template_globals = {
             "cdnjs_prefix": settings.cdnjs_prefix,
             "deployment_name": deployment_name,
+            "external_js": EXTERNAL_JS,
         }
         self.environment.globals.update(template_globals)


### PR DESCRIPTION
Put the URLs and integrity hashes in the templating library code
instead of directly in the base template because we'll later use
the same data source to construct a Content-Security-Policy header.

We should always use HTTPS even if the page is HTTP since
developing with a local proxy will be HTTP and we still don't want
to allow an attacker to mess with the JavaScript.  Change the
default configuration setting.

Fix an invalid reference to one style sheet uncovered by that
change.
