### PR TITLE
Allow overriding the database source command

### DIFF
--- a/grouper/api/main.py
+++ b/grouper/api/main.py
@@ -52,6 +52,8 @@ def start_server(args, settings, plugins):
     logging.debug("configure database session")
     if args.database_url:
         settings.database = args.database_url
+    elif args.database_source:
+        settings.database_source = args.database_source
     Session.configure(bind=get_db_engine(settings.database))
 
     with closing(Session()) as session:

--- a/grouper/background/main.py
+++ b/grouper/background/main.py
@@ -27,6 +27,15 @@ def build_arg_parser():
         "-c", "--config", default=default_settings_path(), help="Path to config file."
     )
     parser.add_argument(
+        "-d", "--database-url", type=str, default=None, help="Override database URL in config."
+    )
+    parser.add_argument(
+        "--database-source",
+        type=str,
+        default=None,
+        help="Override command to run to get database URL in config.",
+    )
+    parser.add_argument(
         "-v", "--verbose", action="count", default=0, help="Increase logging verbosity."
     )
     parser.add_argument(
@@ -56,6 +65,10 @@ def start_processor(args, settings):
 
     # setup database
     logging.debug("configure database session")
+    if args.database_url:
+        settings.database = args.database_url
+    elif args.database_source:
+        settings.database_source = args.database_source
     Session.configure(bind=get_db_engine(settings.database))
 
     background = BackgroundProcessor(settings, plugins)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -34,6 +34,12 @@ def main(sys_argv=sys.argv, session=None):
         "-d", "--database-url", type=str, default=None, help="Override database URL in config."
     )
     parser.add_argument(
+        "--database-source",
+        type=str,
+        default=None,
+        help="Override command to run to get database URL in config.",
+    )
+    parser.add_argument(
         "-q", "--quiet", action="count", default=0, help="Decrease logging verbosity."
     )
     parser.add_argument(
@@ -62,6 +68,8 @@ def main(sys_argv=sys.argv, session=None):
     settings = CtlSettings.global_settings_from_config(args.config)
     if args.database_url:
         settings.database = args.database_url
+    elif args.database_source:
+        settings.database_source = args.database_source
 
     # Construct a session factory, which is passed into all the legacy commands that haven't been
     # converted to usecases yet.

--- a/grouper/fe/main.py
+++ b/grouper/fe/main.py
@@ -62,6 +62,8 @@ def start_server(args, settings, plugins):
     logging.debug("configure database session")
     if args.database_url:
         settings.database = args.database_url
+    elif args.database_source:
+        settings.database_source = args.database_source
     Session.configure(bind=get_db_engine(settings.database))
 
     application = create_fe_application(settings, args.deployment_name)

--- a/grouper/setup.py
+++ b/grouper/setup.py
@@ -41,6 +41,12 @@ def build_arg_parser(description):
         "-d", "--database-url", type=str, default=None, help="Override database URL in config."
     )
     parser.add_argument(
+        "--database-source",
+        type=str,
+        default=None,
+        help="Override command to run to get database URL in config.",
+    )
+    parser.add_argument(
         "--listen-stdin",
         action="store_true",
         help="Ignore address and port and expect connections on standard input",


### PR DESCRIPTION
We want to stop having every Grouper binary call the same piece of
code to get the database URL so that we can stage rollouts of changes
to the database URL handling as well.  However, given our internal
deployment mechanisms, this means that the path to the command to run
to get the database URL will be different for each component.  To
avoid needing four different config files (eight for stage support),
add a --database-source command-line option to override the
database_source setting in the config and specify a command to run.

grouper-background didn't previously support overriding the database
URL with a command-line flag, so add that.

This doesn't include tests because setting up a proper test of
something that runs an external program is irritatingly difficult,
and I'm bailing on that for now.