### PR TITLE
Avoid microseconds in default timestamps

### DIFF
--- a/grouper/models/audit.py
+++ b/grouper/models/audit.py
@@ -1,11 +1,9 @@
-from datetime import datetime
-
 from six import itervalues
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from grouper.models.audit_member import AuditMember
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class Audit(Model):
@@ -27,7 +25,7 @@ class Audit(Model):
 
     # If this audit is complete and when it started/ended
     complete = Column(Boolean, default=False, nullable=False)
-    started_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    started_at = Column(DateTime, default=utcnow_without_ms, nullable=False)
     ends_at = Column(DateTime, nullable=False)
 
     # Tracks the last time we emailed the responsible parties of this audit

--- a/grouper/models/audit_log.py
+++ b/grouper/models/audit_log.py
@@ -1,11 +1,10 @@
-from datetime import datetime
 from enum import IntEnum
 
 from sqlalchemy import Column, DateTime, desc, ForeignKey, Integer, or_, String, Text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import relationship
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 from grouper.plugin import get_plugin_proxy
 
 
@@ -36,7 +35,7 @@ class AuditLog(Model):
     __tablename__ = "audit_log"
 
     id = Column(Integer, primary_key=True)
-    log_time = Column(DateTime, default=datetime.utcnow, nullable=False)
+    log_time = Column(DateTime, default=utcnow_without_ms, nullable=False)
 
     # The actor is the person who took an action.
     actor_id = Column(Integer, ForeignKey("users.id"), nullable=False)
