### PR TITLE
Fix role user group metadata

### DIFF
--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -198,6 +198,20 @@ def test_get_groups(setup):
     assert sorted(group_names) == ["serving-team"]
 
 
+def test_get_groups_role_user(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_group("some-group", "")
+        setup.create_role_user("role-user@a.co")
+        setup.create_group("not-role-user@a.co")
+        setup.create_user("not-role-user@a.co")
+
+    groups = {g.name: g for g in setup.graph.get_groups()}
+    assert not groups["some-group"].is_role_user
+    assert groups["role-user@a.co"].is_role_user
+    assert not groups["not-role-user@a.co"].is_role_user
+
+
 def test_get_group_details(setup):
     # type: (SetupTest) -> None
     build_test_graph(setup)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -267,3 +267,16 @@ class SetupTest(object):
         )
         for permission in permissions:
             permission.delete(self.session)
+
+    def create_role_user(self, role_user, description="", join_policy=GroupJoinPolicy.CAN_ASK):
+        # type: (str, str, GroupJoinPolicy) -> None
+        """Create an old-style role user.
+
+        This concept is obsolete and all code related to it will be deleted once all remaining
+        legacy role users have been converted to service accounts.  This method should be used only
+        for tests to maintain backward compatibility until that happens.
+        """
+        user = User(username=role_user, role_user=True)
+        user.add(self.session)
+        self.create_group(role_user, description, join_policy)
+        self.add_user_to_group(role_user, role_user)


### PR DESCRIPTION
A previous graph refactoring broke the determination of whether a
group is a role user, and we didn't have a test for that behavior.
Fix the bug and add an explicit test.

Explicitly pass the new user_metadata into get_groups instead of
using self.user_metadata, since the latter is from the previous
version of the graph and may be inconsistent.