### PR TITLE
Remove ServiceAccountPermission named tuple

### DIFF
--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -1,16 +1,6 @@
 from datetime import datetime
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
-# Represents a grant of a permission to either a group or a service account.
-PermissionGrant = NamedTuple(
-    "PermissionGrant",
-    [("permission", str), ("argument", str), ("granted_on", datetime), ("is_alias", bool)],
-)
-
-# Variations used when the target of the grant is not obvious in context and needs to be included
-# in the returned data (such as when listing all grants of a given permission to both groups and
-# service accounts), or when the specific permission grant needs to be referred to later (such as
-# for revocation) and thus needs a unique ID.
 GroupPermissionGrant = NamedTuple(
     "GroupPermissionGrant",
     [
@@ -18,7 +8,8 @@ GroupPermissionGrant = NamedTuple(
         ("permission", str),
         ("argument", str),
         ("granted_on", datetime),
-        ("mapping_id", int),
+        ("is_alias", bool),
+        ("grant_id", Optional[int]),
     ],
 )
 ServiceAccountPermissionGrant = NamedTuple(
@@ -28,6 +19,7 @@ ServiceAccountPermissionGrant = NamedTuple(
         ("permission", str),
         ("argument", str),
         ("granted_on", datetime),
-        ("mapping_id", int),
+        ("is_alias", bool),
+        ("grant_id", Optional[int]),
     ],
 )

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -6,10 +6,28 @@ PermissionGrant = NamedTuple(
     "PermissionGrant",
     [("permission", str), ("argument", str), ("granted_on", datetime), ("is_alias", bool)],
 )
+
+# Variations used when the target of the grant is not obvious in context and needs to be included
+# in the returned data (such as when listing all grants of a given permission to both groups and
+# service accounts), or when the specific permission grant needs to be referred to later (such as
+# for revocation) and thus needs a unique ID.
 GroupPermissionGrant = NamedTuple(
-    "GroupPermissionGrant", [("group", str), ("permission", str), ("argument", str)]
+    "GroupPermissionGrant",
+    [
+        ("group", str),
+        ("permission", str),
+        ("argument", str),
+        ("granted_on", datetime),
+        ("mapping_id", int),
+    ],
 )
 ServiceAccountPermissionGrant = NamedTuple(
     "ServiceAccountPermissionGrant",
-    [("service_account", str), ("permission", str), ("argument", str)],
+    [
+        ("service_account", str),
+        ("permission", str),
+        ("argument", str),
+        ("granted_on", datetime),
+        ("mapping_id", int),
+    ],
 )

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
         GroupPermissionGrant,
-        PermissionGrant,
         ServiceAccountPermissionGrant,
     )
     from grouper.repositories.audit_log import AuditLogRepository
@@ -79,7 +78,7 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def permission_grants_for_user(self, user):
-        # type: (str) -> List[PermissionGrant]
+        # type: (str) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -5,7 +5,7 @@ from grouper.entities.permission import PermissionAccess
 from grouper.usecases.interfaces import UserInterface
 
 if TYPE_CHECKING:
-    from grouper.entities.permission_grant import PermissionGrant
+    from grouper.entities.permission_grant import GroupPermissionGrant
     from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.user import UserRepository
@@ -47,7 +47,7 @@ class UserService(UserInterface):
         return PermissionAccess(can_disable, can_change_audited_status)
 
     def permission_grants_for_user(self, user):
-        # type: (str) -> List[PermissionGrant]
+        # type: (str) -> List[GroupPermissionGrant]
         return self.permission_grant_repository.permission_grants_for_user(user)
 
     def user_is_audit_manager(self, user):

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from grouper.entities.permission import Permission, PermissionAccess
     from grouper.entities.permission_grant import (
         GroupPermissionGrant,
-        PermissionGrant,
         ServiceAccountPermissionGrant,
     )
     from grouper.usecases.authorization import Authorization
@@ -249,7 +248,7 @@ class UserInterface(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def permission_grants_for_user(self, user):
-        # type: (str) -> List[PermissionGrant]
+        # type: (str) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod

--- a/tests/service_accounts_test.py
+++ b/tests/service_accounts_test.py
@@ -296,7 +296,7 @@ def test_service_account_fe_perms(
 
     # Unrelated people cannot revoke a permission.
     fe_url = url(
-        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[0].mapping_id)
+        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[0].grant_id)
     )
     with pytest.raises(HTTPError):
         yield http_client.fetch(
@@ -309,7 +309,7 @@ def test_service_account_fe_perms(
     )
     assert resp.code == 200
     fe_url = url(
-        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[1].mapping_id)
+        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[1].grant_id)
     )
     resp = yield http_client.fetch(
         fe_url, method="POST", headers={"X-Grouper-User": owner}, body=urlencode({})

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -80,10 +80,24 @@ def test_permission_disable_existing_grants(setup):
     assert mock_ui.mock_calls == [
         call.disable_permission_failed_existing_grants(
             "some-permission",
-            [GroupPermissionGrant("some-group", "some-permission", "argument", ANY, ANY)],
+            [
+                GroupPermissionGrant(
+                    group="some-group",
+                    permission="some-permission",
+                    argument="argument",
+                    granted_on=ANY,
+                    is_alias=False,
+                    grant_id=ANY,
+                )
+            ],
             [
                 ServiceAccountPermissionGrant(
-                    "service@svc.localhost", "some-permission", "", ANY, ANY
+                    service_account="service@svc.localhost",
+                    permission="some-permission",
+                    argument="",
+                    granted_on=ANY,
+                    is_alias=False,
+                    grant_id=ANY,
                 )
             ],
         )

--- a/tests/usecases/disable_permission_test.py
+++ b/tests/usecases/disable_permission_test.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from mock import call, MagicMock
+from mock import ANY, call, MagicMock
 
 from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE
 from grouper.entities.permission_grant import GroupPermissionGrant, ServiceAccountPermissionGrant
@@ -80,8 +80,12 @@ def test_permission_disable_existing_grants(setup):
     assert mock_ui.mock_calls == [
         call.disable_permission_failed_existing_grants(
             "some-permission",
-            [GroupPermissionGrant("some-group", "some-permission", "argument")],
-            [ServiceAccountPermissionGrant("service@svc.localhost", "some-permission", "")],
+            [GroupPermissionGrant("some-group", "some-permission", "argument", ANY, ANY)],
+            [
+                ServiceAccountPermissionGrant(
+                    "service@svc.localhost", "some-permission", "", ANY, ANY
+                )
+            ],
         )
     ]
 


### PR DESCRIPTION
Replace it with ServiceAccountPermissionGrant for individual service
accounts and PermissionGrant when retrieving all grants for the graph.

This required adding granted_on and mapping_id to
ServiceAccountPermissionGrant.  Do the same with GroupPermissionGrant,
since this will eventually be required as well.