### PR TITLE
Add statistic for graph updates

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -10,6 +10,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import label, literal
 
+from grouper import stats
 from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.models.counter import Counter
 from grouper.models.group import Group
@@ -129,6 +130,8 @@ class GroupGraph(object):
                 return
             self.logger.debug("Checkpoint changed; updating!")
 
+            start_time = datetime.utcnow()
+
             new_graph = DiGraph()
             new_graph.add_nodes_from(self._get_nodes_from_db(session))
             new_graph.add_edges_from(self._get_edges_from_db(session))
@@ -171,6 +174,9 @@ class GroupGraph(object):
                 self.permission_tuples = permission_tuples
                 self.group_tuples = group_tuples
                 self.disabled_group_tuples = disabled_group_tuples
+
+            duration = datetime.utcnow() - start_time
+            stats.log_rate("graph_update_ms", int(duration.total_seconds() * 1000))
 
     @staticmethod
     def _get_checkpoint(session):

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -30,6 +30,10 @@ class PluginProxy(object):
         # type: (List[BasePlugin]) -> None
         self._plugins = plugins
 
+    def add_plugin(self, plugin):
+        # type: (BasePlugin) -> None
+        self._plugins.append(plugin)
+
     def check_machine_set(self, name, machine_set):
         # type: (str, str) -> None
         for plugin in self._plugins:

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -1,0 +1,31 @@
+from typing import TYPE_CHECKING
+
+from grouper.plugin.base import BasePlugin
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+class MockStats(BasePlugin):
+    def __init__(self):
+        # type: () -> None
+        self.update_ms = 0.0
+
+    def log_rate(self, key, val, count=1):
+        # type: (str, float, int) -> None
+        assert key == "graph_update_ms"
+        assert count == 1
+        self.update_ms = val
+
+
+def test_graph_update_stats(setup):
+    # type: (SetupTest) -> None
+    """Test that update timings are logged by a graph update."""
+    mock_stats = MockStats()
+    setup.plugin_proxy.add_plugin(mock_stats)
+
+    # Create a user and a group, which will trigger a graph update.
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    assert mock_stats.update_ms > 0.0

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -67,6 +67,7 @@ class SetupTest(object):
         settings: Settings object for tests (only the database is configured)
         graph: Underlying graph (not refreshed from the database automatically!)
         session: The underlying database session
+        plugin_proxy: The plugin proxy used for the tests
         repository_factory: Factory for repository objects
         service_factory: Factory for service objects
         usecase_factory: Factory for usecase objects
@@ -76,18 +77,18 @@ class SetupTest(object):
         # type: (LocalPath) -> None
         self.settings = Settings()
         self.settings.database = db_url(tmpdir)
-
-        self.initialize_database()
+        self.plugin_proxy = PluginProxy([])
 
         # Reinitialize the global plugin proxy with an empty set of plugins in case a previous test
         # initialized plugins.  This can go away once a plugin proxy is injected into everything
         # that needs it instead of maintained as a global.
-        set_global_plugin_proxy(PluginProxy([]))
+        set_global_plugin_proxy(self.plugin_proxy)
 
+        self.initialize_database()
         self.session = SessionFactory(self.settings).create_session()
         self.graph = GroupGraph()
         self.repository_factory = GraphRepositoryFactory(
-            self.settings, PluginProxy([]), SingletonSessionFactory(self.session), self.graph
+            self.settings, self.plugin_proxy, SingletonSessionFactory(self.session), self.graph
         )
         self.service_factory = ServiceFactory(self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.settings, self.service_factory)


### PR DESCRIPTION
Log the elapsed milliseconds for each graph update.  This will help
us catch regressions and evaluate the impact of further graph
optimizations.