### PR TITLE
Fix creation of group with clickthru

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -194,6 +194,7 @@ class GroupJoinForm(Form):
     clickthru_agreement = BooleanField(
         "Acknowledge reading and accepting the terms of this group's membership",
         [validators.Optional()],
+        default=False,
     )
 
 

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -71,7 +71,7 @@ class GroupJoin(GrouperHandler):
             )
 
         if group.require_clickthru_tojoin:
-            if not form["clickthru_agreement"]:
+            if not form.data["clickthru_agreement"]:
                 return self.render(
                     "group-join.html",
                     form=form,

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -64,6 +64,7 @@ class GroupsView(GrouperHandler):
             description=form.data["description"],
             canjoin=form.data["canjoin"],
             auto_expire=form.data["auto_expire"],
+            require_clickthru_tojoin=form.data["require_clickthru_tojoin"],
         )
         try:
             group.add(self.session)

--- a/grouper/fe/static/css/grouper.css
+++ b/grouper/fe/static/css/grouper.css
@@ -271,6 +271,10 @@ span.disabled {
     white-space: nowrap;
 }
 
+.popover {
+    z-index: 2000;
+}
+
 .popover-content {
     font-weight: normal;
 }

--- a/grouper/fe/templates/forms/group-permission-request-dropdown.html
+++ b/grouper/fe/templates/forms/group-permission-request-dropdown.html
@@ -1,7 +1,8 @@
 {% from 'macros/ui.html' import form_field -%}
 
 {{ form_field(dropdown_form.permission_name, 3, 8, class_="form-control input-permission_name") }}
-{{ form_field(dropdown_form.argument, 3, 8, class_="form-control", help=dropdown_help) }}
+{{ form_field(dropdown_form.argument, 3, 8, class_="form-control",
+              help=dropdown_help, help_title="restricted argument set") }}
 {{ form_field(dropdown_form.reason, 3, 8, class_="form-control input-reason") }}
 {{ dropdown_form.argument_type() }}
 {{ xsrf_form()|safe }}

--- a/grouper/fe/templates/forms/group.html
+++ b/grouper/fe/templates/forms/group.html
@@ -1,14 +1,15 @@
 {% from 'macros/ui.html' import form_field -%}
 
 {% if form.creatorrole %}
-    {{ form_field(form.creatorrole, 3, 6, class_="form-control") }}
+    {{ form_field(form.creatorrole, 4, 6, class_="form-control") }}
 {% endif %}
