### PR TITLE
Add API for retrieving permission grants

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -23,6 +23,7 @@ from grouper.util import try_update
 if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList
     from grouper.entities.permission import Permission
+    from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
     from grouper.graph import GroupGraph
     from grouper.usecases.factory import UseCaseFactory
     from typing import Any, Dict, Iterable, Optional, Tuple
@@ -95,28 +96,28 @@ class GraphHandler(SentryHandler):
         with self.graph.lock:
             checkpoint = self.graph.checkpoint
             checkpoint_time = self.graph.checkpoint_time
-            self.write(
-                {
-                    "status": "error",
-                    "errors": out,
-                    "checkpoint": checkpoint,
-                    "checkpoint_time": checkpoint_time,
-                }
-            )
+        self.write(
+            {
+                "status": "error",
+                "errors": out,
+                "checkpoint": checkpoint,
+                "checkpoint_time": checkpoint_time,
+            }
+        )
 
     def success(self, data):
         # type: (Any) -> None
         with self.graph.lock:
             checkpoint = self.graph.checkpoint
             checkpoint_time = self.graph.checkpoint_time
-            self.write(
-                {
-                    "status": "ok",
-                    "data": data,
-                    "checkpoint": checkpoint,
-                    "checkpoint_time": checkpoint_time,
-                }
-            )
+        self.write(
+            {
+                "status": "ok",
+                "data": data,
+                "checkpoint": checkpoint,
+                "checkpoint_time": checkpoint_time,
+            }
+        )
 
     def raise_and_log_exception(self, exc):
         # type: (Exception) -> None
@@ -234,6 +235,30 @@ class UsersPublicKeys(GraphHandler):
 
         self.set_header("Content-Type", "text/csv")
         self.write(fh.getvalue())
+
+
+class Grants(GraphHandler):
+    def listed_grants(self, grants):
+        # type: (AllGrants) -> None
+        grants_dict = {
+            k: {"users": v.users, "service_accounts": v.service_accounts}
+            for k, v in iteritems(grants)
+        }
+        self.success({"permissions": grants_dict})
+
+    def listed_grants_of_permission(self, permission, grants):
+        # type: (str, AllGrantsOfPermission) -> None
+        grants_dict = {"users": grants.users, "service_accounts": grants.service_accounts}
+        self.success({"permission": permission, "grants": grants_dict})
+
+    def get(self, *args, **kwargs):
+        # type: (*Any, **Any) -> None
+        permission = kwargs.get("name")  # type: Optional[str]
+        usecase = self.usecase_factory.create_list_grants_usecase(self)
+        if permission:
+            usecase.list_grants_of_permission(permission)
+        else:
+            usecase.list_grants()
 
 
 class Groups(GraphHandler):

--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -23,7 +23,7 @@ from grouper.util import try_update
 if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList
     from grouper.entities.permission import Permission
-    from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
+    from grouper.entities.permission_grant import UniqueGrantsOfPermission
     from grouper.graph import GroupGraph
     from grouper.usecases.factory import UseCaseFactory
     from typing import Any, Dict, Iterable, Optional, Tuple
@@ -239,7 +239,7 @@ class UsersPublicKeys(GraphHandler):
 
 class Grants(GraphHandler):
     def listed_grants(self, grants):
