### PR TITLE
Fix permission request form with restricted arguments

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -53,7 +53,8 @@ common:
     # exclude wildcard ownership if any non-wildcard owners are avaiable.
     #
     # Type: List[str]
-    restricted_ownership_permissions: []
+    restricted_ownership_permissions:
+      - "sample.permission"
 
     # Whether to send notification e-mails.
     #

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -225,15 +225,19 @@ $(function () {
             if (args.length == 1 && args[0] == "*") {
                 $argument_input.show();
                 $argument_input.prop('name', 'argument');
+                $argument_input.prop('required', true);
 
                 $argument_select.hide();
                 $argument_select.prop('name', 'ignore');
+                $argument_select.prop('required', false);
             } else {
                 $argument_input.hide();
                 $argument_input.prop('name', 'ignore');
+                $argument_input.prop('required', false);
 
                 $argument_select.show();
                 $argument_select.prop('name', 'argument');
+                $argument_select.prop('required', true);
 
                 $argument_select.empty();
                 $.each(args, function(index, arg) {

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -4,29 +4,41 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 if TYPE_CHECKING:
+    from selenium.webdriver import Chrome
     from selenium.webdriver.remote.webelement import WebElement
 
 
 class BaseFinder(object):
     def __init__(self, root):
+        # type: (Chrome) -> None
         self.root = root
 
     def find_element_by_class_name(self, name):
+        # type: (str) -> WebElement
         return self.root.find_element_by_class_name(name)
 
     def find_elements_by_class_name(self, name):
+        # type: (str) -> WebElement
         return self.root.find_elements_by_class_name(name)
 
     def find_element_by_id(self, id_):
+        # type: (str) -> WebElement
         return self.root.find_element_by_id(id_)
 
     def find_element_by_link_text(self, link_text):
+        # type: (str) -> WebElement
         return self.root.find_element_by_link_text(link_text)
 
+    def find_element_by_name(self, name):
+        # type: (str) -> WebElement
+        return self.root.find_element_by_name(name)
+
     def find_element_by_tag_name(self, name):
+        # type: (str) -> WebElement
         return self.root.find_element_by_tag_name(name)
 
     def find_element_by_xpath(self, path):
+        # type: (str) -> WebElement
         return self.root.find_element_by_xpath(path)
 
 

--- a/itests/pages/permission_request.py
+++ b/itests/pages/permission_request.py
@@ -1,27 +1,35 @@
 from typing import TYPE_CHECKING
 
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 
 from itests.pages.base import BasePage
 
 if TYPE_CHECKING:
+    from selenium.webdriver.remote.webelement import WebElement
     from typing import List
 
 
 class PermissionRequestPage(BasePage):
-    def get_option_values(self, id):
+    @property
+    def permission_request_form(self):
+        # type: () -> WebElement
+        return self.find_element_by_id("permission-request")
+
+    def get_option_values(self, name):
         # type: (str) -> List[str]
-        select = Select(self.find_element_by_id(id))
+        select = Select(self.permission_request_form.find_element_by_name(name))
         return [option.get_attribute("value") for option in select.options]
 
-    def set_select_value(self, id, value):
+    def set_select_value(self, name, value):
         # type: (str, str) -> None
-        select = Select(self.find_element_by_id(id))
+        select = Select(self.permission_request_form.find_element_by_name(name))
         select.select_by_value(value)
 
-    def fill_field(self, id, value):
-        self.find_element_by_id(id).send_keys(value)
+    def fill_field(self, name, value):
+        # type: (str, str) -> None
+        self.permission_request_form.find_element_by_name(name).send_keys(value)
 
     def submit_request(self):
-        self.find_element_by_id("argument").send_keys(Keys.ENTER)
+        # type: () -> None
+        button = self.permission_request_form.find_element_by_tag_name("button")
+        button.click()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ annex==0.5.0
 Jinja2==2.10.1
 PyYAML==5.1
 SQLAlchemy==1.3.2
-WTForms==2.1
+WTForms==2.2.1
 backports.ssl-match-hostname==3.5.0.1
 enum34==1.1.6
 mysqlclient==1.4.2.post1


### PR DESCRIPTION
With WTForms 2.2.1 (used internally at Dropbox), but not in
WTForms 2.1 (the previous pinned version), the argument input
field in the permission request form is marked as required.  When
we replace it with a select box and mark it hidden, the JavaScript
was not clearing the required flag, which resulted in a Chrome
error when the browser tried to move focus to the hidden required
field that had no input.

Bump the version of WTForms so that this error is reproducible in
testing, modify the JavaScript to set or clear the required flag
properly, and add a new integration test for this behavior.