### PR TITLE
Restructure grouper-ctl commands with subcommands

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ In Merou, there are three separate UIs:
 - Frontend server: uses Tornado web handlers with Jinja2 and WTForms,
   returns HTML for a browser
 - The `grouper-ctl` command-line tool: takes command line arguments and
-  reports the results with Python `logging`
+  reports the results with `print` or Python `logging`
 
 There may be additional UIs in the future.  All of these UIs gather data
 for the request from a user and then instantiate and call a *use case*.
@@ -358,8 +358,7 @@ permission:
 - `grouper.fe.handlers.permission_disable`
 - `tests.usecases.disable_permission_test`
 - `tests.ctl.permission_test`
-
-A separate integration test for the frontend hasn't been written yet.
+- `itests.fe.permission_view_test`
 
 Checklists
 ==========

--- a/grouper/ctl/permission.py
+++ b/grouper/ctl/permission.py
@@ -15,26 +15,13 @@ if TYPE_CHECKING:
     from typing import List
 
 
-class PermissionCommand(CtlCommand, DisablePermissionUI):
-    """Commands to modify permissions."""
+class DisablePermissionCommand(CtlCommand, DisablePermissionUI):
+    """Command to disable a permission."""
 
     @staticmethod
     def add_arguments(parser):
         # type: (ArgumentParser) -> None
-        parser.add_argument(
-            "-a",
-            "--actor",
-            required=True,
-            dest="actor_name",
-            help=(
-                "Name of the entity performing this action."
-                " Must be a valid Grouper human or service account."
-            ),
-        )
-
-        subparser = parser.add_subparsers(dest="subcommand")
-        disable_parser = subparser.add_parser("disable", help="Disable a permission")
-        disable_parser.add_argument("name", help="Name of permission to disable")
+        parser.add_argument("name", help="Name of permission to disable")
 
     def __init__(self, usecase_factory):
         # type: (UseCaseFactory) -> None
@@ -83,3 +70,37 @@ class PermissionCommand(CtlCommand, DisablePermissionUI):
         """Run a permission command."""
         usecase = self.usecase_factory.create_disable_permission_usecase(args.actor_name, self)
         usecase.disable_permission(args.name)
+
+
+class PermissionCommand(CtlCommand):
+    """Commands to modify permissions."""
+
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument(
+            "-a",
+            "--actor",
+            required=True,
+            dest="actor_name",
+            help=(
+                "Name of the entity performing this action."
+                " Must be a valid Grouper human or service account."
+            ),
+        )
+
+        subparser = parser.add_subparsers(dest="subcommand")
+        parser = subparser.add_parser("disable", help="Disable a permission")
+        DisablePermissionCommand.add_arguments(parser)
+
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
+
+    def run(self, args):
+        # type: (Namespace) -> None
+        if args.subcommand == "disable":
+            subcommand = DisablePermissionCommand(self.usecase_factory)
+            subcommand.run(args)
+        else:
+            raise ValueError("unknown subcommand {}".format(args.subcommand))


### PR DESCRIPTION
Instead of implementing all UIs for a grouper-ctl command in a
single class, use one class per subcommand that implements only
the relevant UIs, and add another level of indirection to the
class structure.

Also fixes a couple of minor documentation issues found when
reviewing the documentation.