### PR TITLE
Don't grant permissions to auditors_group twice

### DIFF
--- a/grouper/usecases/initialize_schema.py
+++ b/grouper/usecases/initialize_schema.py
@@ -57,6 +57,6 @@ class InitializeSchema(object):
                         "Allows members to own groups with audited permissions",
                         GroupJoinPolicy.CAN_ASK,
                     )
-                self.group_service.grant_permission_to_group(
-                    PERMISSION_AUDITOR, "", self.settings.auditors_group
-                )
+                    self.group_service.grant_permission_to_group(
+                        PERMISSION_AUDITOR, "", self.settings.auditors_group
+                    )

--- a/tests/usecases/initialize_schema_test.py
+++ b/tests/usecases/initialize_schema_test.py
@@ -36,3 +36,11 @@ def test_initialize_schema(setup):
     assert auditors_group
     auditors_group_permissions = [p.name for p in auditors_group.my_permissions()]
     assert PERMISSION_AUDITOR in auditors_group_permissions
+
+
+def test_initialize_schema_twice(setup):
+    # type: (SetupTest) -> None
+    setup.settings.auditors_group = "auditors"
+    usecase = setup.usecase_factory.create_initialize_schema_usecase()
+    usecase.initialize_schema()
+    usecase.initialize_schema()


### PR DESCRIPTION
If sync_db was run a second time on the same database, initializing
the schema would cause a constraint violation because the auditor
permission was traged to the auditors group unconditionally.  Only
grant the permission if the group didn't already exist.

Add a test that sync_db succeeds if run twice on the same database.