### PR TITLE
Suppress duplicates in permission disable error

### DIFF
--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -53,13 +53,13 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
         # type: (...) -> None
         message = ""
         if group_grants:
-            groups = [g.group for g in group_grants]
-            message = "groups " + ", ".join(groups)
+            groups = {g.group for g in group_grants}
+            message = "groups " + ", ".join(sorted(groups))
         if service_account_grants:
-            service_accounts = [g.service_account for g in service_account_grants]
+            service_accounts = {g.service_account for g in service_account_grants}
             if message:
                 message += " and "
-            message += "service accounts " + ", ".join(service_accounts)
+            message += "service accounts " + ", ".join(sorted(service_accounts))
         logging.critical("permission %s still granted to %s", name, message)
         sys.exit(1)
 

--- a/tests/ctl/permission_test.py
+++ b/tests/ctl/permission_test.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tests.setup import SetupTest
 
 
-def test_permission_disable(setup):
+def test_disable(setup):
     # type: (SetupTest) -> None
     with setup.transaction():
         setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
@@ -24,7 +24,7 @@ def test_permission_disable(setup):
     assert not permission.enabled
 
 
-def test_permission_disable_failed(setup):
+def test_disable_failed(setup):
     # type: (SetupTest) -> None
     with setup.transaction():
         setup.create_user("gary@a.co")
@@ -32,7 +32,7 @@ def test_permission_disable_failed(setup):
         run_ctl(setup, "permission", "-a", "gary@a.co", "disable", "some-permission")
 
 
-def test_permission_disable_existing_grants(setup, caplog):
+def test_disable_with_existing_grants(setup, caplog):
     # type: (SetupTest, LogCaptureFixture) -> None
     with setup.transaction():
         setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
@@ -43,3 +43,20 @@ def test_permission_disable_existing_grants(setup, caplog):
         run_ctl(setup, "permission", "-a", "gary@a.co", "disable", "some-permission")
 
     assert "permission some-permission still granted to groups some-group" in caplog.text
+
+
+def test_disable_with_duplicate_grants(setup, caplog):
+    # type: (SetupTest, LogCaptureFixture) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group("some-permission", "", "some-group")
+        setup.grant_permission_to_group("some-permission", "foo", "another-group")
+        setup.grant_permission_to_group("some-permission", "bar", "another-group")
+        setup.grant_permission_to_group("some-permission", "baz", "another-group")
+
+    with pytest.raises(SystemExit):
+        run_ctl(setup, "permission", "-a", "gary@a.co", "disable", "some-permission")
+
+    expected = "permission some-permission still granted to groups another-group, some-group"
+    assert expected in caplog.text


### PR DESCRIPTION
When attempting to disable a permission that's still granted to
some groups or service accounts using grouper-ctl, we were showing
the group or service account name for each grant.  This meant that
the same group or service account could be listed multiple times if
it had multiple grants with different arguments.

Since the argument isn't included in the error, this is duplicative
and makes the error harder to read.  De-duplicate the group or
service account names before showing the error.