-        # type: (AllGrants) -> None
+        # type: (Dict[str, UniqueGrantsOfPermission]) -> None
         grants_dict = {
             k: {"users": v.users, "service_accounts": v.service_accounts}
             for k, v in iteritems(grants)
@@ -247,7 +247,7 @@ class Grants(GraphHandler):
         self.success({"permissions": grants_dict})
 
     def listed_grants_of_permission(self, permission, grants):
-        # type: (str, AllGrantsOfPermission) -> None
+        # type: (str, UniqueGrantsOfPermission) -> None
         grants_dict = {"users": grants.users, "service_accounts": grants.service_accounts}
         self.success({"permission": permission, "grants": grants_dict})
 

--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -6,6 +6,7 @@ additional arguments will be injected when the Tornado Application object is cre
 """
 
 from grouper.api.handlers import (
+    Grants,
     Groups,
     MultiUsers,
     NotFound,
@@ -19,17 +20,19 @@ from grouper.constants import NAME_VALIDATION, PERMISSION_VALIDATION
 from grouper.handlers.health_check import HealthCheck
 
 HANDLERS = [
-    (r"/users", Users),
-    (r"/users/{}".format(NAME_VALIDATION), Users),
-    (r"/token/validate".format(NAME_VALIDATION), TokenValidate),
-    (r"/public-keys", UsersPublicKeys),
+    (r"/debug/health", HealthCheck),
+    (r"/grants", Grants),
+    (r"/grants/{}".format(PERMISSION_VALIDATION), Grants),
     (r"/groups", Groups),
     (r"/groups/{}".format(NAME_VALIDATION), Groups),
     (r"/permissions", Permissions),
     (r"/permissions/{}".format(PERMISSION_VALIDATION), Permissions),
+    (r"/public-keys", UsersPublicKeys),
     (r"/service_accounts", ServiceAccounts),
     (r"/service_accounts/{}".format(NAME_VALIDATION), ServiceAccounts),
+    (r"/users", Users),
+    (r"/users/{}".format(NAME_VALIDATION), Users),
     (r"/multi/users", MultiUsers),
-    (r"/debug/health", HealthCheck),
+    (r"/token/validate".format(NAME_VALIDATION), TokenValidate),
     (r"/.*", NotFound),
 ]

--- a/grouper/api/routes.py
+++ b/grouper/api/routes.py
@@ -33,6 +33,6 @@ HANDLERS = [
     (r"/users", Users),
     (r"/users/{}".format(NAME_VALIDATION), Users),
     (r"/multi/users", MultiUsers),
-    (r"/token/validate".format(NAME_VALIDATION), TokenValidate),
+    (r"/token/validate", TokenValidate),
     (r"/.*", NotFound),
 ]

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import NamedTuple, Optional
+from typing import Dict, List, NamedTuple, Optional
 
 GroupPermissionGrant = NamedTuple(
     "GroupPermissionGrant",
@@ -23,3 +23,15 @@ ServiceAccountPermissionGrant = NamedTuple(
         ("grant_id", Optional[int]),
     ],
 )
+
+# Represents all grants of a specific permission, as a dictionary of users and service accounts who
+# have been granted that permission to lists of all the arguments to that permission that they have
+# been granted.
+AllGrantsOfPermission = NamedTuple(
+    "AllGrantsOfPermission",
+    [("users", Dict[str, List[str]]), ("service_accounts", Dict[str, List[str]])],
+)
+
+# The same, but for every permission, stored in a dictionary mapping permission names to those
+# grants.
+AllGrants = Dict[str, AllGrantsOfPermission]

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -24,14 +24,11 @@ ServiceAccountPermissionGrant = NamedTuple(
     ],
 )
 
-# Represents all grants of a specific permission, as a dictionary of users and service accounts who
-# have been granted that permission to lists of all the arguments to that permission that they have
-# been granted.
-AllGrantsOfPermission = NamedTuple(
-    "AllGrantsOfPermission",
+# Represents all unique grants of a specific permission (meaning that if a user has the same
+# permission and argument granted from multiple groups, it's represented only once).  Contains a
+# dictionary of users and service accounts who have been granted that permission, the values in
+# which are lists of all the arguments to that permission that they have been granted.
+UniqueGrantsOfPermission = NamedTuple(
+    "UniqueGrantsOfPermission",
     [("users", Dict[str, List[str]]), ("service_accounts", Dict[str, List[str]])],
 )
-
-# The same, but for every permission, stored in a dictionary mapping permission names to those
-# grants.
-AllGrants = Dict[str, AllGrantsOfPermission]

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -456,7 +456,7 @@ class GroupGraph(object):
 
         # For each group that has a permission grant, determine all of its users from the graph,
         # and then record each permission grant of that group as a grant to all of those users.
-        # This ensures that each permission grant is recorded for all affected users exactly once.
+        # Use a set for the arguments in our intermediate data structure to handle uniqueness.
         user_grants = defaultdict(lambda: defaultdict(set))  # type: Dict[str, Dict[str, Set[str]]]
         for group, grant_list in iteritems(group_grants):
             members = set()  # type: Set[str]

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
+        AllGrants,
+        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
     )
@@ -60,6 +62,16 @@ class PermissionRepository(with_metaclass(ABCMeta, object)):
 
 class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission grant repositories."""
+
+    @abstractmethod
+    def all_grants(self):
+        # type: () -> AllGrants
+        pass
+
+    @abstractmethod
+    def all_grants_of_permission(self, permission):
+        # type: (str) -> AllGrantsOfPermission
+        pass
 
     @abstractmethod
     def grant_permission_to_group(self, permission, argument, group):

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -8,10 +8,9 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
-        AllGrants,
-        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
+        UniqueGrantsOfPermission,
     )
     from grouper.repositories.audit_log import AuditLogRepository
     from grouper.repositories.checkpoint import CheckpointRepository
