### PR TITLE
Remove backports.ssl-match-hostname dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Jinja2==2.10.1
 PyYAML==5.1
 SQLAlchemy==1.3.2
 WTForms==2.2.1
-backports.ssl-match-hostname==3.5.0.1
 enum34==1.1.6
 mysqlclient==1.4.2.post1
 networkx==2.2


### PR DESCRIPTION
We never call that function anywhere in the code base, so there's
no reason to declare it as a dependency.