### PR TITLE
Remove Sentry support

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -89,11 +89,6 @@ common:
     # Type: str
     from_addr: "no-reply@grouper.local"
 
-    # Sentry DSN for logging exceptions.
-    #
-    # Type: str
-    sentry_dsn:
-
     # The email domain that all service accounts must have.  This will also be
     # used as the domain when constructing message IDs when Grouper sends email.
     #
@@ -149,17 +144,7 @@ api:
     # Type: int
     refresh_interval: 1
 
-    # Sentry DSN for logging exceptions.
-    #
-    # Type: str
-    sentry_dsn:
-
 background:
-    # Sentry DSN for logging exceptions.
-    #
-    # Type: str
-    sentry_dsn:
-
     # How long to wait between iterations.
     #
     # Type: int

--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -7,11 +7,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from six import iteritems, StringIO
-from tornado.web import HTTPError
+from tornado.web import HTTPError, RequestHandler
 
 from grouper import stats
 from grouper.constants import TOKEN_FORMAT
-from grouper.error_reporting import SentryHandler
 from grouper.graph import NoSuchGroup, NoSuchUser
 from grouper.models.base.session import Session
 from grouper.models.public_key import PublicKey
@@ -28,6 +27,7 @@ if TYPE_CHECKING:
     from grouper.entities.permission_grant import UniqueGrantsOfPermission
     from grouper.entities.user import User
     from grouper.graph import GroupGraph
+    from grouper.plugin.proxy import PluginProxy
     from grouper.usecases.factory import UseCaseFactory
     from types import TracebackType
     from typing import Any, Dict, Iterable, Optional, Tuple, Type
@@ -68,11 +68,12 @@ def get_individual_user_info(handler, name, service_account):
         return out
 
 