-{{ form_field(form.groupname, 3, 8, class_="form-control") }}
-{{ form_field(form.email_address, 3, 8, class_="form-control") }}
-{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
-{{ form_field(form.canjoin, 3, 4, class_="form-control") }}
-{{ form_field(form.auto_expire, 3, 4, class_="form-control") }}
-{{ form_field(form.require_clickthru_tojoin, 3, 4,
-        help="require agreement to the group's description, prior requesting membership") }}
+{{ form_field(form.groupname, 4, 8, class_="form-control") }}
+{{ form_field(form.email_address, 4, 8, class_="form-control") }}
+{{ form_field(form.description, 4, 8, class_="form-control", rows=5) }}
+{{ form_field(form.canjoin, 4, 4, class_="form-control") }}
+{{ form_field(form.auto_expire, 4, 4, class_="form-control") }}
+{{ form_field(form.require_clickthru_tojoin, 4, 4,
+        help="Require agreement to the group's description prior to requesting membership",
+        help_title="Require clickthru") }}
 
 {{ xsrf_form()|safe }}

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -32,26 +32,22 @@
                     {% include "forms/group-join.html" %}
                     {% if group.require_clickthru_tojoin %}
                     <input class="clickthru-checkbox" type="checkbox" name="clickthru_agreement"/>
-                    {% else %}
+                    {% endif %}
                     <div class="form-group">
                         <div class="col-sm-offset-3 col-sm-4">
-                            <button type="submit" class="btn btn-primary">Submit</button>
+                            {% if group.require_clickthru_tojoin %}
+                            <button id="join-btn" class="btn btn-primary" data-toggle="modal"
+                                    data-target="#clickthruModal" type="button">
+                                Submit
+                            </button>
+                            {% else %}
+                            <button id="join-btn" type="submit" class="btn btn-primary">
+                                Submit
+                            </button>
+                            {% endif %}
                         </div>
                     </div>
-                    {% endif %}
-
                 </form>
-                {% if group.require_clickthru_tojoin %}
-                <div class="form-group">
-                    <div class="col-sm-offset-3 col-sm-4">
-                        <button id="join-clickthru-btn" class="btn btn-primary" data-toggle="modal"
-                                data-target="#clickthruModal">
-                            Join
-                        </button>
-                    </div>
-                </div>
-                {% else %}
-                {% endif %}
             </div>
         </div>
     </div>
@@ -89,7 +85,6 @@
                     Agree
                 </button>
             </div>
-                </form>
         </div>
     </div>
 </div>

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -26,7 +26,8 @@
           <i class="fa"></i> Show all groups
       </a>
       {% else %}
-      <button class="btn btn-success" data-toggle="modal" data-target="#createModal">
+      <button class="btn btn-success" id="create-group" data-toggle="modal"
+              data-target="#createModal">
           <i class="fa fa-plus"></i> Create
       </button>
       <a class="btn btn-warning" href="/groups?limit={{limit}}&audited=1">

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -615,14 +615,13 @@ enabled. Membership in this group is regularly reviewed.
     </div>
 {%- endmacro %}
 
-{% macro form_field(field, label_width, field_width, help=None) -%}
+{% macro form_field(field, label_width, field_width, help=None, help_title=None) -%}
     <div class="form-group form-group-{{field.label.field_id}} {% if field.errors %}has-error{% endif %}">
         <label for="{{field.label.field_id}}"
                class="col-sm-{{label_width}} control-label">
             {{ field.label.text }}
             {% if help %}
-            <a data-toggle="popover" title="restricted argument set"
-                    data-content="{{ help }}">
+            <a data-toggle="popover" title="{{ help_title }}" data-content="{{ help }}">
                 <sup>?</sup>
             </a>
             {% endif %}

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.group import GroupJoinPolicy
+from itests.pages.groups import GroupJoinPage, GroupsViewPage, GroupViewPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_require_clickthru(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups"))
+        groups_page = GroupsViewPage(browser)
+
+        groups_page.click_create_group_button()
+        create_group_modal = groups_page.get_create_group_modal()
+        create_group_modal.set_group_name("test-group")
+        create_group_modal.set_join_policy(GroupJoinPolicy.CAN_JOIN)
+        create_group_modal.click_require_clickthru_checkbox()
+        create_group_modal.confirm()
+
+    with frontend_server(tmpdir, "rra@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/test-group/join"))
+        join_page = GroupJoinPage(browser)
+
+        join_page.set_reason("Testing")
+        join_page.submit()
+        clickthru_modal = join_page.get_clickthru_modal()
+        clickthru_modal.confirm()
+
+        group_page = GroupViewPage(browser)
+        assert group_page.current_url.endswith("/groups/test-group?refresh=yes")
+        assert group_page.find_member_row("rra@a.co")


### PR DESCRIPTION
Fix various issues when creating a group with the require clickthru
form field:

* The help popover had a lower z-index than the modal, so displayed
  behind the modal, which wasn't useful to anyone.
* The require clickthru form field was ignored and not persisted to
  the database.
* The fields were too narrow, resulting in odd wrapping.
* A bug in the verification logic meant that we weren't checking
  that the user really did confirm the clickthru agreement (although
  it would have been hard to submit without confirming through a
  browser UI without taking special action).
* The button construction for the join form was odd and overly
  complex, which made testing difficult.

Add an integration test for creating and then requesting membership
in a group with a required clickthru agreement.