### PR TITLE
Update to latest mypy

### DIFF
--- a/grouper/app.py
+++ b/grouper/app.py
@@ -33,10 +33,10 @@ class GrouperApplication(Application):
 
         request_time = 1000.0 * handler.request.request_time()
 
-        # This is a private method of Tornado and thus isn't in typeshed.
+        # This is a private method of Tornado and thus isn't in typeshed for Python 2.
         #
         # TODO(rra): Replace this with a custom log_function setting that prepents the username.
-        summary = handler._request_summary()  # type: ignore
+        summary = handler._request_summary()  # type: ignore[attr-defined]
 
         log_method(
             "{} {} {} {:.2f}ms".format(username, handler.get_status(), summary, request_time)

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -52,7 +52,7 @@ def main(sys_argv=sys.argv, session=None):
 
     # Add parsers for legacy commands that have not been refactored.
     for subcommand_module in [group, oneoff, shell]:
-        subcommand_module.add_parser(subparsers)  # type: ignore
+        subcommand_module.add_parser(subparsers)  # type: ignore[attr-defined]
 
     args = parser.parse_args(sys_argv[1:])
 

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -1,4 +1,5 @@
 import json
+from typing import TYPE_CHECKING
 
 from tornado.web import HTTPError
 
@@ -11,7 +12,7 @@ from grouper.models.group import Group
 from grouper.permissions import get_grantable_permissions, get_permission
 from grouper.user_group import get_groups_by_user
 
-if False:
+if TYPE_CHECKING:
     from grouper.models.permission import Permission
     from typing import Any, Dict, Iterable, List, Optional, Tuple
 

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -129,12 +129,8 @@ def get_user_view_template_vars(session, actor, user, graph):
         # they're disabled, so we've excluded them from the in-memory graph.
         user_md = {}
 
-    shell = (
-        get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY).data_value
-        if get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
-        else "No shell configured"
-    )
-    ret["shell"] = shell
+    shell_metadata = get_user_metadata_by_key(session, user.id, USER_METADATA_SHELL_KEY)
+    ret["shell"] = shell_metadata.data_value if shell_metadata else "No shell configured"
     github_username = get_user_metadata_by_key(session, user.id, USER_METADATA_GITHUB_USERNAME_KEY)
     ret["github_username"] = github_username.data_value if github_username else "(Unset)"
     ret["open_audits"] = user_open_audits(session, user)

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from tornado.httpserver import HTTPRequest
     from types import TracebackType
-    from typing import Any, Dict, List, Optional, Tuple, Type, Union
+    from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 
 class BasePlugin(object):
@@ -50,7 +50,7 @@ class BasePlugin(object):
         pass
 
     def get_aliases_for_mapped_permission(self, session, permission, argument):
-        # type: (Session, str, str) -> List[Tuple[str, str]]
+        # type: (Session, str, str) -> Optional[Iterable[Tuple[str, str]]]
         """Called when building the graph to get aliases of a mapped permission.
 
         Args:
@@ -64,7 +64,7 @@ class BasePlugin(object):
         pass
 
     def get_owner_by_arg_by_perm(self, session):
-        # type: (Session) -> Dict[str, Dict[str, List[Group]]]
+        # type: (Session) -> Optional[Dict[str, Dict[str, List[Group]]]]
         """Called when determining owners for permission+arg granting.
 
         Args:
@@ -79,7 +79,7 @@ class BasePlugin(object):
         pass
 
     def get_ssl_context(self):
-        # type: () -> SSLContext
+        # type: () -> Optional[SSLContext]
         """Called to get the ssl.SSLContext for the application."""
         pass
 

--- a/grouper/user_metadata.py
+++ b/grouper/user_metadata.py
@@ -25,7 +25,7 @@ def get_user_metadata(session, user_id):
 
 
 def get_user_metadata_by_key(session, user_id, data_key):
