### PR TITLE
Add plugin support for checking service account names

### DIFF
--- a/grouper/initialization.py
+++ b/grouper/initialization.py
@@ -32,7 +32,7 @@ def create_graph_usecase_factory(
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = GraphRepositoryFactory(settings, plugins, session_factory, graph)
-    service_factory = ServiceFactory(settings, repository_factory)
+    service_factory = ServiceFactory(settings, plugins, repository_factory)
     return UseCaseFactory(settings, plugins, service_factory)
 
 
@@ -46,5 +46,5 @@ def create_sql_usecase_factory(settings, plugins, session_factory=None):
     if not session_factory:
         session_factory = SessionFactory(settings)
     repository_factory = SQLRepositoryFactory(settings, plugins, session_factory)
-    service_factory = ServiceFactory(settings, repository_factory)
+    service_factory = ServiceFactory(settings, plugins, repository_factory)
     return UseCaseFactory(settings, plugins, service_factory)

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -13,6 +13,15 @@ if TYPE_CHECKING:
 
 
 class BasePlugin(object):
+    def configure(self, service_name):
+        # type: (str) -> None
+        """Configure the plugin.
+
+        Called once the plugin is instantiated to identify the executable (grouper-api, grouper-fe,
+        or grouper-background).
+        """
+        pass
+
     def check_machine_set(self, name, machine_set):
         # type: (str, str) -> None
         """Check whether a service account machine set is valid.
@@ -24,14 +33,6 @@ class BasePlugin(object):
         Raises:
             PluginRejectedMachineSet to reject the change.  The exception message will be shown to
             the user.
-        """
-        pass
-
-    def configure(self, service_name):
-        # type: (str) -> None
-        """
-        Called once the plugin is instantiated to identify the executable
-        (grouper-api or grouper-fe).
         """
         pass
 
@@ -66,15 +67,12 @@ class BasePlugin(object):
 
     def get_ssl_context(self):
         # type: () -> SSLContext
-        """
-        Called to get the ssl.SSLContext for the application.
-        """
+        """Called to get the ssl.SSLContext for the application."""
         pass
 
     def log_auditlog_entry(self, entry):
         # type: (AuditLog) -> None
-        """
-        Called when an audit log entry is saved to the database.
+        """Called when an audit log entry is saved to the database.
 
         Args:
             entry: just-saved log object
@@ -103,24 +101,35 @@ class BasePlugin(object):
 
     def log_gauge(self, key, val):
         # type: (str, float) -> None
-        """ Log an instantaneous-value gauge stat that does not vary with
-        time. For e.g., number of CPUs or amount of RAM on a machine.
+        """Log a gauge stat.
+
+        Log an instantaneous-value gauge stat which measures the total of something.  For example,
+        number of CPUs or amount of RAM on a machine.
         """
         pass
 
     def log_rate(self, key, val, count=1):
         # type: (str, float, int) -> None
-        """ Log a time-varying rate stat, such as an execution time or a
-        method invocation.
-            @param key - the name of the stat.
-            @param val - increment to the value of the stat.
-            @param count - the number of samples that created the increment.
+        """Log an incremental rate stat.
+
+        Log a rate stat, which counts something over time.  For example, execution time or number
+        of invocations of a method.
+
+        Args:
+            key: The name of the stat
+            val: Amount to add to the stat (for example, additional ms spent executing a method, or
+                additional count of method invocations)
+            count: Number of samples that created the increment (default: 1)
         """
         pass
 
     def set_default_stats_tags(self, tags):
         # type: (Dict[str, str]) -> None
-        """Set default tags for stats"""
+        """Set default tags for stats logged via log_gauge or log_rate.
+
+        Args:
+            tags: Key/value pairs of tags to associate with the stats.
+        """
         pass
 
     def user_created(self, user, is_service_account=False):
@@ -141,8 +150,7 @@ class BasePlugin(object):
 
     def will_add_public_key(self, key):
         # type: (SSHKey) -> None
-        """
-        Called before adding a public key
+        """Called before adding a public key.
 
         Args:
             key: Parsed public key
@@ -154,8 +162,7 @@ class BasePlugin(object):
 
     def will_disable_user(self, session, user):
         # type: (Session, User) -> None
-        """
-        Called before disabling a user
+        """Called before disabling a user.
 
         Args:
             session: database session
@@ -168,8 +175,7 @@ class BasePlugin(object):
 
     def will_update_group_membership(self, session, group, member, **updates):
         # type: (Session, Group, Union[User, Group], **Any) -> None
-        """
-        Called before applying changes to a group membership
+        """Called before applying changes to a group membership.
 
         Args:
             session: database session

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -36,6 +36,20 @@ class BasePlugin(object):
         """
         pass
 
+    def check_service_account_name(self, name, owner):
+        # type: (str, str) -> None
+        """Check whether a service account name is allowed.
+
+        Args:
+            name: Name of a new service account being created (with domain)
+            owner: The name of the group that will own the new service account
+
+        Raises:
+            PluginRejectedServiceAccountName to reject the name.  The exception message will be
+            shown to the user.
+        """
+        pass
+
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> List[Tuple[str, str]]
         """Called when building the graph to get aliases of a mapped permission.

--- a/grouper/plugin/exceptions.py
+++ b/grouper/plugin/exceptions.py
@@ -20,5 +20,11 @@ class PluginRejectedMachineSet(PluginException):
     pass
 
 
+class PluginRejectedServiceAccountName(PluginException):
+    """A plugin rejected a name for a service account."""
+
+    pass
+
+
 class PluginRejectedPublicKey(PluginException):
     pass

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -35,15 +35,15 @@ class PluginProxy(object):
         # type: (BasePlugin) -> None
         self._plugins.append(plugin)
 
-    def check_machine_set(self, name, machine_set):
-        # type: (str, str) -> None
-        for plugin in self._plugins:
-            plugin.check_machine_set(name, machine_set)
-
     def configure(self, service_name):
         # type: (str) -> None
         for plugin in self._plugins:
             plugin.configure(service_name)
+
+    def check_machine_set(self, name, machine_set):
+        # type: (str, str) -> None
+        for plugin in self._plugins:
+            plugin.check_machine_set(name, machine_set)
 
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> Iterable[Tuple[str, str]]

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -45,6 +45,11 @@ class PluginProxy(object):
         for plugin in self._plugins:
             plugin.check_machine_set(name, machine_set)
 
+    def check_service_account_name(self, name, owner):
+        # type: (str, str) -> None
+        for plugin in self._plugins:
+            plugin.check_service_account_name(name, owner)
+
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> Iterable[Tuple[str, str]]
         for plugin in self._plugins:

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -10,6 +10,7 @@ from grouper.services.transaction import TransactionService
 from grouper.services.user import UserService
 
 if TYPE_CHECKING:
+    from grouper.plugin import PluginProxy
     from grouper.repositories.interfaces import RepositoryFactory
     from grouper.settings import Settings
     from grouper.usecases.interfaces import (
@@ -27,9 +28,10 @@ if TYPE_CHECKING:
 class ServiceFactory(object):
     """Construct backend services."""
 
-    def __init__(self, settings, repository_factory):
-        # type: (Settings, RepositoryFactory) -> None
+    def __init__(self, settings, plugins, repository_factory):
+        # type: (Settings, PluginProxy, RepositoryFactory) -> None
         self.settings = settings
+        self.plugins = plugins
         self.repository_factory = repository_factory
 
     def create_audit_log_service(self):
@@ -73,6 +75,7 @@ class ServiceFactory(object):
         group_request_repository = self.repository_factory.create_group_request_repository()
         return ServiceAccountService(
             self.settings,
+            self.plugins,
             user_repository,
             service_account_repository,
             permission_grant_repository,

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -94,7 +94,7 @@ class CreateServiceAccount(object):
         if "@" not in service:
             service += "@" + self.settings.service_account_email_domain
 
-        valid, error = self.service_account_service.is_valid_service_account_name(service)
+        valid, error = self.service_account_service.is_valid_service_account_name(service, owner)
         if not valid:
             assert error
             self.ui.create_service_account_failed_invalid_name(service, owner, error)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -242,8 +242,8 @@ class ServiceAccountInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def is_valid_service_account_name(self, name):
-        # type: (str) -> Tuple[bool, Optional[str]]
+    def is_valid_service_account_name(self, name, owner):
+        # type: (str, str) -> Tuple[bool, Optional[str]]
         pass
 
     @abstractmethod

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -99,7 +99,7 @@ class SetupTest(object):
         self.sql_repository_factory = SQLRepositoryFactory(
             self.settings, self.plugins, session_factory
         )
-        self.service_factory = ServiceFactory(self.settings, self.repository_factory)
+        self.service_factory = ServiceFactory(self.settings, self.plugins, self.repository_factory)
         self.usecase_factory = UseCaseFactory(self.settings, self.plugins, self.service_factory)
         self._transaction_service = self.service_factory.create_transaction_service()
 


### PR DESCRIPTION
New plugin callback to provide an opportunity to reject service
account names.  Pass the prospective owner into the plugin in case
the plugin wants to enforce any owner-based naming scheme, which
requires plumbing the owner through in a few other places.

Clean up some use of mocks in the usecase test.

Update comments in BasePlugin to use a standard comment style,
and move configure to the top of the method list since it's more of an
initialization call than a part of the functionality.