### PR TITLE
Stop using raw formatting for the GitHub username

### DIFF
--- a/grouper/fe/handlers/user_github.py
+++ b/grouper/fe/handlers/user_github.py
@@ -61,7 +61,7 @@ class UserGitHub(GrouperHandler):
             self.session,
             self.current_user.id,
             "changed_github_username",
-            "Changed GitHub username: {!r}".format(form.data["username"]),
+            "Changed GitHub username: {}".format(form.data["username"]),
             on_user_id=user.id,
         )
 


### PR DESCRIPTION
In the audit log, the new GitHub username was stored with raw
formatting.  That adds quotes and possibly a `u`, which looks odd.
There doesn't seem to be a need for this, so remove the raw
formatting and add a test.