### PR TITLE
Some itest performance improvements

### DIFF
--- a/grouper/fe/templates/base.html
+++ b/grouper/fe/templates/base.html
@@ -45,7 +45,7 @@
                         <div class="input-group search-input">
                             <input type="text" class="form-control" placeholder="Search" name="query" id="query" value="{{search_query}}">
                             <div class="input-group-btn">
-                                <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
+                                <button id="search" class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
                             </div>
                         </div>
                     </form>

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -593,7 +593,7 @@ enabled. Membership in this group is regularly reviewed.
 
 {% macro dropdown(key, current, values, allow_none=False) -%}
     <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        <button id="dropdown-{{key}}" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             {% if current %}
                 {{key|title}}: {{current}}
             {% else %}

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -23,16 +23,16 @@
     {{ dropdown("limit", limit, [100, 250, 500]) }}
     {{ paginator(offset, limit, total) }}
     {% if audited_permissions %}
-    <a class="btn btn-warning show-all" href="{{update_qs(audited='0', offset='0')}}">
+    <a id="show-all" class="btn btn-warning" href="{{update_qs(audited='0', offset='0')}}">
         <i class="fa"></i> Show all permissions
     </a>
     {% else %}
     {% if can_create %}
-    <a class="btn btn-success create-permission" href="/permissions/create">
+    <a id="create-permission" class="btn btn-success" href="/permissions/create">
         <i class="fa fa-plus"></i> Create
     </a>
     {% endif %}
-    <a class="btn btn-warning show-audited" href="{{update_qs(audited='1', offset='0')}}">
+    <a id="show-audited" class="btn btn-warning" href="{{update_qs(audited='1', offset='0')}}">
         <i class="fa"></i> Show audited permissions only
     </a>
     {% endif %}

--- a/itests/conftest.py
+++ b/itests/conftest.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from typing import Iterator
 
 
-@pytest.yield_fixture
+@pytest.fixture(scope="session")
 def browser():
     # type: () -> Iterator[Chrome]
     driver = selenium_browser()
@@ -30,7 +30,7 @@ def browser():
     driver.quit()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def setup(tmpdir):
     # type: (LocalPath) -> Iterator[SetupTest]
     with closing(SetupTest(tmpdir)) as test_setup:

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -18,14 +18,14 @@ if TYPE_CHECKING:
     from typing import Iterator
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def async_server(standard_graph, tmpdir):
     # type: (GroupGraph, LocalPath) -> Iterator[str]
     with frontend_server(tmpdir, "cbguder@a.co") as frontend_url:
         yield frontend_url
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def async_api_server(standard_graph, tmpdir):
     with api_server(tmpdir) as api_url:
         yield api_url

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -37,10 +37,6 @@ class BaseFinder(object):
         # type: (str) -> WebElement
         return self.root.find_element_by_tag_name(name)
 
-    def find_element_by_xpath(self, path):
-        # type: (str) -> WebElement
-        return self.root.find_element_by_xpath(path)
-
 
 class BasePage(BaseFinder):
     @property

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -60,11 +60,11 @@ class BasePage(BaseFinder):
     @property
     def search_input(self):
         # type: () -> WebElement
-        return self.find_element_by_xpath("//div[contains(@class, 'search-input')]/input[1]")
+        return self.find_element_by_id("query")
 
     def click_search_button(self):
         # type: () -> None
-        button = self.find_element_by_xpath("//div[contains(@class, 'search-input')]//button[1]")
+        button = self.find_element_by_id("search")
         button.click()
 
     def has_alert(self, text):

--- a/itests/pages/permissions.py
+++ b/itests/pages/permissions.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from selenium.common.exceptions import NoSuchElementException
+
 from itests.pages.base import BaseElement, BasePage
 
 if TYPE_CHECKING:
@@ -10,7 +12,11 @@ class PermissionsPage(BasePage):
     @property
     def has_create_permission_button(self):
         # type: () -> bool
-        return self.find_elements_by_class_name("create-permission") != []
+        try:
+            self.find_element_by_id("create-permission")
+            return True
+        except NoSuchElementException:
+            return False
 
     @property
     def permission_rows(self):
@@ -21,21 +27,21 @@ class PermissionsPage(BasePage):
     @property
     def limit_label(self):
         # type: () -> str
-        return self.find_element_by_class_name("dropdown-toggle").text.strip()
+        return self.find_element_by_id("dropdown-limit").text.strip()
 
     def click_create_permission_button(self):
         # type: () -> None
-        button = self.find_element_by_class_name("create-permission")
+        button = self.find_element_by_id("create-permission")
         button.click()
 
     def click_show_all_button(self):
         # type: () -> None
-        button = self.find_element_by_class_name("show-all")
+        button = self.find_element_by_id("show-all")
         button.click()
 
     def click_show_audited_button(self):
         # type: () -> None
-        button = self.find_element_by_class_name("show-audited")
+        button = self.find_element_by_id("show-audited")
         button.click()
 
     def click_sort_by_date(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from typing import Iterator
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def setup(tmpdir):
     # type: (LocalPath) -> Iterator[SetupTest]
     with closing(SetupTest(tmpdir)) as test_setup:


### PR DESCRIPTION
Mark the Selenium WebDriver as a session fixture so that it will
be reused between tests.  Grouper doesn't rely on persistant cookies,
which is the primary drawback of reusing a browser, and this provides
a small performance gain (a bit over 10%) in my testing for parallel
tests and a large performance gain (about 30%) in serial tests.
    
Add more id attributes to singleton HTML elements and use
find_element_by_id instead of find_element_by_xpath or
find_element_by_class_name, which are substantially slower for
Selenium.  The speed-ups here are minor, but about 0.5s for the
test_list permission test.
    
Use pytest.fixture instead of pytest.yield_fixture.  Regular fixtures
can call yield and pytest handles this automatically, and the separate
yield_fixture annotation has been deprecated since pytest 3.0.

Remove find_element_by_xpath as an attractive nuisance. While it's
more flexible, the xpath language is hard to read, and for our HTML
we can always avoid having to use it by adding a class or id attribute
to the relevant tag.  It's also much slower than other methods of
parsing the page.
