### PR TITLE
Switch to PermissionGrant in the graph

### DIFF
--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -1,6 +1,11 @@
+from datetime import datetime
 from typing import NamedTuple
 
-PermissionGrant = NamedTuple("PermissionGrant", [("name", str), ("argument", str)])
+# Represents a grant of a permission to either a group or a service account.
+PermissionGrant = NamedTuple(
+    "PermissionGrant",
+    [("permission", str), ("argument", str), ("granted_on", datetime), ("is_alias", bool)],
+)
 GroupPermissionGrant = NamedTuple(
     "GroupPermissionGrant", [("group", str), ("permission", str), ("argument", str)]
 )

--- a/grouper/fe/templates/service-account-permission-grant.html
+++ b/grouper/fe/templates/service-account-permission-grant.html
@@ -17,7 +17,7 @@
             <h3 class="panel-title">Grant Permission to {{user.username}}</h3>
         </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form" method="post"
+            <form id="grant-permission-form" class="form-horizontal" role="form" method="post"
                   action="/groups/{{group.name}}/service/{{user.username}}/grant">
                 {% include "forms/service-account-permission-grant.html" %}
                 <div class="form-group">

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -21,15 +21,17 @@
                 </thead>
                 <tbody>
                 {% for map in mappings %}
-                    <tr>
-                        <td>{{ permission(map) }}</td>
-                        <td class="col-sm-2">{{ map.argument|default("(unargumented)", True) }}</td>
+                    <tr class="permission-row">
+                        <td class="permission-name">{{ permission(map) }}</td>
+                        <td class="col-sm-2 permission-argument">
+                            {{ map.argument|default("(unargumented)", True) }}
+                        </td>
                         <td class="col-sm-2" title="{{ map.granted_on|print_date }}">
                             {{ map.granted_on|long_ago_str }}
                         </td>
                         {% if can_manage %}
                             <td class="col-sm-2">
-                                <button class="btn btn-danger btn-xs"
+                                <button class="btn btn-danger btn-xs permission-revoke"
                                         data-toggle="modal"
                                         data-target="#revokeModal"
                                         data-mapping-id="{{map.mapping_id}}">
@@ -51,7 +53,8 @@
         </div>
         {% if can_manage %}
         <div class='panel-footer'>
-            <a class="btn btn-default btn-sm" href="/groups/{{group.name}}/service/{{user.username}}/grant">
+            <a id="add-permission" class="btn btn-default btn-sm"
+               href="/groups/{{group.name}}/service/{{user.username}}/grant">
                 <span class="glyphicon glyphicon-plus"></span> Add Permission
             </a>
         </div>

--- a/grouper/models/permission.py
+++ b/grouper/models/permission.py
@@ -1,14 +1,9 @@
-from collections import namedtuple
 from datetime import datetime
 
 from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
 
 from grouper.constants import MAX_NAME_LENGTH
 from grouper.models.base.model_base import Model
-
-MappedPermission = namedtuple(
-    "MappedPermission", ["permission", "audited", "argument", "groupname", "granted_on", "alias"]
-)
 
 
 class Permission(Model):

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -132,6 +132,11 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
 
     def permission_grants_for_user(self, name):
         # type: (str) -> List[PermissionGrant]
+        """Return all permission grants a user has from whatever source.
+
+        TODO(rra): Currently does not expand permission aliases, and therefore doesn't match the
+        graph behavior.  Use with caution until that is fixed.
+        """
         now = datetime.utcnow()
         user = User.get(self.session, name=name)
         if not user or user.role_user or user.is_service_account or not user.enabled:

--- a/itests/pages/service_accounts.py
+++ b/itests/pages/service_accounts.py
@@ -1,50 +1,126 @@
+from typing import TYPE_CHECKING
+
 from selenium.webdriver.support.select import Select
 
-from itests.pages.base import BaseModal, BasePage
+from itests.pages.base import BaseElement, BaseModal, BasePage
+
+if TYPE_CHECKING:
+    from selenium.webdriver.remote.webelement import WebElement
+    from typing import List
 
 
 class ServiceAccountViewPage(BasePage):
+    @property
+    def permission_rows(self):
+        # type: () -> List[ServiceAccountPermissionRow]
+        all_permission_rows = self.find_elements_by_class_name("permission-row")
+        return [ServiceAccountPermissionRow(row) for row in all_permission_rows]
+
+    def click_add_permission_button(self):
+        # type: () -> None
+        button = self.find_element_by_id("add-permission")
+        button.click()
+
     def click_disable_button(self):
+        # type: () -> None
         button = self.find_element_by_class_name("disable-service-account")
         button.click()
 
     def click_enable_button(self):
+        # type: () -> None
         button = self.find_element_by_class_name("enable-service-account")
         button.click()
 
     def get_disable_modal(self):
+        # type: () -> DisableServiceAccountModal
         element = self.find_element_by_id("disableModal")
         self.wait_until_visible(element)
         return DisableServiceAccountModal(element)
 
+    def get_revoke_permission_modal(self):
+        # type: () -> RevokeServiceAccountPermissionModal
+        element = self.find_element_by_id("revokeModal")
+        self.wait_until_visible(element)
+        return RevokeServiceAccountPermissionModal(element)
+
 
 class ServiceAccountCreatePage(BasePage):
     def _get_new_service_account_form(self):
