### PR TITLE
Avoid inline styles

### DIFF
--- a/grouper/fe/static/css/grouper.css
+++ b/grouper/fe/static/css/grouper.css
@@ -332,3 +332,7 @@ a.white {
     max-height: 390px;
     overflow-y: auto;
 }
+
+.clickthru-checkbox {
+    display: none;
+}

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -31,8 +31,7 @@
                       method="post" action="/groups/{{group.name}}/join">
                     {% include "forms/group-join.html" %}
                     {% if group.require_clickthru_tojoin %}
-                    <input class="clickthru-checkbox" type="checkbox" name="clickthru_agreement",
-                            style="display:none"/>
+                    <input class="clickthru-checkbox" type="checkbox" name="clickthru_agreement"/>
                     {% else %}
                     <div class="form-group">
                         <div class="col-sm-offset-3 col-sm-4">


### PR DESCRIPTION
We want to prohibit unsafe-inline in styles, so move the style
for the clickthru-checkbox to grouper.css.