### PR TITLE
Convert grouper-ctl dump_sql to a usecase

### DIFF
--- a/grouper/ctl/dump_sql.py
+++ b/grouper/ctl/dump_sql.py
@@ -2,27 +2,31 @@ from __future__ import print_function
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy.schema import CreateIndex, CreateTable
-
-from grouper.models.base.model_base import Model
-from grouper.models.base.session import get_db_engine
+from grouper.ctl.base import CtlCommand
+from grouper.usecases.dump_schema import DumpSchemaUI
 
 if TYPE_CHECKING:
-    from argparse import _SubParsersAction, Namespace
-    from grouper.ctl.settings import CtlSettings
-    from grouper.repositories.factory import SessionFactory
+    from argparse import ArgumentParser, Namespace
+    from grouper.usecases.factory import UseCaseFactory
 
 
-def dump_sql_command(args, settings, session_factory):
-    # type: (Namespace, CtlSettings, SessionFactory) -> None
-    db_engine = get_db_engine(settings.database)
-    for table in Model.metadata.sorted_tables:
-        print(CreateTable(table).compile(db_engine))
-        for index in table.indexes:
-            print(CreateIndex(index).compile(db_engine))
+class DumpSqlCommand(CtlCommand, DumpSchemaUI):
+    """Commands to dump the database schema."""
 
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        return
 
-def add_parser(subparsers):
-    # type: (_SubParsersAction) -> None
-    dump_sql_parser = subparsers.add_parser("dump_sql", help="Dump database schema.")
-    dump_sql_parser.set_defaults(func=dump_sql_command)
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
+
+    def dumped_schema(self, schema):
+        # type: (str) -> None
+        print(schema)
+
+    def run(self, args):
+        # type: (Namespace) -> None
+        usecase = self.usecase_factory.create_dump_schema_usecase(self)
+        usecase.dump_schema()

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from grouper.ctl.dump_sql import DumpSqlCommand
 from grouper.ctl.permission import PermissionCommand
 from grouper.ctl.sync_db import SyncDbCommand
 from grouper.ctl.user import UserCommand
@@ -31,6 +32,8 @@ class CtlCommandFactory(object):
         information such as the database URL that may be overridden on the command line and thus
         cannot be created until after command-line parsing.
         """
+        parser = subparsers.add_parser("dump_sql", help="Dump database schema")
+        DumpSqlCommand.add_arguments(parser)
         parser = subparsers.add_parser("permission", help="Manipulate permissions")
         PermissionCommand.add_arguments(parser)
         parser = subparsers.add_parser("sync_db", help="Create database schema")
@@ -47,7 +50,9 @@ class CtlCommandFactory(object):
 
     def construct_command(self, command):
         # type: (str) -> CtlCommand
-        if command == "permission":
+        if command == "dump_sql":
+            return self.construct_dump_sql_command()
+        elif command == "permission":
             return self.construct_permission_command()
         elif command == "sync_db":
             return self.construct_sync_db_command()
@@ -57,6 +62,10 @@ class CtlCommandFactory(object):
             return self.construct_user_proxy_command()
         else:
             raise UnknownCommand("unknown command {}".format(command))
+
+    def construct_dump_sql_command(self):
+        # type: () -> DumpSqlCommand
+        return DumpSqlCommand(self.usecase_factory)
 
     def construct_permission_command(self):
         # type: () -> PermissionCommand

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from grouper import __version__
-from grouper.ctl import dump_sql, group, oneoff, service_account, shell
+from grouper.ctl import group, oneoff, service_account, shell
 from grouper.ctl.factory import CtlCommandFactory
 from grouper.ctl.settings import CtlSettings
 from grouper.initialization import create_sql_usecase_factory
@@ -51,7 +51,7 @@ def main(sys_argv=sys.argv, session=None):
     CtlCommandFactory.add_all_parsers(subparsers)
 
     # Add parsers for legacy commands that have not been refactored.
-    for subcommand_module in [dump_sql, group, oneoff, service_account, shell]:
+    for subcommand_module in [group, oneoff, service_account, shell]:
         subcommand_module.add_parser(subparsers)  # type: ignore
 
     args = parser.parse_args(sys_argv[1:])

--- a/grouper/services/schema.py
+++ b/grouper/services/schema.py
@@ -13,6 +13,10 @@ class SchemaService(SchemaInterface):
         # type: (SchemaRepository) -> None
         self.schema_repository = schema_repository
 
+    def dump_schema(self):
+        # type: () -> str
+        return self.schema_repository.dump_schema()
+
     def initialize_schema(self):
         # type: () -> None
         self.schema_repository.initialize_schema()

--- a/grouper/usecases/dump_schema.py
+++ b/grouper/usecases/dump_schema.py
@@ -1,0 +1,30 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from six import with_metaclass
+
+if TYPE_CHECKING:
+    from grouper.usecases.interfaces import SchemaInterface
+
+
+class DumpSchemaUI(with_metaclass(ABCMeta, object)):
+    """Abstract base class for UI for DumpSchema."""
+
+    @abstractmethod
+    def dumped_schema(self, schema):
+        # type: (str) -> None
+        pass
+
+
+class DumpSchema(object):
+    """Dump the database schema as a string."""
+
+    def __init__(self, ui, schema_service):
+        # type: (DumpSchemaUI, SchemaInterface) -> None
+        self.ui = ui
+        self.schema_service = schema_service
+
+    def dump_schema(self):
+        # type: () -> None
+        schema = self.schema_service.dump_schema()
+        self.ui.dumped_schema(schema)

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
+from grouper.usecases.dump_schema import DumpSchema
 from grouper.usecases.initialize_schema import InitializeSchema
 from grouper.usecases.list_permissions import ListPermissions
 from grouper.usecases.view_permission import ViewPermission
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from grouper.settings import Settings
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
+    from grouper.usecases.dump_schema import DumpSchemaUI
     from grouper.usecases.list_permissions import ListPermissionsUI
     from grouper.usecases.view_permission import ViewPermissionUI
 
@@ -44,6 +46,11 @@ class UseCaseFactory(object):
         transaction_service = self.service_factory.create_transaction_service()
         user_service = self.service_factory.create_user_service()
         return DisablePermission(actor, ui, permission_service, user_service, transaction_service)
+
+    def create_dump_schema_usecase(self, ui):
+        # type: (DumpSchemaUI) -> DumpSchema
+        schema_service = self.service_factory.create_schema_service()
+        return DumpSchema(ui, schema_service)
 
     def create_list_permissions_usecase(self, ui):
         # type: (ListPermissionsUI) -> ListPermissions

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -163,6 +163,11 @@ class SchemaInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for low-level schema manipulation."""
 
     @abstractmethod
+    def dump_schema(self):
+        # type: () -> str
+        pass
+
+    @abstractmethod
     def initialize_schema(self):
         # type: () -> None
         pass

--- a/tests/usecases/dump_schema_test.py
+++ b/tests/usecases/dump_schema_test.py
@@ -1,0 +1,20 @@
+from typing import TYPE_CHECKING
+
+from grouper.usecases.dump_schema import DumpSchemaUI
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+class MockUI(DumpSchemaUI):
+    def dumped_schema(self, schema):
+        # type: (str) -> None
+        self.schema = schema
+
+
+def test_dump_schema(setup):
+    # type: (SetupTest) -> None
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_dump_schema_usecase(mock_ui)
+    usecase.dump_schema()
+    assert "service_account_permissions_map" in mock_ui.schema


### PR DESCRIPTION
Now that there is a SchemaService, this is a fairly trivial bit of
plumbing and converts another grouper-ctl command to the new model.