### PR TITLE
Remove unused cutoff API feature

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -29,7 +29,7 @@ from grouper.util import singleton
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from grouper.service_account import ServiceAccountPermission
-    from typing import Any, Dict, Iterable, List, Optional, Set
+    from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 MEMBER_TYPE_MAP = {"User": "users", "Group": "subgroups"}
 EPOCH = datetime(1970, 1, 1)
@@ -86,8 +86,8 @@ class GroupGraph(object):
     def __init__(self):
         # type: () -> None
         self.logger = logging.getLogger(__name__)
-        self._graph = None  # type: Optional[DiGraph]
-        self._rgraph = None  # type: Optional[DiGraph]
+        self._graph = DiGraph()
+        self._rgraph = DiGraph()
         self.lock = RLock()
         self.update_lock = RLock()
         self.users = set()  # type: Set[str]
@@ -559,7 +559,8 @@ class GroupGraph(object):
                 )
         return groups
 
-    def get_group_details(self, groupname, cutoff=None, show_permission=None, expose_aliases=True):
+    def get_group_details(self, groupname, show_permission=None, expose_aliases=True):
+        # type: (str, Optional[str], bool) -> Dict[str, Any]
         """ Get users and permissions that belong to a group. Raise NoSuchGroup
         for missing groups. """
 
@@ -573,15 +574,15 @@ class GroupGraph(object):
                 "subgroups": {},
                 "permissions": [],
                 "audited": group_audited,
-            }
+            }  # type: Dict[str, Any]
             if groupname in self.group_service_accounts:
                 data["service_accounts"] = self.group_service_accounts[groupname]
 
             group = ("Group", groupname)
             if not self._graph.has_node(group):
                 raise NoSuchGroup("Group %s is either missing or disabled." % groupname)
-            paths = single_source_shortest_path(self._graph, group, cutoff)
-            rpaths = single_source_shortest_path(self._rgraph, group, cutoff)
+            paths = single_source_shortest_path(self._graph, group)
+            rpaths = single_source_shortest_path(self._rgraph, group)
 
             for member, path in iteritems(paths):
                 if member == group:
@@ -649,12 +650,11 @@ class GroupGraph(object):
             data["audited"] = group_audited
             return data
 
-    def get_user_details(self, username, cutoff=None, expose_aliases=True):
+    def get_user_details(self, username, expose_aliases=True):
+        # type: (str, bool) -> Dict[str, Any]
         """ Get a user's groups and permissions.  Raise NoSuchUser for missing users."""
-        max_dist = cutoff - 1 if (cutoff is not None) else None
-
-        groups = {}
-        permissions = []
+        groups = {}  # type: Dict[str, Dict[str, Any]]
+        permissions = []  # type: List[Dict[str, Any]]
         user_details = {"groups": groups, "permissions": permissions}
 
         with self.lock:
@@ -687,7 +687,7 @@ class GroupGraph(object):
             # user is a member by inheritance, except for ancestors of groups
             # where their role is "np-owner", unless the user is a member of
             # such an ancestor via a non-"np-owner" role in another group.
-            rpaths = {}
+            rpaths = {}  # type: Dict[str, List[Tuple[str, str]]]
             for group in self._rgraph.neighbors(user):
                 role = self._rgraph[user][group]["role"]
                 if GROUP_EDGE_ROLES[role] == "np-owner":
@@ -700,7 +700,7 @@ class GroupGraph(object):
                         "rolename": GROUP_EDGE_ROLES[role],
                     }
                     continue
-                new_rpaths = single_source_shortest_path(self._rgraph, group, max_dist)
+                new_rpaths = single_source_shortest_path(self._rgraph, group)
                 for parent, path in iteritems(new_rpaths):
                     if parent not in rpaths or 1 + len(path) < len(rpaths[parent]):
                         rpaths[parent] = [user] + path
@@ -718,17 +718,17 @@ class GroupGraph(object):
                     "rolename": GROUP_EDGE_ROLES[role],
                 }
 
-                for permission in self.permission_metadata[parent_name]:
+                for service_permission in self.permission_metadata[parent_name]:
                     perm_data = {
-                        "permission": permission.permission,
-                        "argument": permission.argument,
-                        "granted_on": (permission.granted_on - EPOCH).total_seconds(),
+                        "permission": service_permission.permission,
+                        "argument": service_permission.argument,
+                        "granted_on": (service_permission.granted_on - EPOCH).total_seconds(),
                         "path": [elem[1] for elem in path],
                         "distance": len(path) - 1,
                     }
 
                     if expose_aliases:
-                        perm_data["alias"] = permission.alias
+                        perm_data["alias"] = service_permission.alias
 
                     permissions.append(perm_data)
 

--- a/tests/api/handlers_test.py
+++ b/tests/api/handlers_test.py
@@ -56,8 +56,6 @@ def test_users(users, http_client, base_url):  # noqa: F811
     assert body["status"] == "ok"
     assert sorted(body["data"]["users"]) == all_users
 
