### PR TITLE
Add use case for creating a service account

### DIFF
--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from grouper.ctl.dump_sql import DumpSqlCommand
 from grouper.ctl.permission import PermissionCommand
+from grouper.ctl.service_account import ServiceAccountCommand
 from grouper.ctl.sync_db import SyncDbCommand
 from grouper.ctl.user import UserCommand
 from grouper.ctl.user_proxy import UserProxyCommand
@@ -36,6 +37,8 @@ class CtlCommandFactory(object):
         DumpSqlCommand.add_arguments(parser)
         parser = subparsers.add_parser("permission", help="Manipulate permissions")
         PermissionCommand.add_arguments(parser)
+        parser = subparsers.add_parser("service_account", help="Manipulate service accounts")
+        ServiceAccountCommand.add_arguments(parser)
         parser = subparsers.add_parser("sync_db", help="Create database schema")
         SyncDbCommand.add_arguments(parser)
         parser = subparsers.add_parser("user", help="Manipulate users")
@@ -54,6 +57,8 @@ class CtlCommandFactory(object):
             return self.construct_dump_sql_command()
         elif command == "permission":
             return self.construct_permission_command()
+        elif command == "service_account":
+            return self.construct_service_account_command()
         elif command == "sync_db":
             return self.construct_sync_db_command()
         elif command == "user":
@@ -70,6 +75,10 @@ class CtlCommandFactory(object):
     def construct_permission_command(self):
         # type: () -> PermissionCommand
         return PermissionCommand(self.usecase_factory)
+
+    def construct_service_account_command(self):
+        # type: () -> ServiceAccountCommand
+        return ServiceAccountCommand(self.usecase_factory)
 
     def construct_sync_db_command(self):
         # type: () -> SyncDbCommand

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -4,7 +4,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from grouper import __version__
-from grouper.ctl import group, oneoff, service_account, shell
+from grouper.ctl import group, oneoff, shell
 from grouper.ctl.factory import CtlCommandFactory
 from grouper.ctl.settings import CtlSettings
 from grouper.initialization import create_sql_usecase_factory
@@ -51,7 +51,7 @@ def main(sys_argv=sys.argv, session=None):
     CtlCommandFactory.add_all_parsers(subparsers)
 
     # Add parsers for legacy commands that have not been refactored.
-    for subcommand_module in [group, oneoff, service_account, shell]:
+    for subcommand_module in [group, oneoff, shell]:
         subcommand_module.add_parser(subparsers)  # type: ignore
 
     args = parser.parse_args(sys_argv[1:])

--- a/grouper/ctl/service_account.py
+++ b/grouper/ctl/service_account.py
@@ -1,71 +1,96 @@
 import logging
+import sys
 from typing import TYPE_CHECKING
 
-from grouper.ctl.util import ensure_valid_service_account_name
-from grouper.models.group import Group
-from grouper.models.service_account import ServiceAccount
-from grouper.models.user import User
-from grouper.service_account import create_service_account
+from grouper.ctl.base import CtlCommand
+from grouper.usecases.create_service_account import CreateServiceAccountUI
 
 if TYPE_CHECKING:
-    from argparse import Namespace
-    from grouper.ctl.settings import CtlSettings
-    from grouper.repositories.factory import SessionFactory
+    from argparse import ArgumentParser, Namespace
+    from grouper.usecases.factory import UseCaseFactory
 
 
-@ensure_valid_service_account_name
-def service_account_command(args, settings, session_factory):
-    # type: (Namespace, CtlSettings, SessionFactory) -> None
-    session = session_factory.create_session()
-    actor_user = User.get(session, name=args.actor_name)
-    if not actor_user:
-        logging.fatal('Actor user "{}" is not a valid Grouper user'.format(args.actor_name))
-        return
+class CreateServiceAccountCommand(CtlCommand, CreateServiceAccountUI):
+    """Command to create a service account."""
 
