### PR TITLE
Fix display of allowed permission patterns

### DIFF
--- a/grouper/fe/handlers/permissions_create.py
+++ b/grouper/fe/handlers/permissions_create.py
@@ -15,7 +15,7 @@ class PermissionsCreate(GrouperHandler):
             return self.forbidden()
 
         return self.render(
-            "permission-create.html", form=PermissionCreateForm(), can_create=can_create
+            "permission-create.html", form=PermissionCreateForm(), can_create=sorted(can_create)
         )
 
     def post(self):
@@ -59,7 +59,7 @@ class PermissionsCreate(GrouperHandler):
             return self.render(
                 "permission-create.html",
                 form=form,
-                can_create=can_create,
+                can_create=sorted(can_create),
                 alerts=self.get_form_alerts(form.errors),
             )
 

--- a/grouper/fe/templates/permission-create.html
+++ b/grouper/fe/templates/permission-create.html
@@ -17,15 +17,18 @@
             <h3 class="panel-title">Create Permission</h3>
        </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form"
+            <form class="form-horizontal" id="permission-create-form" role="form"
                   method="post" action="/permissions/create">
                 {% include "forms/permission.html" %}
                 <div class="form-permission">
                     <div class="col-sm-offset-3 col-sm-9">
-                        <p>You are only allowed to create permissions that match the following
-                        list of patterns: <strong>
-                            {{ can_create|sort|join("</strong>, <strong>") }}
-                        </strong></p>
+                        <p id="allowed-patterns">
+                            You are only allowed to create permissions that match the following
+                            list of patterns:
+                            {% for permission in can_create %}
+                            <strong>{{permission}}</strong>{{ "," if not loop.last }}
+                            {% endfor %}
+                        </p>
                         <button type="submit" class="btn btn-primary">Submit</button>
                     </div>
                 </div>

--- a/grouper/user_permissions.py
+++ b/grouper/user_permissions.py
@@ -19,7 +19,7 @@ from grouper.models.permission_map import PermissionMap
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.models.user import User
-    from typing import Optional
+    from typing import List, Optional
 
 
 def user_has_permission(session, user, permission, argument=None):
@@ -93,6 +93,7 @@ def user_grantable_permissions(session, user):
 
 
 def user_creatable_permissions(session, user):
+    # type: (Session, User) -> List[str]
     """
     Returns a list of permissions this user is allowed to create. Presently, this only counts
     permissions that a user has directly -- in other words, the 'create' permissions are not
@@ -105,7 +106,7 @@ def user_creatable_permissions(session, user):
     util function matches_glob.
     """
     if user_is_permission_admin(session, user):
-        return "*"
+        return ["*"]
 
     # Someone can create a permission if they are a member of a group that has a permission
     # of PERMISSION_CREATE with an argument that matches the name of a permission.

