### PR TITLE
Improve error page for invalid users

### DIFF
--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -72,14 +72,14 @@
                     <div class="content">
                         <div class="row"><div class="col-md-12">
                             <div class="header">
-                                <h2>{% block heading %}{% endblock %}</h2>
-                                <h3><small>{% block subheading %}{% endblock %}</small></h3>
+                                <h2 id="heading">{% block heading %}{% endblock %}</h2>
+                                <h3><small id="subheading">{% block subheading %}{% endblock %}</small></h3>
                                 <div class="buttons">
                                     {% block headingbuttons %}{% endblock %}
                                 </div>
                             </div>
                         </div></div>
-                        <div class="row"><div class="col-md-12">
+                        <div class="row"><div id="content" class="col-md-12">
                             {% block content %}{% endblock %}
                         </div></div>
                     </div>

--- a/grouper/fe/templates/errors/baduser.html
+++ b/grouper/fe/templates/errors/baduser.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block heading %}
+    Error
+{% endblock %}
+
+{% block subheading %}
+    403 Forbidden
+{% endblock %}
+
+{% block content %}
+<p class="lead">Not a valid user</p>
+
+<p>{{ message }}</p>
+
+<p>If you believe this message is an error, please contact the admins of
+this site ({{ how_to_get_help }}).</p>
+
+{% endblock %}

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -130,16 +130,23 @@ class GrouperHandler(SentryHandler):
         self.set_alerts(alerts)
         super(GrouperHandler, self).redirect(url, *args, **kwargs)
 
-    def get_current_user(self):
-        # type: () -> Optional[User]
-        username = self.request.headers.get(settings().user_auth_header)
+    def get_or_create_user(self, username):
+        # type: (str) -> Optional[User]
+        """Retrieve or create the User object for the authenticated user.
+
+        This is done in a separate method called by prepare instead of in the magic Tornado
+        get_current_user method because exceptions thrown by the latter are caught by Tornado and
+        not propagated to the caller, and we want to use exceptions to handle invalid users and
+        then return an error page in prepare.
+        """
         if not username:
             return None
 
         # Users must be fully qualified
         if not re.match("^{}$".format(USERNAME_VALIDATION), username):
-            raise InvalidUser()
+            raise InvalidUser("{} does not match {}".format(username, USERNAME_VALIDATION))
 
+        # User must exist in the database and be active
         try:
             user, created = User.get_or_create(self.session, username=username)
             if created:
@@ -157,16 +164,30 @@ class GrouperHandler(SentryHandler):
 
         # service accounts are, by definition, not interactive users
         if user.is_service_account:
-            raise InvalidUser()
+            raise InvalidUser("{} is a service account".format(username))
 
         return user
 
     def prepare(self):
         # type: () -> None
-        if not self.current_user or not self.current_user.enabled:
+        username = self.request.headers.get(settings().user_auth_header)
+        try:
+            user = self.get_or_create_user(username)
+        except InvalidUser as e:
+            self.set_status(403)
+            self.raise_and_log_exception(tornado.web.HTTPError(403))
+            self.render(
+                "errors/baduser.html", message=str(e), how_to_get_help=settings().how_to_get_help
+            )
+            self.finish()
+            return
+
+        if not user or not user.enabled:
             self.forbidden()
             self.finish()
             return
