### PR TITLE
Support GitHub username user metadata.

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -80,3 +80,4 @@ MAX_NAME_LENGTH = 128
 
 # Grouper used UserMetadata data_keys
 USER_METADATA_SHELL_KEY = "shell"
+USER_METADATA_GITHUB_USERNAME_KEY = "github_username"

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -316,6 +316,10 @@ class UserShellForm(Form):
     shell = SelectField("Shell", [validators.DataRequired()])
 
 
+class UserGitHubForm(Form):
+    username = StringField("GitHub username")
+
+
 class UserPasswordForm(Form):
     name = StringField(
         "Password name",

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from grouper.constants import USER_METADATA_SHELL_KEY
+from grouper.constants import USER_METADATA_GITHUB_USERNAME_KEY, USER_METADATA_SHELL_KEY
 from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.fe.util import Alert
 from grouper.graph import NoSuchGroup, NoSuchUser
@@ -135,6 +135,8 @@ def get_user_view_template_vars(session, actor, user, graph):
         else "No shell configured"
     )
     ret["shell"] = shell
+    github_username = get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY)
+    ret["github_username"] = github_username.data_value if github_username else "(Unset)"
     ret["open_audits"] = user_open_audits(session, user)
     group_edge_list = get_groups_by_user(session, user) if user.enabled else []
     ret["groups"] = [

--- a/grouper/fe/handlers/user_github.py
+++ b/grouper/fe/handlers/user_github.py
@@ -1,0 +1,68 @@
+from typing import TYPE_CHECKING
+
+from grouper.constants import USER_METADATA_GITHUB_USERNAME_KEY
+from grouper.fe.forms import UserGitHubForm
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.user import User
+from grouper.user_metadata import set_user_metadata
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Any, Optional
+
+
+class UserGitHub(GrouperHandler):
+    @staticmethod
+    def check_access(session, actor, target):
+        # type: (Session, User, User) -> bool
+        return actor.name == target.name
+
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        user_id = kwargs.get("user_id")  # type: Optional[int]
+        name = kwargs.get("name")  # type: Optional[str]
+
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, user):
+            return self.forbidden()
+
+        form = UserGitHubForm()
+
+        self.render("user-github.html", form=form, user=user)
+
+    def post(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        user_id = kwargs.get("user_id")  # type: Optional[int]
+        name = kwargs.get("name")  # type: Optional[str]
+
+        user = User.get(self.session, user_id, name)
+        if not user:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, user):
+            return self.forbidden()
+
+        form = UserGitHubForm(self.request.arguments)
+        if not form.validate():
+            return self.render(
+                "user-github.html", form=form, user=user, alerts=self.get_form_alerts(form.errors)
+            )
+
+        new_username = form.data["username"]
+        if new_username == "":
+            new_username = None
+        set_user_metadata(self.session, user.id, USER_METADATA_GITHUB_USERNAME_KEY, new_username)
+
+        AuditLog.log(
+            self.session,
+            self.current_user.id,
+            "changed_github_username",
+            "Changed GitHub username: {!r}".format(form.data["username"]),
+            on_user_id=user.id,
+        )
+
+        return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -59,6 +59,7 @@ from grouper.fe.handlers.service_account_permission_revoke import ServiceAccount
 from grouper.fe.handlers.service_account_view import ServiceAccountView
 from grouper.fe.handlers.user_disable import UserDisable
 from grouper.fe.handlers.user_enable import UserEnable
+from grouper.fe.handlers.user_github import UserGitHub
 from grouper.fe.handlers.user_password_add import UserPasswordAdd
 from grouper.fe.handlers.user_password_delete import UserPasswordDelete
 from grouper.fe.handlers.user_requests import UserRequests
@@ -109,6 +110,7 @@ for regex in (r"(?P<user_id>[0-9]+)", USERNAME_VALIDATION):
             (r"/users/{}".format(regex), UserView),
             (r"/users/{}/disable".format(regex), UserDisable),
             (r"/users/{}/enable".format(regex), UserEnable),
+            (r"/users/{}/github".format(regex), UserGitHub),
             (r"/users/{}/shell".format(regex), UserShell),
             (r"/users/{}/public-key/add".format(regex), PublicKeyAdd),
             (r"/users/{}/public-key/(?P<key_id>[0-9]+)/delete".format(regex), PublicKeyDelete),

--- a/grouper/fe/templates/forms/user-github.html
+++ b/grouper/fe/templates/forms/user-github.html
@@ -1,0 +1,5 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.username, 3, 8, class_="form-control") }}
+
+{{ xsrf_form()|safe }}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -178,6 +178,35 @@
     </div>
 {%- endmacro %}
 
