### PR TITLE
Use the Group entity in the graph

### DIFF
--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -11,7 +11,14 @@ class GroupJoinPolicy(Enum):
 
 
 Group = NamedTuple(
-    "Group", [("name", str), ("description", str), ("join_policy", GroupJoinPolicy)]
+    "Group",
+    [
+        ("name", str),
+        ("description", str),
+        ("join_policy", GroupJoinPolicy),
+        ("enabled", bool),
+        ("is_role_user", bool),
+    ],
 )
 
 

--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -33,7 +33,7 @@ class GroupsView(GrouperHandler):
         else:
             groups = self.graph.get_groups()
             directly_audited_groups = set()
-        groups = [group for group in groups if not group.service_account]
+        groups = [group for group in groups if not group.is_role_user]
         total = len(groups)
         groups = groups[offset : offset + limit]
 

--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -60,7 +60,7 @@
             <tbody>
             {% for group in groups %}
                 <tr class="group-row">
-                    <td class="group-name">{{ account(group) }}</td>
+                    <td class="group-name">{{ account(group.name, "group") }}</td>
                     <td class="group-description">{{group.description|default("", True)}}</td>
                     <td class="group-can-join">
                         {% if group.canjoin == "canjoin" %}

--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from grouper.entities.group import Group, GroupJoinPolicy
 from grouper.models.group import Group as SQLGroup
+from grouper.models.user import User as SQLUser
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
@@ -25,8 +26,12 @@ class GroupRepository(object):
         group = SQLGroup.get(self.session, name=name)
         if not group:
             return None
+        user = SQLUser.get(self.session, name=name)
+        is_role_user = user.role_user if user else False
         return Group(
             name=group.groupname,
             description=group.description,
             join_policy=GroupJoinPolicy(group.canjoin),
+            enabled=group.enabled,
+            is_role_user=is_role_user,
         )

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -164,8 +164,9 @@ def test_get_disabled_groups(setup):
     disabled_group = disabled_groups[0]
     assert disabled_group.name == "sad-team"
     assert disabled_group.description == "Some group"
-    assert disabled_group.canjoin == GroupJoinPolicy.CAN_JOIN.value
+    assert disabled_group.join_policy == GroupJoinPolicy.CAN_JOIN
     assert not disabled_group.enabled
+    assert not disabled_group.is_role_user
 
 
 def test_get_groups(setup):
@@ -185,8 +186,9 @@ def test_get_groups(setup):
     ]
     for group in groups:
         assert group.description == ""
-        assert group.canjoin == GroupJoinPolicy.CAN_ASK.value
+        assert group.join_policy == GroupJoinPolicy.CAN_ASK
         assert group.enabled
+        assert not group.is_role_user
 
     groups = setup.graph.get_groups(audited=True)
     group_names = [g.name for g in groups]


### PR DESCRIPTION
Rather than using a custom GroupTuple type in the graph, reuse the
Group entity from grouper.entities.group.  This required adding the
is_role_user flag to that entity and populating it in the repository,
and removing the uses of some of the other elements of GroupTuple
that weren't strictly necessary.