-    if args.subcommand == "create":
-        name = args.name
-        if ServiceAccount.get(session, name=name):
-            logging.info("{}: Already exists. Doing nothing.".format(name))
-            return
-        owner_group = Group.get(session, name=args.owner_group)
-        if not owner_group:
-            logging.fatal('Owner group "{}" does not exist.'.format(args.owner_group))
-            return
-        logging.info("{}: No such service account, creating...".format(name))
-        description = args.description
-        machine_set = args.machine_set
-        create_service_account(session, actor_user, name, description, machine_set, owner_group)
-        return
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument("name", help="Name for the service account")
+        parser.add_argument("owner", help="Name of the owner (must be a valid group)")
+        parser.add_argument("machine_set", help="Machine set for the service account")
+        parser.add_argument("description", help="Description for the service account")
+
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
+
+    def create_service_account_failed_already_exists(self, service):
+        # type: (str) -> None
+        logging.critical("service account %s already exists", service)
+        sys.exit(1)
+
+    def create_service_account_failed_invalid_name(self, service, message):
+        # type: (str, str) -> None
+        logging.critical("invalid service account name %s: %s", service, message)
+        sys.exit(1)
+
+    def create_service_account_failed_invalid_owner(self, service, owner):
+        # type: (str, str) -> None
+        logging.critical("owning group %s does not exist", owner)
+        sys.exit(1)
+
+    def create_service_account_failed_invalid_machine_set(self, service, machine_set, message):
+        # type: (str, str, str) -> None
+        logging.critical("machine set %s is not valid: %s", machine_set, message)
+        sys.exit(1)
+
+    def create_service_account_failed_permission_denied(self, service, owner):
+        # type: (str, str) -> None
+        logging.critical(
+            "permission denied creating service account %s owned by %s", service, owner
+        )
+        sys.exit(1)
+
+    def created_service_account(self, service, owner):
+        # type: (str, str) -> None
+        logging.info("created new service account %s owned by %s", service, owner)
+
+    def run(self, args):
+        # type: (Namespace) -> None
+        usecase = self.usecase_factory.create_create_service_account_usecase(args.actor_name, self)
+        usecase.create_service_account(args.name, args.owner, args.machine_set, args.description)
 
 
-def add_parser(subparsers):
-    service_account_parser = subparsers.add_parser("service_account", help="Edit service account")
-    service_account_parser.set_defaults(func=service_account_command)
-    service_account_subparser = service_account_parser.add_subparsers(dest="subcommand")
+class ServiceAccountCommand(CtlCommand):
+    """Commands to modify service accounts."""
 
-    required_options_group = service_account_parser.add_argument_group("required named arguments")
-    required_options_group.add_argument(
-        "-a",
-        "--actor",
-        required=True,
-        dest="actor_name",
-        help=(
-            "Name of the entity performing this action. "
-            "Must be a valid Grouper human or service "
-            "account."
-        ),
-    )
+    @staticmethod
+    def add_arguments(parser):
+        # type: (ArgumentParser) -> None
+        parser.add_argument(
+            "-a",
+            "--actor",
+            required=True,
+            dest="actor_name",
+            help=(
+                "Name of the entity performing this action."
+                " Must be a valid Grouper human or service account."
+            ),
+        )
 
-    service_account_create_parser = service_account_subparser.add_parser(
-        "create", help="Create a new service account"
-    )
-    service_account_create_parser.add_argument("name", help=("Name for the service account"))
-    service_account_create_parser.add_argument(
-        "owner_group", help=("Name of the owner group. Must be a valid " "Grouper group")
-    )
-    service_account_create_parser.add_argument(
-        "machine_set", help=("The machine set for the service account")
-    )
-    service_account_create_parser.add_argument(
-        "description", help=("Description for the service account")
-    )
+        subparser = parser.add_subparsers(dest="subcommand")
+        parser = subparser.add_parser("create", help="Create a new service account")
+        CreateServiceAccountCommand.add_arguments(parser)
+
+    def __init__(self, usecase_factory):
+        # type: (UseCaseFactory) -> None
+        self.usecase_factory = usecase_factory
+
+    def run(self, args):
+        # type: (Namespace) -> None
+        if args.subcommand == "create":
+            subcommand = CreateServiceAccountCommand(self.usecase_factory)
+            subcommand.run(args)
+        else:
+            raise ValueError("unknown subcommand {}".format(args.subcommand))

--- a/grouper/ctl/util.py
+++ b/grouper/ctl/util.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from functools import wraps
 from typing import TYPE_CHECKING
 
-from grouper.constants import NAME_VALIDATION, SERVICE_ACCOUNT_VALIDATION, USERNAME_VALIDATION
+from grouper.constants import NAME_VALIDATION, USERNAME_VALIDATION
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -46,20 +46,6 @@ def ensure_valid_groupname(f):
         # type: (Namespace, CtlSettings, SessionFactory) -> None
         if not re.match("^{}$".format(NAME_VALIDATION), args.groupname):
             logging.error("Invalid group name {}".format(args.groupname))
