### PR TITLE
Disable group join button on click

### DIFF
--- a/grouper/fe/static/css/grouper.css
+++ b/grouper/fe/static/css/grouper.css
@@ -9,6 +9,10 @@ body {
     margin-bottom: 50px;
 }
 
+.waiting {
+    cursor: progress;
+}
+
 .footer {
   position: absolute;
   bottom: 0;

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -258,4 +258,12 @@ $(function () {
         $(".join-group-form .clickthru-checkbox").prop("checked", true);
         $(".join-group-form").submit();
     });
+
+    // The form with id submitOnce disables itself after being clicked and
+    // switches the cursor to the progress cursor.
+    $('#submitOnce').one('submit', function() {
+        $('body').addClass('waiting');
+        $(this).addClass('waiting');
+        $(this).find(':submit').prop('disabled', true);
+    });
 });

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -27,7 +27,7 @@
                     group will be regularly reviewed according to the production access policy.
                 </div>
                 {% endif %}
-                <form class="form-horizontal join-group-form" role="form"
+                <form id="submitOnce" class="form-horizontal join-group-form" role="form"
                       method="post" action="/groups/{{group.name}}/join">
                     {% include "forms/group-join.html" %}
                     {% if group.require_clickthru_tojoin %}


### PR DESCRIPTION
Large groups are having problems with lots of duplicate membership
requests from people clicking on the join submit button multiple
times because they think nothing has happened.  Add JavaScript
support to disable the submit button and switch the cursor to the
progress cursor when the form has been submitted.

It should be possible to reuse the same machinery elsewhere if we
have the same problem.