### PR TITLE
Avoid unnecessary SQL queries in graph construction

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -329,16 +329,18 @@ class GroupGraph(object):
 
     @staticmethod
     def _get_group_service_accounts(session):
+        # type: (Session) -> Dict[str, List[str]]
         """
         Returns a dict of groupname: { list of service account names }.
         """
-        out = defaultdict(list)
-        tuples = session.query(Group, ServiceAccount).filter(
+        out = defaultdict(list)  # type: Dict[str, List[str]]
+        tuples = session.query(Group.groupname, User.username).filter(
             GroupServiceAccount.group_id == Group.id,
             GroupServiceAccount.service_account_id == ServiceAccount.id,
+            ServiceAccount.user_id == User.id
         )
         for group, account in tuples:
-            out[group.groupname].append(account.user.username)
+            out[group].append(account)
         return out
 
     def _get_group_tuples(self, session, enabled=True):

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -244,25 +244,26 @@ class GroupGraph(object):
     # metadata for a permission.
     @staticmethod
     def _get_permission_metadata(session):
+        # type: (Session) -> Dict[str, List[MappedPermission]]
         """
         Returns a dict of groupname: { list of permissions }. Note
         that disabled permissions are not included.
         """
-        out = defaultdict(list)  # groupid -> [ ... ]
+        out = defaultdict(list)  # type: Dict[str, List[MappedPermission]]
 
-        permissions = session.query(Permission, PermissionMap).filter(
+        permissions = session.query(Permission, PermissionMap, Group.groupname).filter(
             Permission.id == PermissionMap.permission_id,
             PermissionMap.group_id == Group.id,
             Group.enabled == True,
         )
 
-        for (permission, permission_map) in permissions:
-            out[permission_map.group.name].append(
+        for (permission, permission_map, groupname) in permissions:
+            out[groupname].append(
                 MappedPermission(
                     permission=permission.name,
                     audited=permission.audited,
                     argument=permission_map.argument,
-                    groupname=permission_map.group.name,
+                    groupname=groupname,
                     granted_on=permission_map.granted_on,
                     alias=False,
                 )
@@ -273,12 +274,12 @@ class GroupGraph(object):
             )
 
             for (name, arg) in aliases:
-                out[permission_map.group.name].append(
+                out[groupname].append(
                     MappedPermission(
                         permission=name,
                         audited=permission.audited,
                         argument=arg,
-                        groupname=permission_map.group.name,
+                        groupname=groupname,
                         granted_on=permission_map.granted_on,
                         alias=True,
                     )

--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -225,19 +225,25 @@ def all_service_account_permissions(session):
     # type: (Session) -> Dict[str, List[ServiceAccountPermission]]
     """Return a dict of service account names to their permissions."""
     out = defaultdict(list)  # type: Dict[str, List[ServiceAccountPermission]]
-    permissions = session.query(Permission, ServiceAccountPermissionMap).filter(
+    permissions = session.query(
+        User.username,
+        Permission.name,
+        ServiceAccountPermissionMap.argument,
+        ServiceAccountPermissionMap.granted_on,
+        ServiceAccountPermissionMap.id,
+    ).filter(
         Permission.id == ServiceAccountPermissionMap.permission_id,
         ServiceAccountPermissionMap.service_account_id == ServiceAccount.id,
         ServiceAccount.user_id == User.id,
         User.enabled == True,
     )
     for permission in permissions:
-        out[permission[1].service_account.user.username].append(
+        out[permission.username].append(
             ServiceAccountPermission(
-                permission=permission[0].name,
-                argument=permission[1].argument,
-                granted_on=permission[1].granted_on,
-                mapping_id=permission[1].id,
+                permission=permission.name,
+                argument=permission.argument,
+                granted_on=permission.granted_on,
+                mapping_id=permission.id,
             )
         )
     return out

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -252,3 +252,15 @@ class SetupTest(object):
         group_obj = Group.get(self.session, name=group)
         assert group_obj
         group_obj.enabled = False
+
+    def disable_service_account(self, service_account):
+        # type: (str) -> None
+        service_obj = ServiceAccount.get(self.session, name=service_account)
+        assert service_obj
+        service_obj.user.enabled = False
+        service_obj.owner.delete(self.session)
+        permissions = self.session.query(ServiceAccountPermissionMap).filter_by(
+            service_account_id=service_obj.id
+        )
+        for permission in permissions:
+            permission.delete(self.session)


### PR DESCRIPTION
When constructing the graph, _get_group_tuples was making a call
to is_role_user for every group.  This in turn translates into a
SQL query to pull the user from the database.  However, this method
is only called after the user metadata has been cached in the
graph, which includes role user data for every user.

Avoid the SQL queries by asking the cached graph data if the user
exists and, if so, if it's a role user.

The name to which a permission was granted was loaded via a 
relationship from the map to the group, which is a deferred load
and thus was resulting in a SQL query per permission grant.  We
were already joining on Group in the initial query, so just
retrieve the group name as well and include it in the result 
tuple, avoiding the need for the additional queries.

We were using a deferred relationship to get the username for a
service account.  Replace the use of model objects with direct
queries for the fields we care about, which also avoids the
deferred load and a bunch of unnecessary SQL queries.

Avoid loading deferred relationships when building the mapping
between groups and service accounts by instead querying directly
for the group name and corresponding service account username.

For every service account encountered when caching users in the
graph, we were making three additional SQL queries due to lazy
loading of relationships (user to service account, service account
to owner mapping, and owner mapping to group).  Instead, ask the
database for all service accounts and their owners up-front, store
those indexed by user ID, and then use that dict rather than using
ORM relationships to retrieve the data for each user.