### PR TITLE
Mostly fix port binding races in integration tests

### DIFF
--- a/grouper/setup.py
+++ b/grouper/setup.py
@@ -40,6 +40,11 @@ def build_arg_parser(description):
     parser.add_argument(
         "-d", "--database-url", type=str, default=None, help="Override database URL in config."
     )
+    parser.add_argument(
+        "--listen-stdin",
+        action="store_true",
+        help="Ignore address and port and expect connections on standard input",
+    )
 
     return parser
 

--- a/itests/setup.py
+++ b/itests/setup.py
@@ -10,7 +10,7 @@ import socket
 import subprocess
 import sys
 import time
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from selenium.webdriver import Chrome, ChromeOptions
@@ -22,16 +22,12 @@ if TYPE_CHECKING:
     from typing import Iterator
 
 
-def _get_unused_port():
-    # type: () -> int
-    """Bind, requesting a system-allocated port, and return it.
-
-    This isn't strictly correct in that there's a race condition where the port could be taken by
-    something else before the server we launch uses it.  Hopefully this will not be common.
-    """
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
+def _bind_socket():
+    # type: () -> socket.socket
+    """Bind a system-allocated port and return it."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    return s
 
 
 def _wait_until_accept(port, timeout=3.0):
@@ -60,21 +56,22 @@ def _wait_until_accept(port, timeout=3.0):
 @contextmanager
 def api_server(tmpdir):
     # type: (LocalPath) -> Iterator[str]
-    api_port = _get_unused_port()
+    api_socket = _bind_socket()
+    api_port = api_socket.getsockname()[1]
 
     cmd = [
         sys.executable,
         src_path("bin", "grouper-api"),
-        "-c",
+        "-vvc",
         src_path("config", "dev.yaml"),
-        "-p",
-        str(api_port),
         "-d",
         db_url(tmpdir),
+        "--listen-stdin",
     ]
 
     logging.info("Starting server with command: %s", " ".join(cmd))
-    p = subprocess.Popen(cmd, env=bin_env())
+    p = subprocess.Popen(cmd, env=bin_env(), stdin=api_socket.fileno())
+    api_socket.close()
 
     logging.info("Waiting on server to come online")
     _wait_until_accept(api_port)
@@ -88,43 +85,56 @@ def api_server(tmpdir):
 @contextmanager
 def frontend_server(tmpdir, user):
     # type: (LocalPath, str) -> Iterator[str]
-    proxy_port = _get_unused_port()
-    fe_port = _get_unused_port()
+    proxy_socket = _bind_socket()
+    proxy_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    proxy_port = proxy_socket.getsockname()[1]
+    fe_socket = _bind_socket()
+    fe_port = fe_socket.getsockname()[1]
 
-    cmds = [
-        [
-            sys.executable,
-            src_path("bin", "grouper-ctl"),
-            "-vvc",
-            src_path("config", "dev.yaml"),
-            "user_proxy",
-            "-P",
-            str(fe_port),
-            "-p",
-            str(proxy_port),
-            user,
-        ],
-        [
-            sys.executable,
-            src_path("bin", "grouper-fe"),
-            "-vvc",
-            src_path("config", "dev.yaml"),
-            "-p",
-            str(fe_port),
-            "-d",
-            db_url(tmpdir),
-        ],
+    proxy_cmd = [
+        sys.executable,
+        src_path("bin", "grouper-ctl"),
+        "-vvc",
+        src_path("config", "dev.yaml"),
+        "user_proxy",
+        "-P",
+        str(fe_port),
+        "-p",
+        str(proxy_port),
+        user,
+    ]
+    fe_cmd = [
+        sys.executable,
+        src_path("bin", "grouper-fe"),
+        "-vvc",
+        src_path("config", "dev.yaml"),
+        "-d",
+        db_url(tmpdir),
+        "--listen-stdin",
     ]
 
     subprocesses = []
-    for cmd in cmds:
-        logging.info("Starting command: %s", " ".join(cmd))
-        p = subprocess.Popen(cmd, env=bin_env())
-        subprocesses.append(p)
+
+    logging.info("Starting command: %s", " ".join(fe_cmd))
+    fe_process = subprocess.Popen(fe_cmd, env=bin_env(), stdin=fe_socket.fileno())
+    subprocesses.append(fe_process)
+    fe_socket.close()
+
+    # TODO(rra): There is a race condition here because grouper-ctl user_proxy doesn't implement
+    # --listen-stdin yet, which in turn is because the built-in Python HTTPServer doesn't support
+    # wrapping a pre-existing socket.  Since we have to close the socket so that grouper-ctl
+    # user_proxy can re-open it, something else might grab it in the interim.  Once it is rewritten
+    # using Tornado, it can use the same approach as the frontend and API servers and take an open
+    # socket on standard input.  At that point, we can also drop the SO_REUSEADDR above, which is
+    # there to protect against the race condition.
+    logging.info("Starting command: %s", " ".join(proxy_cmd))
+    proxy_socket.close()
+    proxy_process = subprocess.Popen(proxy_cmd, env=bin_env())
+    subprocesses.append(proxy_process)
 
     logging.info("Waiting on server to come online")
-    _wait_until_accept(proxy_port)
     _wait_until_accept(fe_port)
+    _wait_until_accept(proxy_port)
     logging.info("Connection established")
 
     yield "http://localhost:{}".format(proxy_port)


### PR DESCRIPTION
The integration tests found an unused port on which to run the
service under test by binding a socket with system port allocation,
retrieving the bound port number, and then closing that socket.
This has two problems that were causing race conditions:

* We weren't setting SO_REUSEADDR, so depending on how quickly the
  child process started, the kernel may not be willing to let it
  rebind the same port we just closed.
* Even with port reuse, there's an inherent race condition when
  tests are running in parallel or anything else is running on the
  same host: someone else may allocate the same port between the
  point when we close it and the point at which the child server
  rebinds to it.

For the API and Frontend servers, implement a new --listen-stdin
option that tells the service to not bind its own port and instead
use the socket passed as standard input as the network socket.
This allows the test to bind a socket with system port allocation
and pass it open to the server under test, eliminating the race.

This unfortunately is not possible with grouper-ctl user_proxy yet
because it's built on Python's internal HTTPServer, which in turn
does not support starting a server with a user-supplied socket
instead of binding its own socket.  It will need to be rewritten to
use Tornado to fix this.  In the meantime, there will still be a
race, but narrow it by setting SO_REUSEADDR and closing the socket
as close as possible to starting the child process.

Replace the older test fixtures with simple wrappers around the new
setup functions so that they also get the benefit of this change.

Use the current instead of the deprecated way of starting the
Tornado IOLoop (unrelated but noticed it while working on this
change).