### PR TITLE
Fix display of group join policy in list

### DIFF
--- a/grouper/fe/templates/groups.html
+++ b/grouper/fe/templates/groups.html
@@ -63,9 +63,9 @@
                     <td class="group-name">{{ account(group.name, "group") }}</td>
                     <td class="group-description">{{group.description|default("", True)}}</td>
                     <td class="group-can-join">
-                        {% if group.canjoin == "canjoin" %}
+                        {% if group.join_policy.name == "CAN_JOIN" %}
                             Anyone
-                        {% elif group.canjoin == "canask" %}
+                        {% elif group.join_policy.name == "CAN_ASK" %}
                             Must Ask
                         {% else %}
                             Nobody

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -187,11 +187,6 @@ class AuditMemberRow(BaseElement):
 
 class GroupRow(BaseElement):
     @property
-    def audited_reason(self):
-        # type: () -> str
-        return self.find_element_by_class_name("group-why-audited").text
-
-    @property
     def name(self):
         # type: () -> str
         return self.find_element_by_class_name("group-name").text
@@ -202,6 +197,21 @@ class GroupRow(BaseElement):
         name = self.find_element_by_class_name("group-name")
         link = name.find_element_by_tag_name("a")
         return link.get_attribute("href")
+
+    @property
+    def description(self):
+        # type: () -> str
+        return self.find_element_by_class_name("group-description").text
+
+    @property
+    def can_join(self):
+        # type: () -> str
+        return self.find_element_by_class_name("group-can-join").text
+
+    @property
+    def audited_reason(self):
+        # type: () -> str
+        return self.find_element_by_class_name("group-why-audited").text
 
 
 class MemberRow(BaseElement):


### PR DESCRIPTION
A previous change passed the Group entity into the templates instead
of a SQLAlchemy model, which broke display of the join policy for a
group in the group list.  Fix this by inspecting the correct
attribute, and add a proper test.