@@ -22,7 +21,7 @@ if TYPE_CHECKING:
     from grouper.repositories.transaction import TransactionRepository
     from grouper.repositories.user import UserRepository
     from grouper.usecases.list_permissions import ListPermissionsSortKey
-    from typing import List, Optional
+    from typing import Dict, List, Optional
 
 
 class GroupEdgeRepository(with_metaclass(ABCMeta, object)):
@@ -65,12 +64,12 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def all_grants(self):
-        # type: () -> AllGrants
+        # type: () -> Dict[str, UniqueGrantsOfPermission]
         pass
 
     @abstractmethod
     def all_grants_of_permission(self, permission):
-        # type: (str) -> AllGrantsOfPermission
+        # type: (str) -> UniqueGrantsOfPermission
         pass
 
     @abstractmethod

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -6,7 +6,12 @@ from sqlalchemy import or_
 from grouper.entities.group import GroupNotFoundException
 from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.entities.permission import PermissionNotFoundException
-from grouper.entities.permission_grant import GroupPermissionGrant, ServiceAccountPermissionGrant
+from grouper.entities.permission_grant import (
+    AllGrants,
+    AllGrantsOfPermission,
+    GroupPermissionGrant,
+    ServiceAccountPermissionGrant,
+)
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
 from grouper.models.group_edge import GroupEdge
@@ -30,6 +35,14 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         # type: (GroupGraph, PermissionGrantRepository) -> None
         self.graph = graph
         self.repository = repository
+
+    def all_grants(self):
+        # type: () -> AllGrants
+        return self.graph.all_grants()
+
+    def all_grants_of_permission(self, permission):
+        # type: (str) -> AllGrantsOfPermission
+        return self.graph.all_grants_of_permission(permission)
 
     def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
@@ -81,6 +94,14 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
     def __init__(self, session):
         # type: (Session) -> None
         self.session = session
+
+    def all_grants(self):
+        # type: () -> AllGrants
+        raise NotImplementedError()
+
+    def all_grants_of_permission(self, permission):
+        # type: (str) -> AllGrantsOfPermission
+        raise NotImplementedError()
 
     def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None

--- a/grouper/repositories/permission_grant.py
+++ b/grouper/repositories/permission_grant.py
@@ -7,10 +7,9 @@ from grouper.entities.group import GroupNotFoundException
 from grouper.entities.group_edge import GROUP_EDGE_ROLES
 from grouper.entities.permission import PermissionNotFoundException
 from grouper.entities.permission_grant import (
-    AllGrants,
-    AllGrantsOfPermission,
     GroupPermissionGrant,
     ServiceAccountPermissionGrant,
+    UniqueGrantsOfPermission,
 )
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
@@ -25,7 +24,7 @@ from grouper.repositories.interfaces import PermissionGrantRepository
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
-    from typing import List
+    from typing import Dict, List
 
 
 class GraphPermissionGrantRepository(PermissionGrantRepository):
