### PR TITLE
Additional graph cleanup

### DIFF
--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -99,7 +99,7 @@ class BackgroundProcessor(object):
         nonauditor_approver_to_groups = defaultdict(set)  # type: Dict[User, Set[str]]
         user_is_auditor = {}  # type: Dict[str, bool]
         for group_tuple in graph.get_groups(audited=True, directly_audited=False):
-            group_md = graph.get_group_details(group_tuple.groupname, expose_aliases=False)
+            group_md = graph.get_group_details(group_tuple.name, expose_aliases=False)
             for username, user_md in iteritems(group_md["users"]):
                 if username not in user_is_auditor:
                     user_perms = graph.get_user_details(username)["permissions"]
@@ -111,7 +111,7 @@ class BackgroundProcessor(object):
                     continue
                 if user_md["role"] in APPROVER_ROLE_INDICES:
                     # non-auditor approver. BAD!
-                    nonauditor_approver_to_groups[username].add(group_tuple.groupname)
+                    nonauditor_approver_to_groups[username].add(group_tuple.name)
 
         if nonauditor_approver_to_groups:
             auditors_group = get_auditors_group(self.settings, session)

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -8,7 +8,7 @@ from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Set
 
 
 class GroupsView(GrouperHandler):
@@ -24,7 +24,7 @@ class GroupsView(GrouperHandler):
 
         if not enabled:
             groups = self.graph.get_disabled_groups()