-    # type: (Session, int, str) -> UserMetadata
+    # type: (Session, int, str) -> Optional[UserMetadata]
     """Return the user's metadata if it has the matching key
 
     Args:
@@ -39,7 +39,7 @@ def get_user_metadata_by_key(session, user_id, data_key):
 
 
 def set_user_metadata(session, user_id, data_key, data_value):
-    # type: (Session, int, str, str) -> Optional[UserMetadata]
+    # type: (Session, int, str, Optional[str]) -> Optional[UserMetadata]
     """Set a single piece of user metadata.
 
     Args:
@@ -66,7 +66,7 @@ def set_user_metadata(session, user_id, data_key, data_value):
     else:
         if data_value is None:
             # do nothing, a delete on a key that's not set
-            return
+            return None
         else:
             user_md = UserMetadata(user_id=user_id, data_key=data_key, data_value=data_value)
             user_md.add(session)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 black==19.3b0
 coverage==4.5.3
 flake8-import-order==0.18.1
-flake8==3.7.7
+flake8==3.7.8
 groupy>=0.5.1
 mock==2.0.0
 py==1.5.2
-mypy==0.701
+mypy==0.730
 pytest-mock==1.10.3
 pytest-tornado==0.7.0
 pytest-xdist==1.28.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,21 @@ application-import-names = grouper, itests, plugins, tests
 
 # E203: whitespace before :, black says to disable
 # W503: line break after binary operator, black says to disable
+# F821: temporary until pyflakes/pull/455 makes it into a release
 # E711: allow SQLAlchemy query expressions with == None
 # E712: allow SQLAlchemy query expressions with == True or == False
 #
 # TODO(rra): Centralize the SQL queries and then restrict the last two ignored
 # diagnostics to just the repository layer.
-ignore = E203, W503, E711, E712
+ignore = E203, W503, F821, E711, E712
 
 [mypy]
 ignore_missing_imports = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_unreachable = True
+
+# We want to add warn_unused_ignores, but currently can't due to grouper/app.py, which has
+# different behavior in Python 2 mode and Python 3 mode.
+#warn_unused_ignores = True

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ get_package_data("grouper", "grouper/fe/templates")
 
 kwargs = {
     "name": "grouper",
-    "version": __version__,  # type: ignore  # noqa: F821
+    "version": __version__,  # type: ignore[name-defined]  # noqa: F821
     "packages": ["grouper", "grouper.fe", "grouper.api", "grouper.ctl"],
     "package_data": package_data,
     "scripts": ["bin/grouper-api", "bin/grouper-fe", "bin/grouper-ctl"],

--- a/tests/exception_test.py
+++ b/tests/exception_test.py
@@ -56,6 +56,11 @@ def test_exception_plugin():
     assert str(test_logger.exc_value) == "some string"
     assert test_logger.exc_tb is not None
 
+    # Reinitializing test_logger unconfuses mypy, which otherwise thinks that test_logger.request
+    # must still be None.  See mypy/issues/4168.
+    test_logger = ExceptionLoggerTestPlugin()
+    proxy = PluginProxy([test_logger])
+
     try:
         raise RandomException("with request")
     except RandomException:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -65,7 +65,7 @@ def test_update_from_config(tmpdir):
     with open(config_path, "w") as config:
         config.write(CONFIG_BOGUS)
     settings.update_from_config(config_path)
-    assert settings._logger != "bar"
+    assert settings._logger != "bar"  # type: ignore[comparison-overlap]
     assert not hasattr(settings, "foo")
 
     # A configuration that doesn't set database or database_source should raise an exception.


### PR DESCRIPTION
Update to mypy 0.730 and enable several new optional features.
Adjust accordingly, including fixing a few discovered bugs.  Add
error code annotations to all type: ignore comments.

This runs into a few limitations of mypy, so there is a small
increase in workarounds.  It also requires suppressing a flake8
error since flake8 doesn't yet understand the new error code
annotations, but that error should also be caught by mypy so
shouldn't be that serious.