-    # TODO: test cutoff
-
 
 @pytest.mark.gen_test
 def test_multi_users(users, http_client, base_url):  # noqa: F811
@@ -120,8 +118,6 @@ def test_service_accounts(session, standard_graph, users, http_client, base_url)
     assert sorted(body["data"]["service_accounts"]) == sorted(
         [u.name for u in itervalues(users) if u.role_user] + ["service@a.co"]
     )
-
-    # TODO: test cutoff
 
     # Retrieve a single service account and check its metadata.
     api_url = url(base_url, "/service_accounts/service@a.co")
@@ -273,8 +269,6 @@ def test_groups(groups, http_client, base_url):  # noqa: F811
     assert resp.code == 200
     assert body["status"] == "ok"
     assert sorted(body["data"]["groups"]) == sorted(groups)
-
-    # TODO: test cutoff
 
 
 @pytest.mark.gen_test

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,44 +1,78 @@
+from typing import TYPE_CHECKING
+
 import grouper.permissions
 
+if TYPE_CHECKING:
+    from datetime import datetime
+    from grouper.graph import GroupGraph
+    from grouper.models.group import Group
+    from grouper.models.permission import Permission
+    from grouper.models.request import Request
+    from grouper.models.user import User
+    from typing import Optional, Set, Union
 
-# These functions operate on and return instrumented Grouper.models.Model instances.
+
 def add_member(parent, member, role="member", expiration=None):
+    # type: (Group, Union[User, Group], str, Optional[datetime]) -> Request
     return parent.add_member(
         member, member, "Unit Testing", "actioned", role=role, expiration=expiration
     )
 
 
 def edit_member(parent, member, role="member", expiration=None):
-    return parent.edit_member(member, member, "Unit Testing", role=role, expiration=expiration)
+    # type: (Group, Union[User, Group], str, Optional[datetime]) -> None
+    parent.edit_member(member, member, "Unit Testing", role=role, expiration=expiration)
 
 
 def revoke_member(parent, member):
-    return parent.revoke_member(member, member, "Unit Testing")
+    # type: (Group, Union[User, Group]) -> None
+    parent.revoke_member(member, member, "Unit Testing")
 
 
 def grant_permission(group, permission, argument=""):
-    return grouper.permissions.grant_permission(
-        group.session, group.id, permission.id, argument=argument
-    )
+    # type: (Group, Permission, str) -> None
+    grouper.permissions.grant_permission(group.session, group.id, permission.id, argument=argument)
 
 
 def get_users(graph, groupname, cutoff=None):
-    return set(graph.get_group_details(groupname, cutoff)["users"])
+    # type: (GroupGraph, str, Optional[int]) -> Set[str]
+    if cutoff:
+        users = graph.get_group_details(groupname)["users"]
+        result = set()
+        for user in users:
+            if users[user]["distance"] <= cutoff:
+                result.add(user)
+        return result
+    else:
+        return set(graph.get_group_details(groupname)["users"])
 
 
 def get_groups(graph, username, cutoff=None):
-    return set(graph.get_user_details(username, cutoff)["groups"])
+    # type: (GroupGraph, str, Optional[int]) -> Set[str]
+    if cutoff:
+        groups = graph.get_user_details(username)["groups"]
+        result = set()
+        for group in groups:
+            if groups[group]["distance"] <= cutoff:
+                result.add(group)
+        return result
+    else:
+        return set(graph.get_user_details(username)["groups"])
 
 
 def get_user_permissions(graph, username, cutoff=None):
+    # type: (GroupGraph, str, Optional[int]) -> Set[str]
     return {
         "{}:{}".format(permission["permission"], permission["argument"])
-        for permission in graph.get_user_details(username, cutoff)["permissions"]
+        for permission in graph.get_user_details(username)["permissions"]
+        if not cutoff or permission["distance"] <= cutoff
     }
 
 
 def get_group_permissions(graph, groupname, cutoff=None):
+    # type: (GroupGraph, str, Optional[int]) -> Set[str]
     return {
         "{}:{}".format(permission["permission"], permission["argument"])
-        for permission in graph.get_group_details(groupname, cutoff)["permissions"]
+        for permission in graph.get_group_details(groupname)["permissions"]
+        if not cutoff or permission["distance"] <= cutoff
     }


### PR DESCRIPTION
The API server supported giving an optional cutoff as a parameter
to several routes, which would restrict graph calculations for
group membership and permissions to paths shorter than that cutoff.
This was never supported by Groupy and not tested except as a side
effect of another test, and I see no sign that we ever used it.

Drop this feature to simplify the graph code.

Add type annotations to all changed functions so that mypy has a
better chance of catching errors.  This required cleaning up some
typing in the graph code.