--- a/itests/fe/permission_create_test.py
+++ b/itests/fe/permission_create_test.py
@@ -1,0 +1,53 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import PERMISSION_CREATE
+from itests.pages.permission_create import PermissionCreatePage
+from itests.pages.permission_view import PermissionViewPage
+from itests.pages.permissions import PermissionsPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_list_create_button(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions"))
+        page = PermissionsPage(browser)
+        assert not page.has_create_permission_button
+
+        with setup.transaction():
+            setup.grant_permission_to_group(PERMISSION_CREATE, "*", "admins")
+            setup.add_user_to_group("gary@a.co", "admins")
+        browser.get(url(frontend_url, "/permissions?refresh=yes"))
+        assert page.has_create_permission_button
+
+
+def test_create_permission(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+        setup.grant_permission_to_group(PERMISSION_CREATE, "foo.*", "some-group")
+        setup.grant_permission_to_group(PERMISSION_CREATE, "bar.baz", "some-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions"))
+        page = PermissionsPage(browser)
+        page.click_create_permission_button()
+
+        create_page = PermissionCreatePage(browser)
+        assert create_page.allowed_patterns == ["bar.baz", "foo.*"]
+        create_page.set_name("foo.bar")
+        create_page.set_description("testing")
+        create_page.form.submit()
+
+        view_page = PermissionViewPage(browser)
+        assert view_page.subheading == "foo.bar"
+        assert view_page.description == "testing"

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -7,6 +7,8 @@ from pytz import UTC
 from grouper.constants import PERMISSION_CREATE
 from grouper.entities.permission import Permission
 from grouper.fe.settings import FrontendSettings
+from itests.pages.permission_create import PermissionCreatePage
+from itests.pages.permission_view import PermissionViewPage
 from itests.pages.permissions import PermissionsPage
 from itests.setup import frontend_server
 from tests.path_util import src_path
@@ -155,3 +157,26 @@ def test_list_create_button(tmpdir, setup, browser):
             setup.add_user_to_group("gary@a.co", "admins")
         browser.get(url(frontend_url, "/permissions?refresh=yes"))
         assert page.has_create_permission_button
+
+
+def test_create_permission(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+        setup.grant_permission_to_group(PERMISSION_CREATE, "foo.*", "some-group")
+        setup.grant_permission_to_group(PERMISSION_CREATE, "bar.baz", "some-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions"))
+        page = PermissionsPage(browser)
+        page.click_create_permission_button()
+
+        create_page = PermissionCreatePage(browser)
+        assert create_page.allowed_patterns == ["bar.baz", "foo.*"]
+        create_page.set_name("foo.bar")
+        create_page.set_description("testing")
+        create_page.form.submit()
+
+        view_page = PermissionViewPage(browser)
+        assert view_page.subheading == "foo.bar"
+        assert view_page.description == "testing"

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -4,11 +4,8 @@ from typing import TYPE_CHECKING
 
 from pytz import UTC
 
-from grouper.constants import PERMISSION_CREATE
 from grouper.entities.permission import Permission
 from grouper.fe.settings import FrontendSettings
-from itests.pages.permission_create import PermissionCreatePage
-from itests.pages.permission_view import PermissionViewPage
 from itests.pages.permissions import PermissionsPage
 from itests.setup import frontend_server
 from tests.path_util import src_path
@@ -140,43 +137,3 @@ def test_list_pagination(tmpdir, setup, browser):
         seen_permissions = [(r.name, r.description, r.created_on) for r in page.permission_rows]
         assert seen_permissions == sorted(expected_permissions)[2:]
         assert page.limit_label == "Limit: 10"
-
-
-def test_list_create_button(tmpdir, setup, browser):
-    # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
-    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
-        browser.get(url(frontend_url, "/permissions"))
-        page = PermissionsPage(browser)
-        assert not page.has_create_permission_button
-
-        with setup.transaction():
-            setup.grant_permission_to_group(PERMISSION_CREATE, "*", "admins")
-            setup.add_user_to_group("gary@a.co", "admins")
-        browser.get(url(frontend_url, "/permissions?refresh=yes"))
-        assert page.has_create_permission_button
-
-
-def test_create_permission(tmpdir, setup, browser):
-    # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.add_user_to_group("gary@a.co", "some-group")
-        setup.grant_permission_to_group(PERMISSION_CREATE, "foo.*", "some-group")
-        setup.grant_permission_to_group(PERMISSION_CREATE, "bar.baz", "some-group")
-
-    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
-        browser.get(url(frontend_url, "/permissions"))
-        page = PermissionsPage(browser)
-        page.click_create_permission_button()
-
-        create_page = PermissionCreatePage(browser)
-        assert create_page.allowed_patterns == ["bar.baz", "foo.*"]
-        create_page.set_name("foo.bar")
-        create_page.set_description("testing")
-        create_page.form.submit()
-
-        view_page = PermissionViewPage(browser)
-        assert view_page.subheading == "foo.bar"
-        assert view_page.description == "testing"

--- a/itests/pages/permission_create.py
+++ b/itests/pages/permission_create.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.base import BasePage
+
+if TYPE_CHECKING:
+    from selenium.webdriver.remote.webelement import WebElement
+    from typing import List
+
+
+class PermissionCreatePage(BasePage):
+    @property
+    def allowed_patterns(self):
+        # type: () -> List[str]
+        patterns = self.find_element_by_id("allowed-patterns")
+        return [e.text for e in patterns.find_elements_by_tag_name("strong")]
+
+    @property
+    def form(self):
+        # type: () -> WebElement
+        return self.find_element_by_id("permission-create-form")
+
+    def set_description(self, description):
+        # type: (str) -> None
+        field = self.form.find_element_by_name("description")
+        field.send_keys(description)
+
+    def set_name(self, name):
+        # type: (str) -> None
+        field = self.form.find_element_by_name("name")
+        field.send_keys(name)

--- a/itests/pages/permissions.py
+++ b/itests/pages/permissions.py
@@ -23,6 +23,11 @@ class PermissionsPage(BasePage):
         # type: () -> str
         return self.find_element_by_class_name("dropdown-toggle").text.strip()
 
+    def click_create_permission_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("create-permission")
+        button.click()
+
     def click_show_all_button(self):
         # type: () -> None
         button = self.find_element_by_class_name("show-all")


### PR DESCRIPTION
The list of allowed permissions on the permission create page was
using a join filter, which now auto-escapes HTML.  Replace it with
a proper for loop to avoid this.

Add a integration test for creating a permission that also checks
the list of allowed permissions that can be created.