### PR TITLE
Use permission repository to create test permissions

### DIFF
--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from six import with_metaclass
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
@@ -36,8 +37,10 @@ class PermissionRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission repositories."""
 
     @abstractmethod
-    def create_permission(self, name, description):
-        # type: (str, str) -> None
+    def create_permission(
+        self, name, description="", audited=False, enabled=True, created_on=None
+    ):
+        # type: (str, str, bool, bool, Optional[datetime]) -> None
         pass
 
     @abstractmethod

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -7,6 +7,7 @@ from grouper.repositories.interfaces import PermissionRepository
 from grouper.usecases.list_permissions import ListPermissionsSortKey
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from grouper.entities.pagination import Pagination
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
@@ -25,9 +26,11 @@ class GraphPermissionRepository(PermissionRepository):
         self.graph = graph
         self.repository = repository
 
-    def create_permission(self, name, description=""):
-        # type: (str, str) -> None
-        self.repository.create_permission(name, description)
+    def create_permission(
+        self, name, description="", audited=False, enabled=True, created_on=None
+    ):
+        # type: (str, str, bool, bool, Optional[datetime]) -> None
+        self.repository.create_permission(name, description, audited, enabled, created_on)
 
     def disable_permission(self, name):
         # type: (str) -> None
@@ -79,9 +82,15 @@ class SQLPermissionRepository(PermissionRepository):
         # type: (Session) -> None
         self.session = session
 
-    def create_permission(self, name, description=""):
-        # type: (str, str) -> None
-        permission = SQLPermission(name=name, description=description)
+    def create_permission(
+        self, name, description="", audited=False, enabled=True, created_on=None
+    ):
+        # type: (str, str, bool, bool, Optional[datetime]) -> None
+        permission = SQLPermission(
+            name=name, description=description, _audited=audited, enabled=enabled
+        )
+        if created_on:
+            permission.created_on = created_on
         permission.add(self.session)
 
     def disable_permission(self, name):


### PR DESCRIPTION
Now that the permission repository supports creating permissions,
use it in SetupTest.  Use the permission repository directly rather
than the service because we want to force specific permission
creation times, which isn't something that seems useful to expose
through the permission service.