-class GraphHandler(SentryHandler):
+class GraphHandler(RequestHandler):
     def initialize(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         self.graph = kwargs["graph"]  # type: GroupGraph
         self.usecase_factory = kwargs["usecase_factory"]  # type: UseCaseFactory
+        self.plugins = kwargs["plugins"]  # type: PluginProxy
 
         self._request_start_time = datetime.utcnow()
 

--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -15,7 +15,7 @@ from grouper.api.routes import HANDLERS
 from grouper.api.settings import ApiSettings
 from grouper.app import GrouperApplication
 from grouper.database import DbRefreshThread
-from grouper.error_reporting import get_sentry_client, setup_signal_handlers
+from grouper.error_reporting import setup_signal_handlers
 from grouper.graph import Graph
 from grouper.initialization import create_graph_usecase_factory
 from grouper.models.base.session import get_db_engine, Session
@@ -26,35 +26,27 @@ from grouper.setup import build_arg_parser, setup_logging
 
 if TYPE_CHECKING:
     from argparse import Namespace
-    from grouper.error_reporting import SentryProxy
     from grouper.graph import GroupGraph
     from grouper.usecases.factory import UseCaseFactory
     from typing import List
 
 
-def create_api_application(graph, settings, usecase_factory):
-    # type: (GroupGraph, ApiSettings, UseCaseFactory) -> GrouperApplication
+def create_api_application(graph, settings, plugins, usecase_factory):
+    # type: (GroupGraph, ApiSettings, PluginProxy, UseCaseFactory) -> GrouperApplication
     tornado_settings = {"debug": settings.debug}
-    handler_settings = {"graph": graph, "usecase_factory": usecase_factory}
+    handler_settings = {"graph": graph, "plugins": plugins, "usecase_factory": usecase_factory}
     handlers = [(route, handler_class, handler_settings) for (route, handler_class) in HANDLERS]
     return GrouperApplication(handlers, **tornado_settings)
 
 
-def start_server(args, settings, sentry_client):
-    # type: (Namespace, ApiSettings, SentryProxy) -> None
+def start_server(args, settings, plugins):
+    # type: (Namespace, ApiSettings, PluginProxy) -> None
     log_level = logging.getLevelName(logging.getLogger().level)
     logging.info("begin. log_level={}".format(log_level))
 
     assert not (
         settings.debug and settings.num_processes > 1
     ), "debug mode does not support multiple processes"
-
-    try:
-        plugins = PluginProxy.load_plugins(settings, "grouper-api")
-        set_global_plugin_proxy(plugins)
-    except PluginsDirectoryDoesNotExist as e:
-        logging.fatal("Plugin directory does not exist: {}".format(e))
-        sys.exit(1)
 
     # setup database
     logging.debug("configure database session")
@@ -66,12 +58,12 @@ def start_server(args, settings, sentry_client):
         graph = Graph()
         graph.update_from_db(session)
 
-    refresher = DbRefreshThread(settings, graph, settings.refresh_interval, sentry_client)
+    refresher = DbRefreshThread(settings, plugins, graph, settings.refresh_interval)
     refresher.daemon = True
     refresher.start()
 
     usecase_factory = create_graph_usecase_factory(settings, plugins, graph=graph)
-    application = create_api_application(graph, settings, usecase_factory)
+    application = create_api_application(graph, settings, plugins, usecase_factory)
 
     if args.listen_stdin:
         logging.info("Starting application server on stdin")
@@ -113,21 +105,21 @@ def main(sys_argv=sys.argv):
     args = parser.parse_args(sys_argv[1:])
 
     try:
-        # load settings
         settings = ApiSettings.global_settings_from_config(args.config)
-
-        # setup logging
         setup_logging(args, settings.log_format)
-
-        # setup sentry
-        sentry_client = get_sentry_client(settings.sentry_dsn)
+        plugins = PluginProxy.load_plugins(settings, "grouper-api")
+        set_global_plugin_proxy(plugins)
+    except PluginsDirectoryDoesNotExist as e:
+        logging.fatal("Plugin directory does not exist: {}".format(e))
+        sys.exit(1)
     except Exception:
-        logging.exception("uncaught exception in startup")
+        logging.exception("Uncaught exception in startup")
         sys.exit(1)
 
     try:
-        start_server(args, settings, sentry_client)
+        start_server(args, settings, plugins)
     except Exception:
-        sentry_client.captureException()
+        plugins.log_exception(None, None, *sys.exc_info())
+        logging.exception("Uncaught exception")
     finally:
         logging.info("end")

--- a/grouper/error_reporting.py
+++ b/grouper/error_reporting.py
@@ -7,61 +7,14 @@ import traceback
 from typing import TYPE_CHECKING
 
 from six import iteritems
-from tornado.web import RequestHandler
-
-try:
-    from raven.contrib.tornado import AsyncSentryClient, SentryMixin
-
-    raven_installed = True
-except ImportError:
-    SentryMixin = object
-    raven_installed = False
-
 
 if TYPE_CHECKING:
     from types import FrameType
-    from typing import Optional
 
 
 signame_by_signum = {
     v: k for k, v in iteritems(signal.__dict__) if k.startswith("SIG") and not k.startswith("SIG_")
 }
-
-
-class SentryHandler(RequestHandler, SentryMixin):
-    """Tornado request handler that mixes in SentryMixin if available."""
-
-    pass
-
-
-class SentryProxy(object):
-    """Simple proxy for sentry client that logs to stderr even if no sentry client exists."""
-
-    def __init__(self, sentry_client):
-        self.sentry_client = sentry_client
-
-    def captureException(self, exc_info=None, **kwargs):
-        if self.sentry_client:
-            self.sentry_client.captureException(exc_info=exc_info, **kwargs)
-
-        logging.exception("exception occurred")
-
-
-def get_sentry_client(sentry_dsn):
-    # type: (Optional[str]) -> SentryProxy
-    if sentry_dsn and raven_installed:
-        logging.info("sentry client setup dsn={}".format(sentry_dsn))
-        sentry_client = SentryProxy(sentry_client=AsyncSentryClient(sentry_dsn))
-    else:
-        if not sentry_dsn:
-            logging.info("no sentry_dsn specified")
-
-        if not raven_installed:
-            logging.info("raven not installed")
-
-        sentry_client = SentryProxy(sentry_client=None)
-
-    return sentry_client
 
 
 def log_and_exit_handler(signum, frame):

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -85,7 +85,6 @@ class Settings(object):
         self.smtp_username = ""
         self.smtp_password = ""
         self.from_addr = "no-reply@grouper.local"
-        self.sentry_dsn = None
         self.service_account_email_domain = "svc.localhost"
         self.timezone = "UTC"
         self.url = "http://127.0.0.1:8888"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -316,10 +316,11 @@ def api_app(session, standard_graph):
     settings = ApiSettings()
     set_global_settings(settings)
     session_factory = SingletonSessionFactory(session)
+    plugins = PluginProxy([])
     usecase_factory = create_graph_usecase_factory(
-        settings, PluginProxy([]), session_factory, standard_graph
+        settings, plugins, session_factory, standard_graph
     )
-    return create_api_application(standard_graph, settings, usecase_factory)
+    return create_api_application(standard_graph, settings, plugins, usecase_factory)
 
 
 @pytest.fixture


### PR DESCRIPTION
Catch a few more places where exceptions were being logged only to
Sentry and log them to the plugin infrastructure instead.