### PR TITLE
Fix revocation of service account permissions

### DIFF
--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -97,18 +97,20 @@ $(function () {
         $("#createFrom").submit();
     });
 
-    // The revokeModal is generated once per page but could be used for any member being removed. So,
-    // when the modal shows up, make sure to populate its text and set its form actions to correspond to
-    // the selected user.
+    // The revokeModal is generated once per page but could be used for any member being
+    // removed. So, when the modal shows up, make sure to populate its text and set its form
+    // actions to correspond to the selected user.
 
     $("#revokeModal").on("show.bs.modal", function(e) {
         var button = $(e.relatedTarget);
+        var group = button.data("group");
+        var user = button.data("user");
         var mappingId = button.data("mapping-id");
 
         var modal = $(e.currentTarget);
 
         var form = modal.find(".revoke-permission-form");
-        form.attr("action", "/groups/{{group.name}}/service/{{user.username}}/revoke/" + mappingId);
+        form.attr("action", "/groups/" + group + "/service/" + user + "/revoke/" + mappingId);
     });
 
     var auditModal = $('#auditModal');

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -34,7 +34,9 @@
                                 <button class="btn btn-danger btn-xs permission-revoke"
                                         data-toggle="modal"
                                         data-target="#revokeModal"
-                                        data-mapping-id="{{map.mapping_id}}">
+                                        data-group="{{group.name}}"
+                                        data-user="{{user.username}}"
+                                        data-mapping-id="{{map.grant_id}}">
                                     <span class="glyphicon glyphicon-remove glyphicon-vertical-adjust"></span> Revoke
                                 </button>
                             </td>
@@ -97,7 +99,7 @@
 <div class="row">
     <div class="col-md-6">
         <blockquote><p>
-            <em>{{account.description|default("", True)}}</em>
+            <em id="description">{{account.description|default("", True)}}</em>
         </p></blockquote>
     </div>
 </div>
@@ -110,11 +112,11 @@
             <table class="table">
                 <tr>
                     <td><strong>Owner</strong></td>
-                    <td><a href="/groups/{{ group.name }}">{{ group.name }}</a></td>
+                    <td id="owner"><a href="/groups/{{ group.name }}">{{ group.name }}</a></td>
                 </tr>
                 <tr>
                     <td><strong>Machine Set</strong></td>
-                    <td>{{ account.machine_set }}</td>
+                    <td id="machine-set">{{ account.machine_set }}</td>
                 </tr>
             </table>
         </div>

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -71,6 +71,7 @@ def test_permission_grant_revoke(tmpdir, setup, browser):
         browser.get(url(frontend_url, "/groups/some-group/service/service@svc.localhost"))
 
         page = ServiceAccountViewPage(browser)
+        assert page.owner == "some-group"
         assert page.permission_rows == []
         page.click_add_permission_button()
 
@@ -79,7 +80,7 @@ def test_permission_grant_revoke(tmpdir, setup, browser):
         grant_page.set_argument("foo")
         grant_page.submit()
 
-        page = ServiceAccountViewPage(browser)
+        assert page.owner == "some-group"
         permission_rows = page.permission_rows
         assert len(permission_rows) == 1
         permission = permission_rows[0]
@@ -90,4 +91,5 @@ def test_permission_grant_revoke(tmpdir, setup, browser):
         permission_revoke_modal = page.get_revoke_permission_modal()
         permission_revoke_modal.confirm()
 
+        assert page.owner == "some-group"
         assert page.permission_rows == []

--- a/itests/pages/service_accounts.py
+++ b/itests/pages/service_accounts.py
@@ -11,6 +11,11 @@ if TYPE_CHECKING:
 
 class ServiceAccountViewPage(BasePage):
     @property
+    def owner(self):
+        # type: () -> str
+        return self.find_element_by_id("owner").text
+
+    @property
     def permission_rows(self):
         # type: () -> List[ServiceAccountPermissionRow]
         all_permission_rows = self.find_elements_by_class_name("permission-row")


### PR DESCRIPTION
When moving the JavaScript for service account permission revocation,
we missed that the URL construction included template variables that
of course are not expanded in the external JavaScript.  Switch to
setting data attributes on the button instead.

This problem was not caught by the test suite despite an explicit
test because the test only checked for a lack of permission rows on
success, and the error page had no permission rows.  Add a positive
test for another page attribute (and add HTML id attributes to more
page elements to make this easier) to confirm that we got back the
service account page rather than some error page.