@@ -37,11 +36,11 @@ class GraphPermissionGrantRepository(PermissionGrantRepository):
         self.repository = repository
 
     def all_grants(self):
-        # type: () -> AllGrants
+        # type: () -> Dict[str, UniqueGrantsOfPermission]
         return self.graph.all_grants()
 
     def all_grants_of_permission(self, permission):
-        # type: (str) -> AllGrantsOfPermission
+        # type: (str) -> UniqueGrantsOfPermission
         return self.graph.all_grants_of_permission(permission)
 
     def grant_permission_to_group(self, permission, argument, group):
@@ -96,11 +95,11 @@ class SQLPermissionGrantRepository(PermissionGrantRepository):
         self.session = session
 
     def all_grants(self):
-        # type: () -> AllGrants
+        # type: () -> Dict[str, UniqueGrantsOfPermission]
         raise NotImplementedError()
 
     def all_grants_of_permission(self, permission):
-        # type: (str) -> AllGrantsOfPermission
+        # type: (str) -> UniqueGrantsOfPermission
         raise NotImplementedError()
 
     def grant_permission_to_group(self, permission, argument, group):

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
+        AllGrants,
+        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
     )
@@ -26,6 +28,14 @@ class PermissionService(PermissionInterface):
         self.audit_log = audit_log
         self.permission_repository = permission_repository
         self.permission_grant_repository = permission_grant_repository
+
+    def all_grants(self):
+        # type: () -> AllGrants
+        return self.permission_grant_repository.all_grants()
+
+    def all_grants_of_permission(self, permission):
+        # type: (str) -> AllGrantsOfPermission
+        return self.permission_grant_repository.all_grants_of_permission(permission)
 
     def create_permission(self, name, description=""):
         # type: (str, str) -> None

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -7,17 +7,16 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
-        AllGrants,
-        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
+        UniqueGrantsOfPermission,
     )
     from grouper.repositories.permission import PermissionRepository
     from grouper.repositories.permission_grant import PermissionGrantRepository
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
     from grouper.usecases.interfaces import AuditLogInterface
-    from typing import List, Optional
+    from typing import Dict, List, Optional
 
 
 class PermissionService(PermissionInterface):
@@ -30,11 +29,11 @@ class PermissionService(PermissionInterface):
         self.permission_grant_repository = permission_grant_repository
 
     def all_grants(self):
-        # type: () -> AllGrants
+        # type: () -> Dict[str, UniqueGrantsOfPermission]
         return self.permission_grant_repository.all_grants()
 
     def all_grants_of_permission(self, permission):
-        # type: (str) -> AllGrantsOfPermission
+        # type: (str) -> UniqueGrantsOfPermission
         return self.permission_grant_repository.all_grants_of_permission(permission)
 
     def create_permission(self, name, description=""):

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -4,6 +4,7 @@ from grouper.usecases.convert_user_to_service_account import ConvertUserToServic
 from grouper.usecases.disable_permission import DisablePermission
 from grouper.usecases.dump_schema import DumpSchema
 from grouper.usecases.initialize_schema import InitializeSchema
+from grouper.usecases.list_grants import ListGrants
 from grouper.usecases.list_permissions import ListPermissions
 from grouper.usecases.view_permission import ViewPermission
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.dump_schema import DumpSchemaUI
+    from grouper.usecases.list_grants import ListGrantsUI
     from grouper.usecases.list_permissions import ListPermissionsUI
     from grouper.usecases.view_permission import ViewPermissionUI
 
@@ -51,6 +53,11 @@ class UseCaseFactory(object):
         # type: (DumpSchemaUI) -> DumpSchema
         schema_service = self.service_factory.create_schema_service()
         return DumpSchema(ui, schema_service)
