### PR TITLE
Improve log_exception plugin hook, use it

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -29,7 +29,8 @@ if TYPE_CHECKING:
     from grouper.entities.user import User
     from grouper.graph import GroupGraph
     from grouper.usecases.factory import UseCaseFactory
-    from typing import Any, Dict, Iterable, Optional, Tuple
+    from types import TracebackType
+    from typing import Any, Dict, Iterable, Optional, Tuple, Type
 
 
 def get_individual_user_info(handler, name, service_account):
@@ -92,6 +93,20 @@ class GraphHandler(SentryHandler):
 
         stats.log_rate("response_status_{}".format(response_status), 1)
         stats.log_rate("response_status_{}_{}".format(self.__class__.__name__, response_status), 1)
+
+    def log_exception(
+        self,
+        exc_type,  # type: Optional[Type[BaseException]]
+        exc_value,  # type: Optional[BaseException]
+        exc_tb,  # type: Optional[TracebackType]
+    ):
+        # type: (...) -> None
+        if isinstance(exc_value, HTTPError):
+            status_code = exc_value.status_code
+        else:
+            status_code = 500
+        self.plugins.log_exception(self.request, status_code, exc_type, exc_value, exc_tb)
+        super(GraphHandler, self).log_exception(exc_type, exc_value, exc_tb)
 
     def error(self, errors):
         # type: (Iterable[Tuple[int, Any]]) -> None

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -8,7 +8,8 @@ if TYPE_CHECKING:
     from ssl import SSLContext
     from sqlalchemy.orm import Session
     from tornado.httpserver import HTTPRequest
-    from typing import Any, Dict, List, Tuple, Union
+    from types import TracebackType
+    from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 
 class BasePlugin(object):
@@ -80,19 +81,23 @@ class BasePlugin(object):
         """
         pass
 
-    def log_exception(self, request, status, exception, stack):
-        # type: (HTTPRequest, int, Exception, List) -> None
-        """
-        Called when responding with statuses 400, 403, 404, and 500.
+    def log_exception(
+        self,
+        request,  # type: Optional[HTTPRequest]
+        status,  # type: Optional[int]
+        exc_type,  # type: Optional[Type[BaseException]]
+        exc_value,  # type: Optional[BaseException]
+        exc_tb,  # type: Optional[TracebackType]
+    ):
+        # type: (...) -> None
+        """Called when an exception is triggered.
 
         Args:
-            request: the request being handled.
-            status: the response status.
-            exception: either a tornado.web.HTTPError or an unexpected exception.
-            stack: "pre-processed" stack trace entries for traceback.format_list.
-
-        Returns:
-            The return code of this method is ignored.
+            request: The request being handled (None for non-Tornado exceptions)
+            status: The response status (None for non-Tornado exceptions)
+            exc_type: The type of the exception
+            exc_value: The exception object
+            exc_tb: The traceback, in the same form as sys.exc_info()[2]
         """
         pass
 

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
     from ssl import SSLContext
     from sqlalchemy.orm import Session
     from tornado.httpserver import HTTPRequest
-    from typing import Any, Dict, List, Iterable, Optional, Tuple, Union
+    from types import TracebackType
+    from typing import Any, Dict, List, Iterable, Optional, Type, Tuple, Union
 
 
 class PluginProxy(object):
@@ -73,10 +74,17 @@ class PluginProxy(object):
         for plugin in self._plugins:
             plugin.log_auditlog_entry(entry)
 
-    def log_exception(self, request, status, exception, stack):
-        # type: (HTTPRequest, int, Exception, List) -> None
+    def log_exception(
+        self,
+        request,  # type: Optional[HTTPRequest]
+        status,  # type: Optional[int]
+        exc_type,  # type: Optional[Type[BaseException]]
+        exc_value,  # type: Optional[BaseException]
+        exc_tb,  # type: Optional[TracebackType]
+    ):
+        # type: (...) -> None
         for plugin in self._plugins:
-            plugin.log_exception(request, status, exception, stack)
+            plugin.log_exception(request, status, exc_type, exc_value, exc_tb)
 
     def log_gauge(self, key, val):
         # type: (str, float) -> None

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -1,0 +1,70 @@
+import sys
+from typing import TYPE_CHECKING
+
+from tornado.httpserver import HTTPRequest
+
+from grouper.plugin.base import BasePlugin
+from grouper.plugin.proxy import PluginProxy
+
+if TYPE_CHECKING:
+    from types import TracebackType
+    from typing import Optional, Type
+
+
+class RandomException(Exception):
+    pass
+
+
+class ExceptionLoggerTestPlugin(BasePlugin):
+    def __init__(self):
+        # type: () -> None
+        self.request = None  # type: Optional[HTTPRequest]
+        self.status = None  # type: Optional[int]
+        self.exc_type = None  # type: Optional[Type[BaseException]]
+        self.exc_value = None  # type: Optional[BaseException]
+        self.exc_tb = None  # type: Optional[TracebackType]
+
+    def log_exception(
+        self,
+        request,  # type: Optional[HTTPRequest]
+        status,  # type: Optional[int]
+        exc_type,  # type: Optional[Type[BaseException]]
+        exc_value,  # type: Optional[BaseException]
+        exc_tb,  # type: Optional[TracebackType]
+    ):
+        # type: (...) -> None
+        self.request = request
+        self.status = status
+        self.exc_type = exc_type
+        self.exc_value = exc_value
+        self.exc_tb = exc_tb
+
+
+def test_exception_plugin():
+    # type: () -> None
+    test_logger = ExceptionLoggerTestPlugin()
+    proxy = PluginProxy([test_logger])
+
+    try:
+        raise RandomException("some string")
+    except RandomException:
+        proxy.log_exception(None, None, *sys.exc_info())
+
+    assert test_logger.request is None
+    assert test_logger.status is None
+    assert test_logger.exc_type == RandomException
+    assert str(test_logger.exc_value) == "some string"
+    assert test_logger.exc_tb is not None
+
+    try:
+        raise RandomException("with request")
+    except RandomException:
+        request = HTTPRequest("GET", "/foo")
+        proxy.log_exception(request, 200, *sys.exc_info())
+
+    assert test_logger.request is not None
+    assert test_logger.request.uri == "/foo"
+    assert test_logger.status == 200
+    assert test_logger.exc_type == RandomException
+    assert str(test_logger.exc_value) == "with request"
+    assert test_logger.exc_tb is not None


### PR DESCRIPTION
This hook currently isn't used, so before we add an initial use of
it, clean up the types and parameters.  Pass in the full tuple that
Python normally includes with exceptions, in addition to the request
and status if any, and allow the request and status to be omitted
for non-Tornado exceptions.

Remove Sentry support in the background processor and instead just
call the log_exception plugins.

Add a log_exception handler that logs via the plugin log_exception
method and then still runs the normal Tornado exception logging.

Cleaning up remaining Sentry support will be in a subsequent diff.