+        # type: () -> WebElement
         return self.find_element_by_class_name("new-service-account-form")
 
     def set_name(self, name):
+        # type: (str) -> None
         form = self._get_new_service_account_form()
         field = form.find_element_by_name("name")
         field.send_keys(name)
 
     def submit(self):
+        # type: () -> None
         form = self._get_new_service_account_form()
         form.submit()
 
 
 class ServiceAccountEnablePage(BasePage):
     def _get_enable_service_account_form(self):
+        # type: () -> WebElement
         return self.find_element_by_class_name("enable-service-account-form")
 
     def select_owner(self, owner):
+        # type: (str) -> None
         form = self._get_enable_service_account_form()
         owner_select = form.find_element_by_tag_name("select")
         Select(owner_select).select_by_visible_text(owner)
 
     def submit(self):
+        # type: () -> None
         form = self._get_enable_service_account_form()
+        form.submit()
+
+
+class ServiceAccountGrantPermissionPage(BasePage):
+    def _get_grant_permission_form(self):
+        # type: () -> WebElement
+        return self.find_element_by_id("grant-permission-form")
+
+    def select_permission(self, permission):
+        # type: (str) -> None
+        form = self._get_grant_permission_form()
+        permission_select = form.find_element_by_name("permission")
+        Select(permission_select).select_by_visible_text(permission)
+
+    def set_argument(self, argument):
+        # type: (str) -> None
+        form = self._get_grant_permission_form()
+        field = form.find_element_by_name("argument")
+        field.send_keys(argument)
+
+    def submit(self):
+        # type: () -> None
+        form = self._get_grant_permission_form()
         form.submit()
 
 
 class DisableServiceAccountModal(BaseModal):
     pass
+
+
+class RevokeServiceAccountPermissionModal(BaseModal):
+    pass
+
+
+class ServiceAccountPermissionRow(BaseElement):
+    @property
+    def permission(self):
+        # type: () -> str
+        return self.find_element_by_class_name("permission-name").text
+
+    @property
+    def argument(self):
+        # type: () -> str
+        return self.find_element_by_class_name("permission-argument").text
+
+    def click_revoke_button(self):
+        # type: () -> None
+        button = self.find_element_by_class_name("permission-revoke")
+        button.click()

--- a/tests/groups_test.py
+++ b/tests/groups_test.py
@@ -260,7 +260,7 @@ def test_graph_disable(session, graph, groups, http_client, base_url):  # noqa: 
     graph.update_from_db(session)
     old_groups = graph.groups
     assert sorted(old_groups) == sorted(groups.keys())
-    assert groupname in graph.permission_metadata
+    assert groupname in graph.permission_grants
 
     # disable a group
     fe_url = url(base_url, "/groups/{}/disable".format(groupname))
@@ -275,7 +275,7 @@ def test_graph_disable(session, graph, groups, http_client, base_url):  # noqa: 
     graph.update_from_db(session)
     assert len(graph.groups) == (len(old_groups) - 1), "disabled group removed from graph"
     assert groupname not in graph.groups
-    assert groupname not in graph.permission_metadata
+    assert groupname not in graph.permission_grants
 
 
 @pytest.mark.gen_test

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import namedtuple
+from typing import TYPE_CHECKING
 
 import pytest
 from six.moves.urllib.parse import urlencode
@@ -45,6 +46,9 @@ from tests.fixtures import (  # noqa: F401
 )
 from tests.url_util import url
 from tests.util import get_group_permissions, get_user_permissions, grant_permission
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
 
 
 @pytest.fixture
@@ -559,9 +563,8 @@ def test_grant_and_revoke(
     user_name = "oliver@a.co"
 
     def _check_graph_for_perm(graph):
-        return any(
-            [x.permission == permission_name for x in graph.permission_metadata[group_name]]
-        )
+        # type: (GroupGraph) -> bool
+        return any([g.permission == permission_name for g in graph.permission_grants[group_name]])
 
     # make some permission admins
     grant_permission(groups["security-team"], permissions[PERMISSION_ADMIN])

--- a/tests/repositories/permission_grant_test.py
+++ b/tests/repositories/permission_grant_test.py
@@ -32,7 +32,7 @@ def test_permission_grants_for_user(setup):
 
     # Check the returned permissions.
     permission_grants = permission_grant_repository.permission_grants_for_user("gary@a.co")
-    assert sorted([(p.name, p.argument) for p in permission_grants]) == [
+    assert sorted([(p.permission, p.argument) for p in permission_grants]) == [
         ("other-perm", "*"),
         ("other-perm", "arg"),
         ("other-perm", "arg"),


### PR DESCRIPTION
Rather than using a custom MappedPermission named tuple to store
permission grants, use the standard PermissionGrant entity.  This
requires splitting permission grants from permission metadata,
which now contains only information about the permission itself,
and reworking how the graph checks whether permissions are audited.

Rename the name field of PermissionGrant to permission, which is
more consistent with the other versions of this entity and makes
for more obvious code in the graph.

Add a test for granting and revoking service account permissions to
ensure that we're exercising the template code that creates links
based on the permission grant ID.