@@ -82,7 +81,6 @@ class AuditLog(Model):
         """
         entry = AuditLog(
             actor_id=actor_id,
-            log_time=datetime.utcnow(),
             action=action,
             description=description,
             on_user_id=on_user_id if on_user_id else None,

--- a/grouper/models/base/model_base.py
+++ b/grouper/models/base/model_base.py
@@ -1,5 +1,20 @@
+from datetime import datetime
+
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import object_session
+
+
+def utcnow_without_ms():
+    # type: () -> datetime
+    """Return the current time without microseconds.
+
+    This is used as a default value for creation dates for database rows.  Trying to store
+    microseconds in the database has varying results depending on the database backend (MySQL
+    strips them, SQLite stores them), which in turn can cause test failures because the
+    pre-committed object and the object read from the database don't match.  Grouper has no need of
+    sub-second timestamp accuracy, so simplify things by using this function.
+    """
+    return datetime.utcnow().replace(microsecond=0)
 
 
 class _Model(object):

--- a/grouper/models/comment.py
+++ b/grouper/models/comment.py
@@ -1,11 +1,8 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, Text
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
 
 from grouper.models.base.constants import OBJ_TYPES
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class CommentObjectMixin(object):
@@ -35,5 +32,5 @@ class Comment(Model):
     comment = Column(Text, nullable=False)
 
     created_on = Column(
-        DateTime, default=datetime.utcnow, onupdate=func.current_timestamp(), nullable=False
+        DateTime, default=utcnow_without_ms, onupdate=utcnow_without_ms, nullable=False
     )

--- a/grouper/models/counter.py
+++ b/grouper/models/counter.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, Integer, String
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class Counter(Model):
@@ -12,7 +10,7 @@ class Counter(Model):
     id = Column(Integer, primary_key=True)
     name = Column(String(length=255), unique=True, nullable=False)
     count = Column(Integer, nullable=False, default=0)
-    last_modified = Column(DateTime, default=datetime.utcnow, nullable=False)
+    last_modified = Column(DateTime, default=utcnow_without_ms, nullable=False)
 
     @classmethod
     def incr(cls, session, name, count=1):
@@ -22,7 +20,7 @@ class Counter(Model):
         else:
             counter.count = cls.count + count
             # TODO(herb): reenable after it's safe
-            # counter.last_modified = datetime.utcnow()
+            # counter.last_modified = utcnow_without_ms()
 
         session.flush()
         return counter

--- a/grouper/models/perf_profile.py
+++ b/grouper/models/perf_profile.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, Index, LargeBinary, String
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class PerfProfile(Model):
@@ -12,4 +10,4 @@ class PerfProfile(Model):
     uuid = Column(String(length=36), primary_key=True)
     plop_input = Column(LargeBinary(length=1000000), nullable=False)
     flamegraph_input = Column(LargeBinary(length=1000000), nullable=False)
-    created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_on = Column(DateTime, default=utcnow_without_ms, nullable=False)

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -1,10 +1,9 @@
 from collections import namedtuple
-from datetime import datetime
 
 from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
 
 from grouper.constants import MAX_NAME_LENGTH
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 MappedPermission = namedtuple(
     "MappedPermission", ["permission", "audited", "argument", "groupname", "granted_on", "alias"]
@@ -23,7 +22,7 @@ class Permission(Model):
 
     name = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     description = Column(Text, nullable=False)
-    created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_on = Column(DateTime, default=utcnow_without_ms, nullable=False)
     _audited = Column("audited", Boolean, default=False, nullable=False)
     enabled = Column("enabled", Boolean, default=True, nullable=False)
 

--- a/grouper/models/permission_map.py
+++ b/grouper/models/permission_map.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class PermissionMap(Model):
@@ -28,7 +26,7 @@ class PermissionMap(Model):
     group = relationship("Group", foreign_keys=[group_id])
 
     argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
-    granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+    granted_on = Column(DateTime, default=utcnow_without_ms, nullable=False)
 
     @staticmethod
     def get(session, id=None):

--- a/grouper/models/permission_request_status_change.py
+++ b/grouper/models/permission_request_status_change.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 from grouper.models.comment import CommentObjectMixin
 
 
@@ -24,4 +22,4 @@ class PermissionRequestStatusChange(Model, CommentObjectMixin):
     from_status = Column(Enum(*REQUEST_STATUS_CHOICES))
     to_status = Column(Enum(*REQUEST_STATUS_CHOICES), nullable=False)
 
-    change_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    change_at = Column(DateTime, default=utcnow_without_ms, nullable=False)

--- a/grouper/models/public_key.py
+++ b/grouper/models/public_key.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class PublicKey(Model):
@@ -20,5 +18,5 @@ class PublicKey(Model):
     public_key = Column(Text, nullable=False)
     fingerprint = Column(String(length=64), nullable=False, unique=True)
     fingerprint_sha256 = Column(String(length=64), nullable=False, unique=True)
-    created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_on = Column(DateTime, default=utcnow_without_ms, nullable=False)
     comment = Column(String(length=255))

--- a/grouper/models/request.py
+++ b/grouper/models/request.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import label
 
 from grouper.models.base.constants import OBJ_TYPES_IDX, REQUEST_STATUS_CHOICES
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 from grouper.models.base.session import flush_transaction
 from grouper.models.comment import Comment, CommentObjectMixin
 from grouper.models.counter import Counter
@@ -40,7 +40,7 @@ class Request(Model, CommentObjectMixin):
     edge_id = Column(Integer, ForeignKey("group_edges.id"), nullable=False)
     edge = relationship("GroupEdge", backref="requests")
 
-    requested_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    requested_at = Column(DateTime, default=utcnow_without_ms, nullable=False)
 
     status = Column(Enum(*REQUEST_STATUS_CHOICES), default="pending", nullable=False)
 

--- a/grouper/models/request_status_change.py
+++ b/grouper/models/request_status_change.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 from grouper.models.comment import CommentObjectMixin
 from grouper.models.user import User
 
@@ -24,4 +22,4 @@ class RequestStatusChange(Model, CommentObjectMixin):
     from_status = Column(Enum(*REQUEST_STATUS_CHOICES))
     to_status = Column(Enum(*REQUEST_STATUS_CHOICES), nullable=False)
 
-    change_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    change_at = Column(DateTime, default=utcnow_without_ms, nullable=False)

--- a/grouper/models/service_account_permission_map.py
+++ b/grouper/models/service_account_permission_map.py
@@ -1,11 +1,10 @@
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
 from grouper.constants import MAX_NAME_LENGTH
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
@@ -37,7 +36,7 @@ class ServiceAccountPermissionMap(Model):
     service_account = relationship("ServiceAccount", foreign_keys=[service_account_id])
 
     argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
-    granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
+    granted_on = Column(DateTime, default=utcnow_without_ms, nullable=False)
 
     @staticmethod
     def get(session, id=None):

--- a/grouper/models/user_metadata.py
+++ b/grouper/models/user_metadata.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 class UserMetadata(Model):
@@ -18,4 +16,4 @@ class UserMetadata(Model):
 
     data_key = Column(String(length=64), nullable=False)
     data_value = Column(String(length=64), nullable=False)
-    last_modified = Column(DateTime, default=datetime.utcnow, nullable=False)
+    last_modified = Column(DateTime, default=utcnow_without_ms, nullable=False)

--- a/grouper/models/user_password.py
+++ b/grouper/models/user_password.py
@@ -1,13 +1,12 @@
 import crypt
 import hmac
 import os
-from datetime import datetime
 
 from six import PY2
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import relationship
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 
 
 def _make_salt():
@@ -28,7 +27,7 @@ class UserPassword(Model):
     user_id = Column(Integer, ForeignKey("users.id"))
     name = Column(String(length=16), nullable=False)
 
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow_without_ms, nullable=False)
     disabled_at = Column(DateTime, default=None, nullable=True)
 
     _hashed_secret = Column(Text, nullable=False)

--- a/grouper/models/user_token.py
+++ b/grouper/models/user_token.py
@@ -1,13 +1,12 @@
 import hashlib
 import hmac
 import os
-from datetime import datetime
 
 from six import PY2
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
-from grouper.models.base.model_base import Model
+from grouper.models.base.model_base import Model, utcnow_without_ms
 from grouper.models.user import User
 
 
@@ -29,7 +28,7 @@ class UserToken(Model):
     user_id = Column(Integer, ForeignKey("users.id"))
     name = Column(String(length=16), nullable=False)
 
-    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at = Column(DateTime, default=utcnow_without_ms, nullable=False)
     disabled_at = Column(DateTime, default=None, nullable=True)
 
     hashed_secret = Column(String(length=64), unique=True, nullable=False)

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -58,8 +58,6 @@ class AuditLogRepository(object):
         are ported to this service.
         """
         actor = self._id_for_user(authorization.actor)
-        if not date:
-            date = datetime.utcnow()
 
         # We currently have no way to log audit log entries for objects that no longer exist.  This
         # should eventually be fixed via a schema change to use strings for all fields of the audit
@@ -70,7 +68,6 @@ class AuditLogRepository(object):
 
         entry = AuditLog(
             actor_id=actor,
-            log_time=date,
             action=action,
             description=description,
             on_user_id=user,
@@ -78,6 +75,8 @@ class AuditLogRepository(object):
             on_permission_id=permission,
             category=int(category),
         )
+        if date:
+            entry.log_time = date
         entry.add(self.session)
 
         # This should happen at the service layer, not the repository layer, but the API for the


### PR DESCRIPTION
Behavior of database backends varies when given timestamps that
include microseconds.  MySQL strips them but SQLite stores them.
This can cause confusing test behavior between different backends.
Grouper has no need of sub-second timestamp accuracy, so solve
this problem more systematically by stripping microseconds from
the default timestamps in the database model.