-            return
-
-        return f(args, settings, session_factory)
-
-    return wrapper
-
-
-def ensure_valid_service_account_name(f):
-    # type: (CommandFunction) -> CommandFunction
-    @wraps(f)
-    def wrapper(args, settings, session_factory):
-        # type: (Namespace, CtlSettings, SessionFactory) -> None
-        if not re.match("^{}$".format(SERVICE_ACCOUNT_VALIDATION), args.name):
-            logging.error('Invalid service account name "{}"'.format(args.name))
             return
 
         return f(args, settings, session_factory)

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,3 +1,15 @@
+class InvalidServiceAccountNameException(Exception):
+    """Not a valid name for a service account."""
+
+    pass
+
+
+class InvalildServiceAccountMachineSetException(Exception):
+    """Not a valid machine set for a service account."""
+
+    pass
+
+
 class ServiceAccountNotFoundException(Exception):
     """Attempt to operate on a service account not found in the storage layer."""
 

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,15 +1,3 @@
-class InvalidServiceAccountNameException(Exception):
-    """Not a valid name for a service account."""
-
-    pass
-
-
-class InvalildServiceAccountMachineSetException(Exception):
-    """Not a valid machine set for a service account."""
-
-    pass
-
-
 class ServiceAccountNotFoundException(Exception):
     """Attempt to operate on a service account not found in the storage layer."""
 

