### PR TITLE
Set Content-Security-Policy and Referrer-Policy

### DIFF
--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -39,15 +39,12 @@ def create_fe_application(
     # type: (...) -> GrouperApplication
     tornado_settings = {
         "debug": settings.debug,
+        "session": session if session else Session,
         "static_path": os.path.join(os.path.dirname(grouper.fe.__file__), "static"),
+        "template_engine": FrontendTemplateEngine(settings, deployment_name),
         "xsrf_cookies": xsrf_cookies,
     }
-    handler_settings = {
-        "session": session if session else Session,
-        "template_engine": FrontendTemplateEngine(settings, deployment_name),
-    }
-    handlers = [(route, handler_class, handler_settings) for (route, handler_class) in HANDLERS]
-    return GrouperApplication(handlers, **tornado_settings)
+    return GrouperApplication(HANDLERS, **tornado_settings)
 
 
 def start_server(args, settings, sentry_client):

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -66,8 +66,8 @@ class GrouperHandler(RequestHandler):
     def initialize(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         self.graph = Graph()
-        self.session = kwargs["session"]()  # type: Session
-        self.template_engine = kwargs["template_engine"]  # type: FrontendTemplateEngine
+        self.session = self.settings["session"]()  # type: Session
+        self.template_engine = self.settings["template_engine"]  # type: FrontendTemplateEngine
         self.plugins = get_plugin_proxy()
         session_factory = SingletonSessionFactory(self.session)
         self.usecase_factory = create_graph_usecase_factory(
@@ -86,6 +86,13 @@ class GrouperHandler(RequestHandler):
 
         stats.log_rate("requests", 1)
         stats.log_rate("requests_{}".format(self.__class__.__name__), 1)
+        logging.error("initialized")
+
+    def set_default_headers(self):
+        # type: () -> None
+        logging.error(self)
+        self.set_header("Content-Security-Policy", self.settings["template_engine"].csp_header())
+        self.set_header("Referrer-Policy", "same-origin")
 
     def write_error(self, status_code, **kwargs):
         """Override for custom error page."""

--- a/itests/fe/headers_test.py
+++ b/itests/fe/headers_test.py
@@ -1,0 +1,49 @@
+from typing import TYPE_CHECKING
+
+from six.moves.urllib.request import urlopen
+
+from grouper.fe.settings import FrontendSettings
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from tests.setup import SetupTest
+
+
+def test_csp(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        r = urlopen(url(frontend_url, "/"))
+        assert r.getcode() == 200
+        headers = r.info()
+
+    # Some basic sanity checks on the Content-Security-Policy.
+    assert "Content-Security-Policy" in headers
+    csp_header = str(headers["Content-Security-Policy"])
+    csp_directive = {}
+    for parameter in csp_header.split(";"):
+        directive, value = parameter.strip().split(None, 1)
+        csp_directive[directive] = value
+    assert csp_directive["default-src"] == "'none'"
+    assert "unsafe-inline" not in csp_directive["script-src"]
+    assert "unsafe-inline" not in csp_directive["style-src"]
+
+    # Make sure the cdnjs_prefix setting was honored.
+    settings = FrontendSettings()
+    assert settings.cdnjs_prefix in csp_directive["script-src"]
+
+
+def test_referrer_policy(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        r = urlopen(url(frontend_url, "/"))
+        assert r.getcode() == 200
+        headers = r.info()
+        assert str(headers["Referrer-Policy"]) == "same-origin"


### PR DESCRIPTION
Build a Content-Security-Policy header from external resources and
the configured CDNJS prefix and set it on every request, including
some restrictive default settings.  Also set Referrer-Policy to
same-origin on every request.

Unfortunately, set_default_headers is called before initialize in
request handlers, so the template engine had to move to the Tornado
settings to be accessible early enough.  Since we're making that
change anyway, also move the session class and drop the parameters
to initialize.  This makes us somewhat more vulnerable to changes in
the attributes in newer versions of Tornado, but avoids globals or
messing about with subclassing Application.