### PR TITLE
Better logging and handling of ownerless expirations

### DIFF
--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -27,6 +27,19 @@ class AuditLogRepository(object):
         self.session = session
         self.plugins = plugins
 
+    def entries_affecting_group(self, group, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        group_obj = Group.get(self.session, name=group)
+        if not group_obj:
+            return []
+        results = (
+            self.session.query(AuditLog)
+            .filter(AuditLog.on_group_id == group_obj.id)
+            .order_by(desc(AuditLog.log_time))
+            .limit(limit)
+        )
+        return [self._to_audit_log_entry(e) for e in results]
+
     def entries_affecting_permission(self, permission, limit):
         # type: (str, int) -> List[AuditLogEntry]
         permission_obj = Permission.get(self.session, name=permission)
@@ -35,6 +48,19 @@ class AuditLogRepository(object):
         results = (
             self.session.query(AuditLog)
             .filter(AuditLog.on_permission_id == permission_obj.id)
+            .order_by(desc(AuditLog.log_time))
+            .limit(limit)
+        )
+        return [self._to_audit_log_entry(e) for e in results]
+
+    def entries_affecting_user(self, user, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        user_obj = User.get(self.session, name=user)
+        if not user_obj:
+            return []
+        results = (
+            self.session.query(AuditLog)
+            .filter(AuditLog.on_user_id == user_obj.id)
             .order_by(desc(AuditLog.log_time))
             .limit(limit)
         )

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -23,6 +23,18 @@ class AuditLogService(AuditLogInterface):
         # type: (AuditLogRepository) -> None
         self.audit_log_repository = audit_log_repository
 
+    def entries_affecting_group(self, group, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        return self.audit_log_repository.entries_affecting_group(group, limit)
+
+    def entries_affecting_permission(self, permission, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        return self.audit_log_repository.entries_affecting_permission(permission, limit)
+
+    def entries_affecting_user(self, user, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        return self.audit_log_repository.entries_affecting_user(user, limit)
+
     def log_create_service_account_from_disabled_user(self, user, authorization, date=None):
         # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
@@ -118,7 +130,3 @@ class AuditLogService(AuditLogInterface):
             on_user=request.requester,
             date=date,
         )
-
-    def entries_affecting_permission(self, permission, limit):
-        # type: (str, int) -> List[AuditLogEntry]
-        return self.audit_log_repository.entries_affecting_permission(permission, limit)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -42,6 +42,21 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
     """
 
     @abstractmethod
+    def entries_affecting_group(self, group, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        pass
+
+    @abstractmethod
+    def entries_affecting_permission(self, permission, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        pass
+
+    @abstractmethod
+    def entries_affecting_user(self, user, limit):
+        # type: (str, int) -> List[AuditLogEntry]
+        pass
+
+    @abstractmethod
     def log_create_service_account_from_disabled_user(self, user, authorization, date=None):
         # type: (str, Authorization, Optional[datetime]) -> None
         pass
@@ -93,11 +108,6 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def log_user_group_request_status_change(self, request, status, authorization, date=None):
         # type: (UserGroupRequest, GroupRequestStatus, Authorization, Optional[datetime]) -> None
-        pass
-
-    @abstractmethod
-    def entries_affecting_permission(self, permission, limit):
-        # type: (str, int) -> List[AuditLogEntry]
         pass
 
 

--- a/tests/email_util_test.py
+++ b/tests/email_util_test.py
@@ -1,0 +1,91 @@
+from datetime import datetime
+from time import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grouper.email_util import notify_edge_expiration, UnknownActorDuringExpirationException
+from grouper.models.group_edge import GroupEdge
+from grouper.settings import Settings
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_actor_for_edge_expiration(setup):
+    # type: (SetupTest) -> None
+    """Test choice of actor ID when expiring an edge.
+
+    Our current audit log model has no concept of a system-generated change and has to map every
+    change to a user ID that performed that change.  We previously had a bug where we would try to
+    grab the first owner of the group and use them as the actor when someone expired out of a
+    group, which caused uncaught exceptions if the group somehow ended up in a state with no
+    owners.  Test that we do something sane when expiring edges if possible.
+
+    Everything we're testing here is a workaround for a bug.  Once the audit log has been fixed so
+    that we can log entries for system actions without attributing them to some user in the system,
+    this test and all of the logic it's testing can go away.
+    """
+    settings = Settings()
+    now_minus_one_second = datetime.utcfromtimestamp(int(time() - 1))
+    audit_log_service = setup.service_factory.create_audit_log_service()
+
+    # An expiring individual user should be logged with an actor ID of the user.
+    with setup.transaction():
+        setup.add_user_to_group("user@a.co", "some-group", expiration=now_minus_one_second)
+    edge = setup.session.query(GroupEdge).filter_by(expiration=now_minus_one_second).one()
+    notify_edge_expiration(settings, setup.session, edge)
+    log_entries = audit_log_service.entries_affecting_user("user@a.co", 1)
+    assert log_entries
+    assert log_entries[0].actor == "user@a.co"
+    assert log_entries[0].action == "expired_from_group"
+    assert log_entries[0].on_user == "user@a.co"
+    with setup.transaction():
+        edge.delete(setup.session)
+
+    # An expiring group should be logged with an actor ID of the owner of the parent group.
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "parent-group", role="owner")
+        setup.add_user_to_group("zorkian@a.co", "child-group", role="owner")
+        setup.add_group_to_group("child-group", "parent-group", expiration=now_minus_one_second)
+    edge = setup.session.query(GroupEdge).filter_by(expiration=now_minus_one_second).one()
+    notify_edge_expiration(settings, setup.session, edge)
+    log_entries = audit_log_service.entries_affecting_group("child-group", 1)
+    assert log_entries
+    assert log_entries[0].actor == "gary@a.co"
+    assert log_entries[0].action == "expired_from_group"
+    assert log_entries[0].on_group == "child-group"
+    log_entries = audit_log_service.entries_affecting_group("parent-group", 1)
+    assert log_entries
+    assert log_entries[0].actor == "gary@a.co"
+    assert log_entries[0].action == "expired_from_group"
+    assert log_entries[0].on_group == "parent-group"
+    with setup.transaction():
+        edge.delete(setup.session)
+
+    # If the parent group has no owner, it should be logged with an actor ID of the owner of the
+    # child group.
+    with setup.transaction():
+        setup.add_user_to_group("zorkian@a.co", "a-group", role="owner")
+        setup.add_group_to_group("a-group", "ownerless-group", expiration=now_minus_one_second)
+    edge = setup.session.query(GroupEdge).filter_by(expiration=now_minus_one_second).one()
+    notify_edge_expiration(settings, setup.session, edge)
+    log_entries = audit_log_service.entries_affecting_group("a-group", 1)
+    assert log_entries
+    assert log_entries[0].actor == "zorkian@a.co"
+    assert log_entries[0].action == "expired_from_group"
+    assert log_entries[0].on_group == "a-group"
+    log_entries = audit_log_service.entries_affecting_group("ownerless-group", 1)
+    assert log_entries
+    assert log_entries[0].actor == "zorkian@a.co"
+    assert log_entries[0].action == "expired_from_group"
+    assert log_entries[0].on_group == "ownerless-group"
+    with setup.transaction():
+        edge.delete(setup.session)
+
+    # If neither group has an owner, raise an exception.
+    with setup.transaction():
+        setup.add_group_to_group("other-group", "ownerless-group", expiration=now_minus_one_second)
+    edge = setup.session.query(GroupEdge).filter_by(expiration=now_minus_one_second).one()
+    with pytest.raises(UnknownActorDuringExpirationException):
+        notify_edge_expiration(settings, setup.session, edge)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -141,8 +141,8 @@ class SetupTest(object):
         user = User(username=name)
         user.add(self.session)
 
-    def add_group_to_group(self, member, group):
-        # type: (str, str) -> None
+    def add_group_to_group(self, member, group, expiration=None):
+        # type: (str, str, Optional[datetime]) -> None
         self.create_group(member)
         self.create_group(group)
         member_obj = Group.get(self.session, name=member)
@@ -153,13 +153,14 @@ class SetupTest(object):
             group_id=group_obj.id,
             member_type=OBJ_TYPES["Group"],
             member_pk=member_obj.id,
+            expiration=expiration,
             active=True,
             _role=GROUP_EDGE_ROLES.index("member"),
         )
         edge.add(self.session)
 
-    def add_user_to_group(self, user, group, role="member"):
-        # type: (str, str, str) -> None
+    def add_user_to_group(self, user, group, role="member", expiration=None):
+        # type: (str, str, str, Optional[datetime]) -> None
         self.create_user(user)
         self.create_group(group)
         user_obj = User.get(self.session, name=user)
@@ -170,6 +171,7 @@ class SetupTest(object):
             group_id=group_obj.id,
             member_type=OBJ_TYPES["User"],
             member_pk=user_obj.id,
+            expiration=expiration,
             active=True,
             _role=GROUP_EDGE_ROLES.index(role),
         )


### PR DESCRIPTION
When expiring a group edge, we had been picking a random owner from
the group from which the edge was expiring.  We did this without
checking if that group had an owner, so if it didn't, Grouper would
raise an entirely uninformative StopIteration exception.

Drastically reduce the incidence of this problem by using the user
themselves as the actor ID when expiring a user (since the actor ID
is fairly arbitrary anyway) and, when expiring edges to another group,
using an arbitrary owner of the parent group or an arbitrary owner of
the child group.

When expiring a group edge between two groups, both of which have no
owners, there isn't much we can do given the current design of the
audit log, but raise an explicit exception that lists both of the
affected groups to make it easier to fix manually.