+{% macro github_panel(user, github_username, can_control=False) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">GitHub</h3>
+        </div>
+        <div class="table-responsive standard-panel">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-md-2">GitHub username</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>{{ github_username }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/github">
+                <span class="glyphicon glyphicon-pencil"></span> Change GitHub username
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endmacro %}
+
 
 {% macro help_for(subj, text) -%}
     <span class="has-help" data-toggle="popover" title="Grouper Help" data-content="

--- a/grouper/fe/templates/user-github.html
+++ b/grouper/fe/templates/user-github.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block subtitle %} change GitHub username for {{user.name}}{% endblock %}
+
+{% block heading %}
+    <a href="/users">Users</a>
+{% endblock %}
+
+{% block subheading %}
+    Change GitHub username for User {{ user.name }}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Change GitHub username for User {{ user.name }}</h3>
+       </div>
+
+        <div class="panel-body" id="dropdown_form">
+            <form class="form-horizontal" role="form"
+                method="post" action="/users/{{ user.name }}/github">
+                {% include "forms/user-github.html" %}
+                <div class="form-github">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% from 'macros/ui.html' import group_panel, permission_panel, log_entry_panel, tokens_panel,
-                                shell_panel, passwords_panel %}
+                                shell_panel, passwords_panel, github_panel %}
 {% from 'macros/ui.html' import public_key_panel with context %}
 
 {% block subtitle %} user {{user.username}}{% endblock %}
@@ -116,6 +116,12 @@
         </div>
     </div>
 {% endif %}
+
+<div class="row">
+    <div class="col-md-4">
+        {{ github_panel(user, github_username, can_control) }}
+    </div>
+</div>
 
 <div class="row">
     <div class="col-md-12">

--- a/grouper/user_metadata.py
+++ b/grouper/user_metadata.py
@@ -1,11 +1,17 @@
 import re
+from typing import TYPE_CHECKING
 
 from grouper.constants import PERMISSION_VALIDATION
 from grouper.models.counter import Counter
 from grouper.models.user_metadata import UserMetadata
 
+if TYPE_CHECKING:
+    from typing import Optional, Sequence
+    from grouper.models.base.session import Session
+
 
 def get_user_metadata(session, user_id):
+    # type: (Session, int) -> Sequence[UserMetadata]
     """Return all of a user's metadata.
 
     Args:
@@ -19,6 +25,7 @@ def get_user_metadata(session, user_id):
 
 
 def get_user_metadata_by_key(session, user_id, data_key):
+    # type: (Session, int, str) -> UserMetadata
     """Return the user's metadata if it has the matching key
 
     Args:
@@ -26,12 +33,13 @@ def get_user_metadata_by_key(session, user_id, data_key):
         user_id(int): id of user in question
 
     Returns:
-        List of UserMetadata objects
+        A UserMetadata object
     """
     return session.query(UserMetadata).filter_by(user_id=user_id, data_key=data_key).scalar()
 
 
 def set_user_metadata(session, user_id, data_key, data_value):
+    # type: (Session, int, str, str) -> Optional[UserMetadata]
     """Set a single piece of user metadata.
 
     Args:

--- a/tests/github_test.py
+++ b/tests/github_test.py
@@ -1,0 +1,52 @@
+import pytest
+from six.moves.urllib.parse import urlencode
+
+from grouper.constants import USER_METADATA_GITHUB_USERNAME_KEY
+from grouper.models.user import User
+from grouper.user_metadata import get_user_metadata_by_key
+from tests.fixtures import (  # noqa: F401
+    fe_app as app,
+    graph,
+    groups,
+    permissions,
+    service_accounts,
+    session,
+    standard_graph,
+    users,
+)
+from tests.url_util import url
+
+
+@pytest.mark.gen_test
+def test_github(session, users, http_client, base_url):  # noqa: F811
+    user = users["zorkian@a.co"]
+    assert get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY) is None
+
+    user = User.get(session, name=user.username)
+    fe_url = url(base_url, "/users/{}/github".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"username": "joe-on-github"}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
+    user = User.get(session, name=user.username)
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY) is not None
+    )
+    assert (
+        get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY).data_value
+        == "joe-on-github"
+    )
+
+    fe_url = url(base_url, "/users/{}/github".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"username": ""}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
+    user = User.get(session, name=user.username)
+    assert get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY) is None


### PR DESCRIPTION
Add UI support for setting, unsetting, and displaying a user's GitHub username. The actual data is stored in UserMetadata.

The new code is heavily cribbed from the support for custom user shells.