### PR TITLE
Separate grants to role users

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -273,14 +273,22 @@ class Grants(GraphHandler, ListGrantsUI):
     def listed_grants(self, grants):
         # type: (Dict[str, UniqueGrantsOfPermission]) -> None
         grants_dict = {
-            k: {"users": v.users, "service_accounts": v.service_accounts}
+            k: {
+                "users": v.users,
+                "role_users": v.role_users,
+                "service_accounts": v.service_accounts,
+            }
             for k, v in iteritems(grants)
         }
         self.success({"permissions": grants_dict})
 
     def listed_grants_of_permission(self, permission, grants):
         # type: (str, UniqueGrantsOfPermission) -> None
-        grants_dict = {"users": grants.users, "service_accounts": grants.service_accounts}
+        grants_dict = {
+            "users": grants.users,
+            "role_users": grants.role_users,
+            "service_accounts": grants.service_accounts,
+        }
         self.success({"permission": permission, "grants": grants_dict})
 
     def get(self, *args, **kwargs):

--- a/grouper/entities/permission_grant.py
+++ b/grouper/entities/permission_grant.py
@@ -26,9 +26,13 @@ ServiceAccountPermissionGrant = NamedTuple(
 
 # Represents all unique grants of a specific permission (meaning that if a user has the same
 # permission and argument granted from multiple groups, it's represented only once).  Contains a
-# dictionary of users and service accounts who have been granted that permission, the values in
-# which are lists of all the arguments to that permission that they have been granted.
+# dictionary of users, role users, and service accounts who have been granted that permission, the
+# values in which are lists of all the arguments to that permission that they have been granted.
 UniqueGrantsOfPermission = NamedTuple(
     "UniqueGrantsOfPermission",
-    [("users", Dict[str, List[str]]), ("service_accounts", Dict[str, List[str]])],
+    [
+        ("users", Dict[str, List[str]]),
+        ("role_users", Dict[str, List[str]]),
+        ("service_accounts", Dict[str, List[str]]),
+    ],
 )

--- a/itests/api/grants_test.py
+++ b/itests/api/grants_test.py
@@ -29,6 +29,9 @@ def create_graph(setup):
     setup.create_user("oliver@a.co")
     setup.create_service_account("service@svc.localhost", "some-group")
     setup.grant_permission_to_service_account("some-permission", "*", "service@svc.localhost")
+    setup.create_role_user("role-user@a.co")
+    setup.grant_permission_to_group("some-permission", "foo", "role-user@a.co")
+    setup.grant_permission_to_group("some-permission", "role", "role-user@a.co")
 
 
 def test_list_grants(tmpdir, setup):
@@ -37,13 +40,18 @@ def test_list_grants(tmpdir, setup):
         create_graph(setup)
 
     expected = {
-        "not-gary": {"users": {"zorkian@a.co": ["foo"]}, "service_accounts": {}},
-        "other-permission": {"users": {"gary@a.co": [""]}, "service_accounts": {}},
+        "not-gary": {"users": {"zorkian@a.co": ["foo"]}, "role_users": {}, "service_accounts": {}},
+        "other-permission": {
+            "users": {"gary@a.co": [""]},
+            "role_users": {},
+            "service_accounts": {},
+        },
         "some-permission": {
             "users": {"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            "role_users": {"role-user@a.co": ["foo", "role"]},
             "service_accounts": {"service@svc.localhost": ["*"]},
         },
-        "twice": {"users": {"gary@a.co": ["*"]}, "service_accounts": {}},
+        "twice": {"users": {"gary@a.co": ["*"]}, "role_users": {}, "service_accounts": {}},
     }
 
     with api_server(tmpdir) as api_url:
@@ -60,6 +68,7 @@ def test_list_grants_of_permission(tmpdir, setup):
 
     expected = {
         "users": {"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+        "role_users": {"role-user@a.co": ["foo", "role"]},
         "service_accounts": {"service@svc.localhost": ["*"]},
     }
 

--- a/tests/usecases/list_grants_test.py
+++ b/tests/usecases/list_grants_test.py
@@ -43,6 +43,9 @@ def create_graph(setup):
     setup.create_user("oliver@a.co")
     setup.create_service_account("service@svc.localhost", "some-group")
     setup.grant_permission_to_service_account("some-permission", "*", "service@svc.localhost")
+    setup.create_role_user("role-user@a.co")
+    setup.grant_permission_to_group("some-permission", "foo", "role-user@a.co")
+    setup.grant_permission_to_group("some-permission", "role", "role-user@a.co")
 
 
 def test_list_grants(setup):
@@ -55,15 +58,20 @@ def test_list_grants(setup):
     usecase.list_grants()
 
     expected = {
-        "not-gary": UniqueGrantsOfPermission(users={"zorkian@a.co": ["foo"]}, service_accounts={}),
+        "not-gary": UniqueGrantsOfPermission(
+            users={"zorkian@a.co": ["foo"]}, role_users={}, service_accounts={}
+        ),
         "other-permission": UniqueGrantsOfPermission(
-            users={"gary@a.co": [""]}, service_accounts={}
+            users={"gary@a.co": [""]}, role_users={}, service_accounts={}
         ),
         "some-permission": UniqueGrantsOfPermission(
             users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            role_users={"role-user@a.co": ["foo", "role"]},
             service_accounts={"service@svc.localhost": ["*"]},
         ),
-        "twice": UniqueGrantsOfPermission(users={"gary@a.co": ["*"]}, service_accounts={}),
+        "twice": UniqueGrantsOfPermission(
+            users={"gary@a.co": ["*"]}, role_users={}, service_accounts={}
+        ),
     }
     assert mock_ui.grants == expected
     assert mock_ui.grants_of_permission == {}
@@ -81,6 +89,7 @@ def test_list_grants_of_permission(setup):
     assert mock_ui.grants_of_permission == {
         "some-permission": UniqueGrantsOfPermission(
             users={"gary@a.co": ["bar", "foo"], "zorkian@a.co": ["*"]},
+            role_users={"role-user@a.co": ["foo", "role"]},
             service_accounts={"service@svc.localhost": ["*"]},
         )
     }
@@ -92,4 +101,8 @@ def test_unknown_permission(setup):
     usecase = setup.usecase_factory.create_list_grants_usecase(mock_ui)
     usecase.list_grants_of_permission("unknown-permission")
     assert mock_ui.grants == {}
-    assert mock_ui.grants_of_permission == {"unknown-permission": UniqueGrantsOfPermission({}, {})}
+    assert mock_ui.grants_of_permission == {
+        "unknown-permission": UniqueGrantsOfPermission(
+            users={}, role_users={}, service_accounts={}
+        )
+    }


### PR DESCRIPTION
The ListGrants use case and /grants API endpoint separated users
from service accounts but lumped the deprecated role users in with
users.  This doesn't match our current output needs, so add a
third element for role users and plumb that through to the /grants
route.

This can be deleted later once role users are entirely obsolete.