-            directly_audited_groups = None
+            directly_audited_groups = set()  # type: Set[str]
         elif audited_only:
             groups = self.graph.get_groups(audited=True)
             directly_audited_groups = set(

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -26,12 +26,12 @@ class GroupsView(GrouperHandler):
             groups = self.graph.get_disabled_groups()
             directly_audited_groups = None
         elif audited_only:
-            groups = self.graph.get_groups(audited=True, directly_audited=False)
+            groups = self.graph.get_groups(audited=True)
             directly_audited_groups = set(
-                [g.groupname for g in self.graph.get_groups(audited=True, directly_audited=True)]
+                [g.name for g in self.graph.get_groups(directly_audited=True)]
             )
         else:
-            groups = self.graph.get_groups(audited=False)
+            groups = self.graph.get_groups()
             directly_audited_groups = set()
         groups = [group for group in groups if not group.service_account]
         total = len(groups)

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -30,7 +30,7 @@
               data-target="#createModal">
           <i class="fa fa-plus"></i> Create
       </button>
-      <a class="btn btn-warning" href="/groups?limit={{limit}}&audited=1">
+      <a id="show-audited" class="btn btn-warning" href="/groups?limit={{limit}}&audited=1">
           <i class="fa"></i> Show audited groups
       </a>
       {% endif %}
@@ -49,7 +49,7 @@
         <table class="table table-elist">
             <thead>
                 <tr>
-                    <th class="col-sm-2">Groupname</th>
+                    <th class="col-sm-2">Group name</th>
                     <th class="col-sm-4">Description</th>
                     <th class="col-sm-1">Can join?</th>
 		    {% if audited_groups %}
@@ -73,7 +73,7 @@
                     </td>
 		    {% if audited_groups %}
 		    <td class="group-why-audited">
-		      {% if group.groupname in directly_audited_groups %}
+		      {% if group.name in directly_audited_groups %}
 		      Direct
 		      {% else %}
 		      Inherited

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -73,11 +73,9 @@ class GrouperHandler(SentryHandler):
 
         stats.log_rate("requests", 1)
         stats.log_rate("requests_{}".format(self.__class__.__name__), 1)
-        logging.error("initialized")
 
     def set_default_headers(self):
         # type: () -> None
-        logging.error(self)
         self.set_header("Content-Security-Policy", self.settings["template_engine"].csp_header())
         self.set_header("Referrer-Policy", "same-origin")
 

--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from itests.fixtures import async_server  # noqa: F401
@@ -9,6 +11,7 @@ from itests.pages.groups import (
     GroupsViewPage,
     GroupViewPage,
 )
+from itests.setup import frontend_server
 from plugins import group_ownership_policy
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
@@ -22,6 +25,11 @@ from tests.fixtures import (  # noqa: F401
 )
 from tests.url_util import url
 
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
 
 def test_list_groups(async_server, browser, groups):  # noqa: F811
     fe_url = url(async_server, "/groups")
@@ -32,6 +40,32 @@ def test_list_groups(async_server, browser, groups):  # noqa: F811
     for name in groups:
         row = page.find_group_row(name)
         assert row.href.endswith("/groups/{}".format(name))
+
+
+def test_list_audited_groups(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_group("one-group", "Some group")
+        setup.create_group("audited-group", "Another group")
+        setup.create_permission("audited", "", audited=True)
+        setup.grant_permission_to_group("audited", "", "audited-group")
+        setup.add_group_to_group("child-audited", "audited-group")
+        setup.create_user("gary@a.co")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups"))
+        page = GroupsViewPage(browser)
+        assert page.find_group_row("one-group")
+        assert page.find_group_row("audited-group")
+        assert page.find_group_row("child-audited")
+
+        page.click_show_audited_button()
+        row = page.find_group_row("audited-group")
+        assert row.audited_reason == "Direct"
+        row = page.find_group_row("child-audited")
+        assert row.audited_reason == "Inherited"
+        with pytest.raises(NoSuchElementException):
+            page.find_group_row("one-group")
 
 
 def test_show_group(async_server, browser, groups):  # noqa: F811

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -32,6 +32,7 @@ class GroupEditMemberPage(BasePage):
 
 class GroupsViewPage(BasePage):
     def find_group_row(self, name):
+        # type: (str) -> GroupRow
         for row in self.find_elements_by_class_name("group-row"):
             group_row = GroupRow(row)
             if group_row.name == name:
@@ -42,6 +43,11 @@ class GroupsViewPage(BasePage):
     def click_create_group_button(self):
         # type: () -> None
         button = self.find_element_by_id("create-group")
+        button.click()
+
+    def click_show_audited_button(self):
+        # type: () -> None
+        button = self.find_element_by_id("show-audited")
         button.click()
 
     def get_create_group_modal(self):
@@ -181,11 +187,18 @@ class AuditMemberRow(BaseElement):
 
 class GroupRow(BaseElement):
     @property
+    def audited_reason(self):
+        # type: () -> str
+        return self.find_element_by_class_name("group-why-audited").text
+
+    @property
     def name(self):
+        # type: () -> str
         return self.find_element_by_class_name("group-name").text
 
     @property
     def href(self):
+        # type: () -> str
         name = self.find_element_by_class_name("group-name")
         link = name.find_element_by_tag_name("a")
         return link.get_attribute("href")

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -162,7 +162,6 @@ def test_get_disabled_groups(setup):
     disabled_groups = setup.graph.get_disabled_groups()
     assert len(disabled_groups) == 1
     disabled_group = disabled_groups[0]
-    assert disabled_group.groupname == "sad-team"
     assert disabled_group.name == "sad-team"
     assert disabled_group.description == "Some group"
     assert disabled_group.canjoin == GroupJoinPolicy.CAN_JOIN.value
@@ -185,7 +184,6 @@ def test_get_groups(setup):
         "tech-ops",
     ]
     for group in groups:
-        assert group.groupname == group.name
         assert group.description == ""
         assert group.canjoin == GroupJoinPolicy.CAN_ASK.value
         assert group.enabled


### PR DESCRIPTION
Return a Permission from the graph instead of the almost-the-same
PermissionTuple.  Stop exposing the database-generated group ID to
graph callers, and stop storing the name of the group twice under
different names in GroupTuple.

Add type annotations to every graph function for better mypy
checking in preparation for more refactoring.  Remove the unused
nodes and edges properties.

Fix a variable naming error distinguishing service permission grants
from group permission grants introduced in a previous commit.

Stop returning group permissions as part of the base group metadata,
since the only caller calls get_group_details to get the permissions
anyway.  The permissions included in the base group metadata were only
the directly granted permissions and thus weren't useful.

Add a test for the untested audited groups view page and fix a missing
space in one of the table row titles.
    
Remove some stray logging calls that crept in from an earlier diff,
discovered while adding the new test.