### PR TITLE
Don't pass owner to service account naming plugins

### DIFF
--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -36,13 +36,12 @@ class BasePlugin(object):
         """
         pass
 
-    def check_service_account_name(self, name, owner):
-        # type: (str, str) -> None
+    def check_service_account_name(self, name):
+        # type: (str) -> None
         """Check whether a service account name is allowed.
 
         Args:
             name: Name of a new service account being created (with domain)
-            owner: The name of the group that will own the new service account
 
         Raises:
             PluginRejectedServiceAccountName to reject the name.  The exception message will be

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -45,10 +45,10 @@ class PluginProxy(object):
         for plugin in self._plugins:
             plugin.check_machine_set(name, machine_set)
 
-    def check_service_account_name(self, name, owner):
-        # type: (str, str) -> None
+    def check_service_account_name(self, name):
+        # type: (str) -> None
         for plugin in self._plugins:
-            plugin.check_service_account_name(name, owner)
+            plugin.check_service_account_name(name)
 
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> Iterable[Tuple[str, str]]

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -79,8 +79,8 @@ class ServiceAccountService(ServiceAccountInterface):
 
         self.audit_log.log_enable_service_account(user, owner, authorization)
 
-    def is_valid_service_account_name(self, name, owner):
-        # type: (str, str) -> Tuple[bool, Optional[str]]
+    def is_valid_service_account_name(self, name):
+        # type: (str) -> Tuple[bool, Optional[str]]
         """Check if the given name is valid for use as a service account.
 
         Returns:
@@ -104,7 +104,7 @@ class ServiceAccountService(ServiceAccountInterface):
             return (False, error)
 
         try:
-            self.plugins.check_service_account_name(name, owner)
+            self.plugins.check_service_account_name(name)
         except PluginRejectedServiceAccountName as e:
             return (False, str(e))
 

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -94,7 +94,7 @@ class CreateServiceAccount(object):
         if "@" not in service:
             service += "@" + self.settings.service_account_email_domain
 
-        valid, error = self.service_account_service.is_valid_service_account_name(service, owner)
+        valid, error = self.service_account_service.is_valid_service_account_name(service)
         if not valid:
             assert error
             self.ui.create_service_account_failed_invalid_name(service, owner, error)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -242,8 +242,8 @@ class ServiceAccountInterface(with_metaclass(ABCMeta, object)):
         pass
 
     @abstractmethod
-    def is_valid_service_account_name(self, name, owner):
-        # type: (str, str) -> Tuple[bool, Optional[str]]
+    def is_valid_service_account_name(self, name):
+        # type: (str) -> Tuple[bool, Optional[str]]
         pass
 
     @abstractmethod

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -214,10 +214,10 @@ def test_invalid_machine_set(setup):
 
 
 class ServiceAccountNameTestPlugin(BasePlugin):
-    def check_service_account_name(self, name, owner):
-        # type: (str, str) -> None
+    def check_service_account_name(self, name):
+        # type: (str) -> None
         if "_" in name:
-            raise PluginRejectedServiceAccountName("{} owned by {}".format(name, owner))
+            raise PluginRejectedServiceAccountName(name)
 
 
 def test_name_rejected_by_plugin(setup):
@@ -232,7 +232,7 @@ def test_name_rejected_by_plugin(setup):
     usecase.create_service_account("ser_vice", "some-group", "", "")
     assert mock_ui.mock_calls == [
         call.create_service_account_failed_invalid_name(
-            "ser_vice@svc.localhost", "some-group", "ser_vice@svc.localhost owned by some-group"
+            "ser_vice@svc.localhost", "some-group", "ser_vice@svc.localhost"
         )
     ]
 


### PR DESCRIPTION
This implies a guarantee that we don't actually implement, such as
revalidating service account names when service accounts are
deactivated and then reactivated with a different owner.