+
+    def create_list_grants_usecase(self, ui):
+        # type: (ListGrantsUI) -> ListGrants
+        permission_service = self.service_factory.create_permission_service()
+        return ListGrants(ui, permission_service)
 
     def create_list_permissions_usecase(self, ui):
         # type: (ListPermissionsUI) -> ListPermissions

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission, PermissionAccess
     from grouper.entities.permission_grant import (
+        AllGrants,
+        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
     )
@@ -145,6 +147,16 @@ class GroupRequestInterface(with_metaclass(ABCMeta, object)):
 
 class PermissionInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for permission operations and queries."""
+
+    @abstractmethod
+    def all_grants(self):
+        # type: () -> AllGrants
+        pass
+
+    @abstractmethod
+    def all_grants_of_permission(self, permission):
+        # type: (str) -> AllGrantsOfPermission
+        pass
 
     @abstractmethod
     def create_permission(self, name, description=""):

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -24,14 +24,13 @@ if TYPE_CHECKING:
     from grouper.entities.pagination import PaginatedList, Pagination
     from grouper.entities.permission import Permission, PermissionAccess
     from grouper.entities.permission_grant import (
-        AllGrants,
-        AllGrantsOfPermission,
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
+        UniqueGrantsOfPermission,
     )
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
-    from typing import ContextManager, List, Optional
+    from typing import ContextManager, Dict, List, Optional
 
 
 class AuditLogInterface(with_metaclass(ABCMeta, object)):
@@ -150,12 +149,12 @@ class PermissionInterface(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def all_grants(self):
-        # type: () -> AllGrants
+        # type: () -> Dict[str, UniqueGrantsOfPermission]
         pass
 
     @abstractmethod
     def all_grants_of_permission(self, permission):
-        # type: (str) -> AllGrantsOfPermission
+        # type: (str) -> UniqueGrantsOfPermission
         pass
 
     @abstractmethod

--- a/grouper/usecases/list_grants.py
+++ b/grouper/usecases/list_grants.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING
 from six import with_metaclass
 
 if TYPE_CHECKING:
-    from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
+    from grouper.entities.permission_grant import UniqueGrantsOfPermission
     from grouper.usecases.interfaces import PermissionInterface
+    from typing import Dict
 
 
 class ListGrantsUI(with_metaclass(ABCMeta, object)):
@@ -13,12 +14,12 @@ class ListGrantsUI(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def listed_grants(self, grants):
-        # type: (AllGrants) -> None
+        # type: (Dict[str, UniqueGrantsOfPermission]) -> None
         pass
 
     @abstractmethod
     def listed_grants_of_permission(self, permission, grants):
-        # type: (str, AllGrantsOfPermission) -> None
+        # type: (str, UniqueGrantsOfPermission) -> None
         pass
 
 

--- a/grouper/usecases/list_grants.py
+++ b/grouper/usecases/list_grants.py
@@ -1,0 +1,41 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from six import with_metaclass
+
+if TYPE_CHECKING:
+    from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
+    from grouper.usecases.interfaces import PermissionInterface
+
+
+class ListGrantsUI(with_metaclass(ABCMeta, object)):
+    """Abstract base class for UI for ListGrants."""
+
+    @abstractmethod
+    def listed_grants(self, grants):
+        # type: (AllGrants) -> None
+        pass
+
+    @abstractmethod
+    def listed_grants_of_permission(self, permission, grants):
+        # type: (str, AllGrantsOfPermission) -> None
+        pass
+
+
+class ListGrants(object):
+    """List all permission grants by permission, expanding the graph."""
+
+    def __init__(self, ui, permission_service):
+        # type: (ListGrantsUI, PermissionInterface) -> None
+        self.ui = ui
+        self.permission_service = permission_service
+
+    def list_grants(self):
+        # type: () -> None
+        grants = self.permission_service.all_grants()
+        self.ui.listed_grants(grants)
+
+    def list_grants_of_permission(self, permission):
+        # type: (str) -> None
+        grants = self.permission_service.all_grants_of_permission(permission)
+        self.ui.listed_grants_of_permission(permission, grants)

--- a/itests/api/grants_test.py
+++ b/itests/api/grants_test.py
@@ -1,0 +1,71 @@
+from typing import TYPE_CHECKING
+
+from groupy.client import Groupy
+
+from itests.setup import api_server
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from tests.setup import SetupTest
+
+
+def create_graph(setup):
+    # type: (SetupTest) -> None
+    """Create a simple graph structure with some permission grants."""
+    setup.add_user_to_group("gary@a.co", "some-group")
+    setup.grant_permission_to_group("some-permission", "foo", "some-group")
+    setup.add_user_to_group("gary@a.co", "other-group")
+    setup.grant_permission_to_group("other-permission", "", "other-group")
+    setup.grant_permission_to_group("not-gary", "foo", "not-member-group")
+    setup.grant_permission_to_group("some-permission", "*", "not-member-group")
+    setup.grant_permission_to_group("some-permission", "bar", "parent-group")
+    setup.add_group_to_group("some-group", "parent-group")
+    setup.grant_permission_to_group("twice", "*", "group-one")
+    setup.grant_permission_to_group("twice", "*", "group-two")
+    setup.add_group_to_group("child-group", "group-one")
+    setup.add_group_to_group("child-group", "group-two")
+    setup.add_user_to_group("gary@a.co", "child-group")
+    setup.add_user_to_group("zorkian@a.co", "not-member-group")
+    setup.create_user("oliver@a.co")
+    setup.create_service_account("service@svc.localhost", "some-group")
+    setup.grant_permission_to_service_account("some-permission", "*", "service@svc.localhost")
+
+
+def test_list_grants(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    with setup.transaction():
+        create_graph(setup)
+
+    expected = {
+        "not-gary": {"users": {"zorkian@a.co": ["foo"]}, "service_accounts": {}},
+        "other-permission": {"users": {"gary@a.co": [""]}, "service_accounts": {}},
+        "some-permission": {
+            "users": {"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            "service_accounts": {"service@svc.localhost": ["*"]},
+        },
+        "twice": {"users": {"gary@a.co": ["*"]}, "service_accounts": {}},
+    }
+
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        result = api_client._fetch("/grants")
+        assert result["status"] == "ok"
+        assert result["data"]["permissions"] == expected
+
+
+def test_list_grants_of_permission(tmpdir, setup):
+    # type: (LocalPath, SetupTest) -> None
+    with setup.transaction():
+        create_graph(setup)
+
+    expected = {
+        "users": {"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+        "service_accounts": {"service@svc.localhost": ["*"]},
+    }
+
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        result = api_client._fetch("/grants/some-permission")
+        assert result["status"] == "ok"
+        assert result["data"]["permission"] == "some-permission"
+        assert result["data"]["grants"] == expected

--- a/tests/groups_test.py
+++ b/tests/groups_test.py
@@ -4,6 +4,7 @@ import pytest
 from six.moves.urllib.parse import urlencode
 from tornado.httpclient import HTTPError
 
+from grouper.graph import NoSuchGroup
 from grouper.models.group import Group
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
@@ -260,7 +261,7 @@ def test_graph_disable(session, graph, groups, http_client, base_url):  # noqa: 
     graph.update_from_db(session)
     old_groups = graph.groups
     assert sorted(old_groups) == sorted(groups.keys())
-    assert groupname in graph.permission_grants
+    assert "permissions" in graph.get_group_details(groupname)
 
     # disable a group
     fe_url = url(base_url, "/groups/{}/disable".format(groupname))
@@ -275,7 +276,8 @@ def test_graph_disable(session, graph, groups, http_client, base_url):  # noqa: 
     graph.update_from_db(session)
     assert len(graph.groups) == (len(old_groups) - 1), "disabled group removed from graph"
     assert groupname not in graph.groups
-    assert groupname not in graph.permission_grants
+    with pytest.raises(NoSuchGroup):
+        graph.get_group_details(groupname)
 
 
 @pytest.mark.gen_test

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -564,7 +564,12 @@ def test_grant_and_revoke(
 
     def _check_graph_for_perm(graph):
         # type: (GroupGraph) -> bool
-        return any([g.permission == permission_name for g in graph.permission_grants[group_name]])
+        return any(
+            [
+                g["permission"] == permission_name and g["distance"] == 0
+                for g in graph.get_group_details(group_name)["permissions"]
+            ]
+        )
 
     # make some permission admins
     grant_permission(groups["security-team"], permissions[PERMISSION_ADMIN])

--- a/tests/usecases/list_grants.py
+++ b/tests/usecases/list_grants.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
+from grouper.entities.permission_grant import UniqueGrantsOfPermission
 from grouper.usecases.list_grants import ListGrantsUI
 
 if TYPE_CHECKING:
@@ -11,15 +11,15 @@ if TYPE_CHECKING:
 class MockUI(ListGrantsUI):
     def __init__(self):
         # type: () -> None
-        self.grants = {}  # type: AllGrants
-        self.grants_of_permission = {}  # type: Dict[str, AllGrantsOfPermission]
+        self.grants = {}  # type: Dict[str, UniqueGrantsOfPermission]
+        self.grants_of_permission = {}  # type: Dict[str, UniqueGrantsOfPermission]
 
     def listed_grants(self, grants):
-        # type: (AllGrants) -> None
+        # type: (Dict[str, UniqueGrantsOfPermission]) -> None
         self.grants = grants
 
     def listed_grants_of_permission(self, permission, grants):
-        # type: (str, AllGrantsOfPermission) -> None
+        # type: (str, UniqueGrantsOfPermission) -> None
         self.grants_of_permission[permission] = grants
 
 
@@ -55,13 +55,15 @@ def test_list_grants(setup):
     usecase.list_grants()
 
     expected = {
-        "not-gary": AllGrantsOfPermission(users={"zorkian@a.co": ["foo"]}, service_accounts={}),
-        "other-permission": AllGrantsOfPermission(users={"gary@a.co": [""]}, service_accounts={}),
-        "some-permission": AllGrantsOfPermission(
+        "not-gary": UniqueGrantsOfPermission(users={"zorkian@a.co": ["foo"]}, service_accounts={}),
+        "other-permission": UniqueGrantsOfPermission(
+            users={"gary@a.co": [""]}, service_accounts={}
+        ),
+        "some-permission": UniqueGrantsOfPermission(
             users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
             service_accounts={"service@svc.localhost": ["*"]},
         ),
-        "twice": AllGrantsOfPermission(users={"gary@a.co": ["*"]}, service_accounts={}),
+        "twice": UniqueGrantsOfPermission(users={"gary@a.co": ["*"]}, service_accounts={}),
     }
     assert mock_ui.grants == expected
     assert mock_ui.grants_of_permission == {}
@@ -77,7 +79,7 @@ def test_list_grants_of_permission(setup):
     usecase.list_grants_of_permission("some-permission")
     assert mock_ui.grants == {}
     assert mock_ui.grants_of_permission == {
-        "some-permission": AllGrantsOfPermission(
+        "some-permission": UniqueGrantsOfPermission(
             users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
             service_accounts={"service@svc.localhost": ["*"]},
         )
@@ -90,4 +92,4 @@ def test_unknown_permission(setup):
     usecase = setup.usecase_factory.create_list_grants_usecase(mock_ui)
     usecase.list_grants_of_permission("unknown-permission")
     assert mock_ui.grants == {}
-    assert mock_ui.grants_of_permission == {"unknown-permission": AllGrantsOfPermission({}, {})}
+    assert mock_ui.grants_of_permission == {"unknown-permission": UniqueGrantsOfPermission({}, {})}

--- a/tests/usecases/list_grants.py
+++ b/tests/usecases/list_grants.py
@@ -1,0 +1,93 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.permission_grant import AllGrants, AllGrantsOfPermission
+from grouper.usecases.list_grants import ListGrantsUI
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+    from typing import Dict
+
+
+class MockUI(ListGrantsUI):
+    def __init__(self):
+        # type: () -> None
+        self.grants = {}  # type: AllGrants
+        self.grants_of_permission = {}  # type: Dict[str, AllGrantsOfPermission]
+
+    def listed_grants(self, grants):
+        # type: (AllGrants) -> None
+        self.grants = grants
+
+    def listed_grants_of_permission(self, permission, grants):
+        # type: (str, AllGrantsOfPermission) -> None
+        self.grants_of_permission[permission] = grants
+
+
+def create_graph(setup):
+    # type: (SetupTest) -> None
+    """Create a simple graph structure with some permission grants."""
+    setup.add_user_to_group("gary@a.co", "some-group")
+    setup.grant_permission_to_group("some-permission", "foo", "some-group")
+    setup.add_user_to_group("gary@a.co", "other-group")
+    setup.grant_permission_to_group("other-permission", "", "other-group")
+    setup.grant_permission_to_group("not-gary", "foo", "not-member-group")
+    setup.grant_permission_to_group("some-permission", "*", "not-member-group")
+    setup.grant_permission_to_group("some-permission", "bar", "parent-group")
+    setup.add_group_to_group("some-group", "parent-group")
+    setup.grant_permission_to_group("twice", "*", "group-one")
+    setup.grant_permission_to_group("twice", "*", "group-two")
+    setup.add_group_to_group("child-group", "group-one")
+    setup.add_group_to_group("child-group", "group-two")
+    setup.add_user_to_group("gary@a.co", "child-group")
+    setup.add_user_to_group("zorkian@a.co", "not-member-group")
+    setup.create_user("oliver@a.co")
+    setup.create_service_account("service@svc.localhost", "some-group")
+    setup.grant_permission_to_service_account("some-permission", "*", "service@svc.localhost")
+
+
+def test_list_grants(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        create_graph(setup)
+
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_list_grants_usecase(mock_ui)
+    usecase.list_grants()
+
+    expected = {
+        "not-gary": AllGrantsOfPermission(users={"zorkian@a.co": ["foo"]}, service_accounts={}),
+        "other-permission": AllGrantsOfPermission(users={"gary@a.co": [""]}, service_accounts={}),
+        "some-permission": AllGrantsOfPermission(
+            users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            service_accounts={"service@svc.localhost": ["*"]},
+        ),
+        "twice": AllGrantsOfPermission(users={"gary@a.co": ["*"]}, service_accounts={}),
+    }
+    assert mock_ui.grants == expected
+    assert mock_ui.grants_of_permission == {}
+
+
+def test_list_grants_of_permission(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        create_graph(setup)
+
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_list_grants_usecase(mock_ui)
+    usecase.list_grants_of_permission("some-permission")
+    assert mock_ui.grants == {}
+    assert mock_ui.grants_of_permission == {
+        "some-permission": AllGrantsOfPermission(
+            users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            service_accounts={"service@svc.localhost": ["*"]},
+        )
+    }
+
+
+def test_unknown_permission(setup):
+    # type: (SetupTest) -> None
+    mock_ui = MockUI()
+    usecase = setup.usecase_factory.create_list_grants_usecase(mock_ui)
+    usecase.list_grants_of_permission("unknown-permission")
+    assert mock_ui.grants == {}
+    assert mock_ui.grants_of_permission == {"unknown-permission": AllGrantsOfPermission({}, {})}


### PR DESCRIPTION
/grants will return all permission grants in a JSON dict with the
permissions as keys, followed by users or service_accounts, followed
by the name of the user or service account, followed by a list of
arguments.

/grants/<permission> will return the same for a specific permission,
without the first layer of dict but with a separate top-level key of
permission, indicating the requested permission.

The test uses the low-level API directly since Groupy doesn't have
high-level support for grants.  (It's not clear yet whether it's
worth the trouble of adding that.)