--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -32,8 +32,8 @@ def create_graph_usecase_factory(
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = GraphRepositoryFactory(settings, plugins, session_factory, graph)
-    service_factory = ServiceFactory(repository_factory)
-    return UseCaseFactory(settings, service_factory)
+    service_factory = ServiceFactory(settings, repository_factory)
+    return UseCaseFactory(settings, plugins, service_factory)
 
 
 def create_sql_usecase_factory(settings, plugins, session_factory=None):
@@ -46,5 +46,5 @@ def create_sql_usecase_factory(settings, plugins, session_factory=None):
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = SQLRepositoryFactory(settings, plugins, session_factory)
-    service_factory = ServiceFactory(repository_factory)
-    return UseCaseFactory(settings, service_factory)
+    service_factory = ServiceFactory(settings, repository_factory)
+    return UseCaseFactory(settings, plugins, service_factory)

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -88,6 +88,11 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
+    def permission_grants_for_service_account(self, name):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        pass
+
+    @abstractmethod
     def permission_grants_for_user(self, user):
         # type: (str) -> List[GroupPermissionGrant]
         pass
@@ -100,6 +105,11 @@ class PermissionGrantRepository(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def revoke_all_service_account_grants(self, permission):
         # type: (str) -> List[ServiceAccountPermissionGrant]
+        pass
+
+    @abstractmethod
+    def service_account_has_permission(self, service, permission):
+        # type: (str, str) -> bool
         pass
 
     @abstractmethod
@@ -119,6 +129,11 @@ class UserRepository(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def disable_user(self, name):
         # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def user_exists(self, name):
+        # type: (str) -> bool
         pass
 
     @abstractmethod

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -26,6 +26,10 @@ class GraphUserRepository(UserRepository):
         # type: (str) -> None
         self.repository.disable_user(user)
 
+    def user_exists(self, name):
+        # type: (str) -> bool
+        return self.repository.user_exists(name)
+
     def user_is_enabled(self, name):
         # type: (str) -> bool
         """Return whether a user is enabled.
@@ -57,6 +61,10 @@ class SQLUserRepository(UserRepository):
         if not user:
             raise UserNotFoundException(name)
         user.enabled = False
+
+    def user_exists(self, name):
+        # type: (str) -> bool
+        return SQLUser.get(self.session, name=name) is not None
 
     def user_is_enabled(self, name):
         # type: (str) -> bool

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -35,6 +35,17 @@ class AuditLogService(AuditLogInterface):
         # type: (str, int) -> List[AuditLogEntry]
         return self.audit_log_repository.entries_affecting_user(user, limit)
 
+    def log_create_service_account(self, service, owner, authorization, date=None):
+        # type: (str, str, Authorization, Optional[datetime]) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="create_service_account",
+            description="Created new service account",
+            on_group=owner,
+            on_user=service,
+            date=date,
+        )
+
     def log_create_service_account_from_disabled_user(self, user, authorization, date=None):
         # type: (str, Authorization, Optional[datetime]) -> None
         self.audit_log_repository.log(
@@ -50,7 +61,7 @@ class AuditLogService(AuditLogInterface):
         self.audit_log_repository.log(
             authorization=authorization,
             action="create_permission",
-            description="Created permission.",
+            description="Created permission",
             on_permission=permission,
             date=date,
         )

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -11,6 +11,7 @@ from grouper.services.user import UserService
 
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import RepositoryFactory
+    from grouper.settings import Settings
     from grouper.usecases.interfaces import (
         AuditLogInterface,
         GroupInterface,
@@ -26,8 +27,9 @@ if TYPE_CHECKING:
 class ServiceFactory(object):
     """Construct backend services."""
 
-    def __init__(self, repository_factory):
-        # type: (RepositoryFactory) -> None
+    def __init__(self, settings, repository_factory):
+        # type: (Settings, RepositoryFactory) -> None
+        self.settings = settings
         self.repository_factory = repository_factory
 
     def create_audit_log_service(self):
@@ -66,11 +68,14 @@ class ServiceFactory(object):
         audit_log_service = self.create_audit_log_service()
         user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
+        permission_grant_repository = self.repository_factory.create_permission_grant_repository()
         group_edge_repository = self.repository_factory.create_group_edge_repository()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return ServiceAccountService(
+            self.settings,
             user_repository,
             service_account_repository,
+            permission_grant_repository,
             group_edge_repository,
             group_request_repository,
             audit_log_service,

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -1,5 +1,7 @@
+import re
 from typing import TYPE_CHECKING
 
+from grouper.constants import MAX_NAME_LENGTH, SERVICE_ACCOUNT_VALIDATION, USER_ADMIN
 from grouper.entities.user import (
     UserHasPendingRequestsException,
     UserIsEnabledException,
@@ -8,12 +10,16 @@ from grouper.entities.user import (
 from grouper.usecases.interfaces import ServiceAccountInterface
 
 if TYPE_CHECKING:
+    from grouper.entities.permission_grant import ServiceAccountPermissionGrant
     from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.service_account import ServiceAccountRepository
     from grouper.repositories.user import UserRepository
+    from grouper.settings import Settings
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.interfaces import AuditLogInterface
+    from typing import List, Optional, Tuple
 
 
 class ServiceAccountService(ServiceAccountInterface):
@@ -21,18 +27,29 @@ class ServiceAccountService(ServiceAccountInterface):
 
     def __init__(
         self,
+        settings,  # type: Settings
         user_repository,  # type: UserRepository
         service_account_repository,  # type: ServiceAccountRepository
+        permission_grant_repository,  # type: PermissionGrantRepository
         group_edge_repository,  # type: GroupEdgeRepository
         group_request_repository,  # type: GroupRequestRepository
         audit_log_service,  # type: AuditLogInterface
     ):
         # type: (...) -> None
+        self.settings = settings
         self.user_repository = user_repository
         self.service_account_repository = service_account_repository
+        self.permission_grant_repository = permission_grant_repository
         self.group_edge_repository = group_edge_repository
         self.group_request_repository = group_request_repository
         self.audit_log = audit_log_service
+
+    def create_service_account(self, service, owner, machine_set, description, authorization):
+        # type: (str, str, str, str, Authorization) -> None
+        self.service_account_repository.create_service_account(
+            service, owner, machine_set, description
+        )
+        self.audit_log.log_create_service_account(service, owner, authorization)
 
     def create_service_account_from_disabled_user(self, user, authorization):
         # type: (str, Authorization) -> None
@@ -57,3 +74,41 @@ class ServiceAccountService(ServiceAccountInterface):
         self.service_account_repository.enable_service_account(user)
 
         self.audit_log.log_enable_service_account(user, owner, authorization)
+
+    def is_valid_service_account_name(self, name):
+        # type: (str) -> Tuple[bool, Optional[str]]
+        """Check if the given name is valid for use as a service account.
+
+        Returns:
+            Tuple whose first element is True or False indicating whether it is valid, and whose
+            second element is None if valid and an error message if not.
+        """
+        if len(name) > MAX_NAME_LENGTH:
+            error = "{} is longer than {} characters".format(name, MAX_NAME_LENGTH)
+            return (False, error)
+
+        if not re.match("^{}$".format(SERVICE_ACCOUNT_VALIDATION), name):
+            error = "{} is not a valid service account name (does not match {})".format(
+                name, SERVICE_ACCOUNT_VALIDATION
+            )
+            return (False, error)
+
+        if name.split("@")[-1] != self.settings.service_account_email_domain:
+            error = "All service accounts must end in @{}".format(
+                self.settings.service_account_email_domain
+            )
+            return (False, error)
+
+        return (True, None)
+
+    def permission_grants_for_service_account(self, service):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        return self.permission_grant_repository.permission_grants_for_service_account(service)
+
+    def service_account_exists(self, service):
+        # type: (str) -> bool
+        return self.service_account_repository.service_account_exists(service)
+
+    def service_account_is_user_admin(self, service):
+        # type: (str) -> bool
+        return self.permission_grant_repository.service_account_has_permission(service, USER_ADMIN)

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -55,6 +55,10 @@ class UserService(UserInterface):
         # type: (str) -> List[GroupPermissionGrant]
         return self.permission_grant_repository.permission_grants_for_user(user)
 
+    def user_exists(self, user):
+        # type: (str) -> bool
+        return self.user_repository.user_exists(user)
+
     def user_is_audit_manager(self, user):
         # type: (str) -> bool
         return self.permission_grant_repository.user_has_permission(user, AUDIT_MANAGER)

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -1,0 +1,124 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from six import with_metaclass
+
+from grouper.entities.group import GroupNotFoundException
+from grouper.plugin.exceptions import PluginRejectedMachineSet
+from grouper.usecases.authorization import Authorization
+
+if TYPE_CHECKING:
+    from grouper.plugin.proxy import PluginProxy
+    from grouper.settings import Settings
+    from grouper.usecases.interfaces import (
+        ServiceAccountInterface,
+        TransactionInterface,
+        UserInterface,
+    )
+
+
+class CreateServiceAccountUI(with_metaclass(ABCMeta, object)):
+    """Abstract base class for UI for CreateServiceAccount."""
+
+    @abstractmethod
+    def create_service_account_failed_already_exists(self, service):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def create_service_account_failed_invalid_name(self, service, message):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def create_service_account_failed_invalid_owner(self, service, owner):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def create_service_account_failed_invalid_machine_set(self, service, machine_set, message):
+        # type: (str, str, str) -> None
+        pass
+
+    @abstractmethod
+    def create_service_account_failed_permission_denied(self, service, owner):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def created_service_account(self, service, owner):
+        # type: (str, str) -> None
+        pass
+
+
+class CreateServiceAccount(object):
+    """Create a new service account."""
+
+    def __init__(
+        self,
+        actor,  # type: str
+        ui,  # type: CreateServiceAccountUI
+        settings,  # type: Settings
+        plugins,  # type: PluginProxy
+        service_account_service,  # type: ServiceAccountInterface
+        user_service,  # type: UserInterface
+        transaction_service,  # type: TransactionInterface
+    ):
+        # type: (...) -> None
+        self.actor = actor
+        self.ui = ui
+        self.settings = settings
+        self.plugins = plugins
+        self.service_account_service = service_account_service
+        self.user_service = user_service
+        self.transaction_service = transaction_service
+
+    def create_service_account(self, service, owner, machine_set, description):
+        # type: (str, str, str, str) -> None
+        if "@" not in service:
+            service += "@" + self.settings.service_account_email_domain
+
+        valid, error = self.service_account_service.is_valid_service_account_name(service)
+        if not valid:
+            assert error
+            self.ui.create_service_account_failed_invalid_name(service, error)
+            return
+
+        # Creation is permitted if the actor is a user admin or if the actor is a user (not a
+        # service account) and is a member of the owning group.
+        if self.service_account_service.service_account_exists(self.actor):
+            allowed = self.service_account_service.service_account_is_user_admin(self.actor)
+        else:
+            allowed = owner in self.user_service.groups_of_user(self.actor)
+            if not allowed:
+                allowed = self.user_service.user_is_user_admin(self.actor)
+        if not allowed:
+            self.ui.create_service_account_failed_permission_denied(service, owner)
+            return
+
+        if self.user_service.user_exists(service):
+            self.ui.create_service_account_failed_already_exists(service)
+            return
+        if self.service_account_service.service_account_exists(service):
+            self.ui.create_service_account_failed_already_exists(service)
+            return
+
+        if machine_set:
+            try:
+                self.plugins.check_machine_set(service, machine_set)
+            except PluginRejectedMachineSet as e:
+                self.ui.create_service_account_failed_invalid_machine_set(
+                    service, machine_set, str(e)
+                )
+                return
+
+        authorization = Authorization(self.actor)
+        with self.transaction_service.transaction():
+            try:
+                self.service_account_service.create_service_account(
+                    service, owner, machine_set, description, authorization
+                )
+            except GroupNotFoundException:
+                self.ui.create_service_account_failed_invalid_owner(service, owner)
+            else:
+                self.ui.created_service_account(service, owner)

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
+from grouper.usecases.create_service_account import CreateServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
 from grouper.usecases.dump_schema import DumpSchema
 from grouper.usecases.initialize_schema import InitializeSchema
@@ -11,7 +12,9 @@ from grouper.usecases.view_permission import ViewPermission
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from grouper.plugin.proxy import PluginProxy
     from grouper.settings import Settings
+    from grouper.usecases.create_service_account import CreateServiceAccountUI
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.dump_schema import DumpSchemaUI
@@ -24,10 +27,26 @@ if TYPE_CHECKING:
 class UseCaseFactory(object):
     """Create use cases with dependency injection."""
 
-    def __init__(self, settings, service_factory):
-        # type: (Settings, Session) -> None
+    def __init__(self, settings, plugins, service_factory):
+        # type: (Settings, PluginProxy, Session) -> None
         self.settings = settings
+        self.plugins = plugins
         self.service_factory = service_factory
+
+    def create_create_service_account_usecase(self, actor, ui):
+        # type: (str, CreateServiceAccountUI) -> CreateServiceAccount
+        service_account_service = self.service_factory.create_service_account_service()
+        user_service = self.service_factory.create_user_service()
+        transaction_service = self.service_factory.create_transaction_service()
+        return CreateServiceAccount(
+            actor,
+            ui,
+            self.settings,
+            self.plugins,
+            service_account_service,
+            user_service,
+            transaction_service,
+        )
 
     def create_convert_user_to_service_account_usecase(self, actor, ui):
         # type: (str, ConvertUserToServiceAccountUI) -> ConvertUserToServiceAccount

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from grouper.entities.user import User
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
-    from typing import ContextManager, Dict, List, Optional
+    from typing import ContextManager, Dict, List, Optional, Tuple
 
 
 class AuditLogInterface(with_metaclass(ABCMeta, object)):
@@ -55,6 +55,11 @@ class AuditLogInterface(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def entries_affecting_user(self, user, limit):
         # type: (str, int) -> List[AuditLogEntry]
+        pass
+
+    @abstractmethod
+    def log_create_service_account(self, service, owner, authorization, date=None):
+        # type: (str, str, Authorization, Optional[datetime]) -> None
         pass
 
     @abstractmethod
@@ -222,6 +227,11 @@ class ServiceAccountInterface(with_metaclass(ABCMeta, object)):
     """Abstract base class for service account operations and queries."""
 
     @abstractmethod
+    def create_service_account(self, service, owner, machine_set, description, authorization):
+        # type: (str, str, str, str, Authorization) -> None
+        pass
+
+    @abstractmethod
     def create_service_account_from_disabled_user(self, user, authorization):
         # type: (str, Authorization) -> None
         pass
@@ -229,6 +239,26 @@ class ServiceAccountInterface(with_metaclass(ABCMeta, object)):
     @abstractmethod
     def enable_service_account(self, user, owner, authorization):
         # type: (str, str, Authorization) -> None
+        pass
+
+    @abstractmethod
+    def is_valid_service_account_name(self, name):
+        # type: (str) -> Tuple[bool, Optional[str]]
+        pass
+
+    @abstractmethod
+    def permission_grants_for_service_account(self, user):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        pass
+
+    @abstractmethod
+    def service_account_exists(self, service):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def service_account_is_user_admin(self, user):
+        # type: (str) -> bool
         pass
 
 
@@ -270,6 +300,11 @@ class UserInterface(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def user_can_create_permissions(self, user):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def user_exists(self, user):
         # type: (str) -> bool
         pass
 

--- a/itests/api/service_accounts_test.py
+++ b/itests/api/service_accounts_test.py
@@ -59,7 +59,7 @@ def test_get_role_user(api_client):  # noqa: F811
 def test_includes_disabled_service_accounts(tmpdir, setup):
     # type: (LocalPath, SetupTest) -> None
     with setup.transaction():
-        setup.create_service_account("service@a.co", "some-group", "an account", "some machines")
+        setup.create_service_account("service@a.co", "some-group", "some machines", "an account")
     with setup.transaction():
         setup.disable_service_account("service@a.co")
 

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -293,7 +293,7 @@ def test_graph_update_stats(setup):
     # type: (SetupTest) -> None
     """Test that update timings are logged by a graph update."""
     mock_stats = MockStats()
-    setup.plugin_proxy.add_plugin(mock_stats)
+    setup.plugins.add_plugin(mock_stats)
 
     # Create a user and a group, which will trigger a graph update.
     with setup.transaction():

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -32,7 +32,6 @@ from grouper.graph import GroupGraph
 from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.group import Group
 from grouper.models.group_edge import GroupEdge
-from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.permission import Permission
 from grouper.models.permission_map import PermissionMap
 from grouper.models.public_key import PublicKey
@@ -72,7 +71,7 @@ class SetupTest(object):
         settings: Settings object for tests (only the database is configured)
         graph: Underlying graph (not refreshed from the database automatically!)
         session: The underlying database session
-        plugin_proxy: The plugin proxy used for the tests
+        plugins: The plugin proxy used for the tests
         repository_factory: Factory for repository objects
         sql_repository_factory: Factory that returns only SQL repository objects (no graph)
         service_factory: Factory for service objects
@@ -83,25 +82,25 @@ class SetupTest(object):
         # type: (LocalPath) -> None
         self.settings = Settings()
         self.settings.database = db_url(tmpdir)
-        self.plugin_proxy = PluginProxy([])
+        self.plugins = PluginProxy([])
 
         # Reinitialize the global plugin proxy with an empty set of plugins in case a previous test
         # initialized plugins.  This can go away once a plugin proxy is injected into everything
         # that needs it instead of maintained as a global.
-        set_global_plugin_proxy(self.plugin_proxy)
+        set_global_plugin_proxy(self.plugins)
 
         self.initialize_database()
         self.session = SessionFactory(self.settings).create_session()
         self.graph = GroupGraph()
         session_factory = SingletonSessionFactory(self.session)
         self.repository_factory = GraphRepositoryFactory(
-            self.settings, self.plugin_proxy, session_factory, self.graph
+            self.settings, self.plugins, session_factory, self.graph
         )
         self.sql_repository_factory = SQLRepositoryFactory(
-            self.settings, self.plugin_proxy, session_factory
+            self.settings, self.plugins, session_factory
         )
-        self.service_factory = ServiceFactory(self.repository_factory)
-        self.usecase_factory = UseCaseFactory(self.settings, self.service_factory)
+        self.service_factory = ServiceFactory(self.settings, self.repository_factory)
+        self.usecase_factory = UseCaseFactory(self.settings, self.plugins, self.service_factory)
         self._transaction_service = self.service_factory.create_transaction_service()
 
     def initialize_database(self):
@@ -223,27 +222,13 @@ class SetupTest(object):
             requester=user_obj, user_or_group=user_obj, reason="", status="pending", role=role
         )
 
-    def create_service_account(self, service_account, owner, description="", machine_set=""):
+    def create_service_account(self, service_account, owner, machine_set="", description=""):
         # type: (str, str, str, str) -> None
         self.create_group(owner)
-        group_obj = Group.get(self.session, name=owner)
-        assert group_obj
-
-        if User.get(self.session, name=service_account):
-            return
-        user = User(username=service_account)
-        user.add(self.session)
-        service_account_obj = ServiceAccount(
-            user_id=user.id, description=description, machine_set=machine_set
+        service_account_repository = self.repository_factory.create_service_account_repository()
+        service_account_repository.create_service_account(
+            service_account, owner, machine_set, description
         )
-        service_account_obj.add(self.session)
-        user.is_service_account = True
-
-        self.session.flush()
-        owner_map = GroupServiceAccount(
-            group_id=group_obj.id, service_account_id=service_account_obj.id
-        )
-        owner_map.add(self.session)
 
     def grant_permission_to_service_account(self, permission, argument, service_account):
         # type: (str, str, str) -> None

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -1,0 +1,178 @@
+from typing import TYPE_CHECKING
+
+from mock import call, MagicMock
+
+from grouper.constants import MAX_NAME_LENGTH, SERVICE_ACCOUNT_VALIDATION, USER_ADMIN
+from grouper.models.group import Group
+from grouper.models.group_service_accounts import GroupServiceAccount
+from grouper.models.service_account import ServiceAccount
+from grouper.models.user import User
+from grouper.plugin.base import BasePlugin
+from grouper.plugin.exceptions import PluginRejectedMachineSet
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_success(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account(
+        "service@svc.localhost", "some-group", "machine-set", "description"
+    )
+    assert mock_ui.mock_calls == [
+        call.created_service_account("service@svc.localhost", "some-group")
+    ]
+
+    # Check the User and ServiceAccount that were created.
+    user = User.get(setup.session, name="service@svc.localhost")
+    assert user is not None
+    assert user.is_service_account
+    assert user.enabled
+    service = ServiceAccount.get(setup.session, name="service@svc.localhost")
+    assert service is not None
+    assert service.machine_set == "machine-set"
+    assert service.description == "description"
+
+    # Check that the ServiceAccount is owned by the correct Group.
+    group = Group.get(setup.session, name="some-group")
+    assert group is not None
+    linkage = GroupServiceAccount.get(setup.session, service_account_id=service.id)
+    assert linkage is not None
+    assert linkage.group_id == group.id
+
+
+def test_add_domain(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    mock_ui = MagicMock()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service", "some-group", "machine-set", "description")
+
+    service = ServiceAccount.get(setup.session, name="service@svc.localhost")
+    assert service is not None
+    assert service.machine_set == "machine-set"
+    assert service.description == "description"
+    assert ServiceAccount.get(setup.session, name="service") is None
+
+
+def test_admin_can_create(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_group("some-group")
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@svc.localhost", "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.created_service_account("service@svc.localhost", "some-group")
+    ]
+
+    service = ServiceAccount.get(setup.session, name="service@svc.localhost")
+    assert service is not None
+    assert service.machine_set == ""
+    assert service.description == ""
+
+
+def test_permission_denied(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_group("some-group")
+        setup.create_user("gary@a.co")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@svc.localhost", "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_permission_denied("service@svc.localhost", "some-group")
+    ]
+
+
+def test_invalid_name(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@foo@bar", "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_invalid_name(
+            "service@foo@bar",
+            "service@foo@bar is not a valid service account name (does not match {})".format(
+                SERVICE_ACCOUNT_VALIDATION
+            ),
+        )
+    ]
+
+    # Test a service account name that's one character longer than MAX_NAME_LENGTH minus the length
+    # of the default email domain minus 1 (for the @).
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    long_name = "x" * (MAX_NAME_LENGTH - len(setup.settings.service_account_email_domain))
+    long_name += "@" + setup.settings.service_account_email_domain
+    usecase.create_service_account(long_name, "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_invalid_name(
+            long_name, "{} is longer than {} characters".format(long_name, MAX_NAME_LENGTH)
+        )
+    ]
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@a.co", "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_invalid_name(
+            "service@a.co",
+            "All service accounts must end in @{}".format(
+                setup.settings.service_account_email_domain
+            ),
+        )
+    ]
+
+
+def test_invalid_owner(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@svc.localhost", "some-group", "", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_invalid_owner("service@svc.localhost", "some-group")
+    ]
+
+
+class MachineSetTestPlugin(BasePlugin):
+    def check_machine_set(self, name, machine_set):
+        # type: (str, str) -> None
+        assert name == "service@svc.localhost"
+        raise PluginRejectedMachineSet("some error message")
+
+
+def test_invalid_machine_set(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    setup.plugins.add_plugin(MachineSetTestPlugin())
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account("service@svc.localhost", "some-group", "machine-set", "")
+    assert mock_ui.mock_calls == [
+        call.create_service_account_failed_invalid_machine_set(
+            "service@svc.localhost", "machine-set", "some error message"
+        )
+    ]


### PR DESCRIPTION
Implement creating a service account as a use case and add tests
for the success case and the various error conditions.

Convert the grouper-ctl service_account create command to the new
usecase and the new grouper-ctl command architecture, and update
its tests accordingly.