### PR TITLE
Rename _audited to audited in Permission model

### DIFF
--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -332,7 +332,7 @@ class GroupGraph(object):
                     name=permission.name,
                     description=permission.description,
                     created_on=permission.created_on,
-                    audited=permission._audited,
+                    audited=permission.audited,
                 )
             )
         return out

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -24,7 +24,7 @@ class Permission(Model):
     name = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     description = Column(Text, nullable=False)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
-    _audited = Column("audited", Boolean, default=False, nullable=False)
+    audited = Column("audited", Boolean, default=False, nullable=False)
     enabled = Column("enabled", Boolean, default=True, nullable=False)
 
     @staticmethod
@@ -32,7 +32,3 @@ class Permission(Model):
         if name is not None:
             return session.query(Permission).filter_by(name=name).scalar()
         return None
-
-    @property
-    def audited(self):
-        return self._audited

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -24,8 +24,8 @@ class Permission(Model):
     name = Column(String(length=MAX_NAME_LENGTH), unique=True, nullable=False)
     description = Column(Text, nullable=False)
     created_on = Column(DateTime, default=datetime.utcnow, nullable=False)
-    audited = Column("audited", Boolean, default=False, nullable=False)
-    enabled = Column("enabled", Boolean, default=True, nullable=False)
+    audited = Column(Boolean, default=False, nullable=False)
+    enabled = Column(Boolean, default=True, nullable=False)
 
     @staticmethod
     def get(session, name=None):

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -199,7 +199,7 @@ def enable_permission_auditing(session, permission_name, actor_user_id):
     if not permission:
         raise NoSuchPermission(name=permission_name)
 
-    permission._audited = True
+    permission.audited = True
 
     AuditLog.log(
         session,
@@ -226,7 +226,7 @@ def disable_permission_auditing(session, permission_name, actor_user_id):
     if not permission:
         raise NoSuchPermission(name=permission_name)
 
-    permission._audited = False
+    permission.audited = False
 
     AuditLog.log(
         session,

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -87,7 +87,7 @@ class SQLPermissionRepository(PermissionRepository):
     ):
         # type: (str, str, bool, bool, Optional[datetime]) -> None
         permission = SQLPermission(
-            name=name, description=description, _audited=audited, enabled=enabled
+            name=name, description=description, audited=audited, enabled=enabled
         )
         if created_on:
             permission.created_on = created_on


### PR DESCRIPTION
The Permission model used _audited as the Python name for the
audited database column and then added a property named audited.
This presumably was some way to make changing the property harder,
but seems pointless.  Stop doing this.