+
+        self.current_user = user
 
     def on_finish(self):
         # type: () -> None

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
 
 def test_require_clickthru(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/groups"))
         groups_page = GroupsViewPage(browser)

--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -50,7 +50,6 @@ def test_list_audited_groups(tmpdir, setup, browser):
         setup.create_permission("audited", "", audited=True)
         setup.grant_permission_to_group("audited", "", "audited-group")
         setup.add_group_to_group("child-audited", "audited-group")
-        setup.create_user("gary@a.co")
 
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/groups"))

--- a/itests/fe/headers_test.py
+++ b/itests/fe/headers_test.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
 
 def test_csp(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         r = urlopen(url(frontend_url, "/"))
         assert r.getcode() == 200
@@ -41,9 +38,6 @@ def test_csp(tmpdir, setup):
 
 def test_referrer_policy(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         r = urlopen(url(frontend_url, "/"))
         assert r.getcode() == 200

--- a/itests/fe/invalid_user_test.py
+++ b/itests/fe/invalid_user_test.py
@@ -45,4 +45,4 @@ def test_disabled_user(tmpdir, setup, browser):
         page = ErrorPage(browser)
         assert page.heading == "Error"
         assert page.subheading == "403 Forbidden"
-        assert "The operation you tried to complete is unauthorized" in page.content
+        assert "disabled@a.co is not an active account" in page.content

--- a/itests/fe/invalid_user_test.py
+++ b/itests/fe/invalid_user_test.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING
+
+from itests.pages.error import ErrorPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_invalid_user(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with frontend_server(tmpdir, "has.period@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/"))
+        page = ErrorPage(browser)
+        assert page.heading == "Error"
+        assert page.subheading == "403 Forbidden"
+        assert "has.period@a.co does not match" in page.content
+
+
+def test_service_account(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_service_account("service@svc.localhost", "some-group")
+
+    with frontend_server(tmpdir, "service@svc.localhost") as frontend_url:
+        browser.get(url(frontend_url, "/"))
+        page = ErrorPage(browser)
+        assert page.heading == "Error"
+        assert page.subheading == "403 Forbidden"
+        assert "service@svc.localhost is a service account" in page.content
+
+
+def test_disabled_user(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_user("disabled@a.co")
+        setup.session.flush()
+        setup.disable_user("disabled@a.co")
+
+    with frontend_server(tmpdir, "disabled@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/"))
+        page = ErrorPage(browser)
+        assert page.heading == "Error"
+        assert page.subheading == "403 Forbidden"
+        assert "The operation you tried to complete is unauthorized" in page.content

--- a/itests/fe/permission_create_test.py
+++ b/itests/fe/permission_create_test.py
@@ -15,9 +15,6 @@ if TYPE_CHECKING:
 
 def test_list_create_button(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions"))
         page = PermissionsPage(browser)

--- a/itests/fe/permission_view_test.py
+++ b/itests/fe/permission_view_test.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 def test_view(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
     with setup.transaction():
-        setup.create_user("gary@a.co")
         setup.create_permission("audited-permission", "", audited=True)
         setup.create_permission("some-permission", "Some permission")
         setup.create_permission("disabled-permission", "", enabled=False)

--- a/itests/fe/permissions_test.py
+++ b/itests/fe/permissions_test.py
@@ -61,7 +61,6 @@ def create_test_data(setup):
                 audited=permission.audited,
             )
         setup.create_permission("disabled", enabled=False)
-        setup.create_user("gary@a.co")
     return permissions
 
 

--- a/itests/fe/search_test.py
+++ b/itests/fe/search_test.py
@@ -19,7 +19,6 @@ def test_search(tmpdir, setup, browser):
     with setup.transaction():
         setup.create_group("group-some")
         setup.create_permission("awesome-permission")
-        setup.create_user("gary@a.co")
         setup.create_user("some@a.co")
 
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
@@ -41,9 +40,6 @@ def test_search(tmpdir, setup, browser):
 
 def test_search_escaping(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
-    with setup.transaction():
-        setup.create_user("gary@a.co")
-
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/"))
 

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -50,12 +50,12 @@ class BasePage(BaseFinder):
     @property
     def heading(self):
         # type: () -> str
-        return self.find_element_by_xpath("//div[@class='header']/h2[1]").text
+        return self.find_element_by_id("heading").text
 
     @property
     def subheading(self):
         # type: () -> str
-        return self.find_element_by_xpath("//div[@class='header']/h3[1]/small[1]").text
+        return self.find_element_by_id("subheading").text
 
     @property
     def search_input(self):

--- a/itests/pages/error.py
+++ b/itests/pages/error.py
@@ -1,0 +1,8 @@
+from itests.pages.base import BasePage
+
+
+class ErrorPage(BasePage):
+    @property
+    def content(self):
+        # type: () -> str
+        return self.find_element_by_id("content").text

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -252,9 +252,8 @@ class SetupTest(object):
 
     def disable_user(self, user):
         # type: (str) -> None
-        user_obj = User.get(self.session, name=user)
-        assert user_obj
-        user_obj.enabled = False
+        user_repository = self.repository_factory.create_user_repository()
+        user_repository.disable_user(user)
 
     def disable_group(self, group):
         # type: (str) -> None

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -250,6 +250,12 @@ class SetupTest(object):
         )
         grant.add(self.session)
 
+    def disable_user(self, user):
+        # type: (str) -> None
+        user_obj = User.get(self.session, name=user)
+        assert user_obj
+        user_obj.enabled = False
+
     def disable_group(self, group):
         # type: (str) -> None
         group_obj = Group.get(self.session, name=group)


### PR DESCRIPTION
Provide a readable error page for syntactically invalid users and
for attempting to visit Grouper as a service account.  This requires
avoiding the magic Tornado get_current_user method override, since
Tornado catches exceptions from that method.  Instead, call our own
method and catch exceptions in prepare.

Add id attributes to page headings and subheadings to make finding
them in Selenium tests more efficient.

Stop pre-creating the user used in frontend Selenium tests so that
we regularly exercise the automatic creation of a new user and thus
don't need a separate explicit test for it.