### PR TITLE
Don't allow multiple join requests to the same group

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -180,7 +180,7 @@ class GroupJoinForm(Form):
         [
             validators.Length(min=3, max=constants.MAX_NAME_LENGTH),
             validators.DataRequired(),
-            ValidateRegex(r"(?:User|Member|Group): {}".format(constants.NAME_VALIDATION)),
+            ValidateRegex(r"(?:User|Group): {}".format(constants.NAME_VALIDATION)),
         ],
     )
     role = SelectField(

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -7,13 +7,14 @@ from grouper.entities.group_edge import APPROVER_ROLE_INDICES, GROUP_EDGE_ROLES
 from grouper.fe.forms import GroupJoinForm
 from grouper.fe.settings import settings
 from grouper.fe.util import Alert, GrouperHandler
+from grouper.group_requests import count_requests_by_group
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group, GROUP_JOIN_CHOICES
 from grouper.models.user import User
 from grouper.user_group import get_groups_by_user
 
 if TYPE_CHECKING:
-    from typing import Any, List, Optional, Tuple, Union
+    from typing import Any, Mapping, List, Optional, Tuple, Union
 
 
 class GroupJoin(GrouperHandler):
@@ -28,9 +29,18 @@ class GroupJoin(GrouperHandler):
 
         group_md = self.graph.get_group_details(group.name)
 
+        members = group.my_members()
+        user_is_member = self._is_user_a_member(group, members)
+
         form = GroupJoinForm()
-        form.member.choices = self._get_choices(group)
-        return self.render("group-join.html", form=form, group=group, audited=group_md["audited"])
+        form.member.choices = self._get_choices(group, members, user_is_member)
+        return self.render(
+            "group-join.html",
+            form=form,
+            group=group,
+            audited=group_md["audited"],
+            user_is_member=user_is_member,
+        )
 
     def post(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
@@ -41,8 +51,11 @@ class GroupJoin(GrouperHandler):
         if not group or not group.enabled:
             return self.notfound()
 
+        members = group.my_members()
+        user_is_member = self._is_user_a_member(group, members)
+
         form = GroupJoinForm(self.request.arguments)
-        form.member.choices = self._get_choices(group)
+        form.member.choices = self._get_choices(group, members, user_is_member)
         if not form.validate():
             return self.render(
                 "group-join.html", form=form, group=group, alerts=self.get_form_alerts(form.errors)
@@ -173,15 +186,13 @@ class GroupJoin(GrouperHandler):
 
         return self.session.query(resource).filter_by(name=member_name, enabled=True).one()
 
-    def _get_choices(self, group):
-        # type: (Group) -> List[Tuple[str, ...]]
-        # This returns List[Tuple[str, str]], but mypy is confused by the * 2 syntax.
+    def _get_choices(self, group, members, user_is_member):
+        # type: (Group, Mapping[Tuple[str, str], Any], bool) -> List[Tuple[str, str]]
         choices = []
 
-        members = group.my_members()
-
-        if ("User", self.current_user.name) not in members:
-            choices.append(("User: {}".format(self.current_user.name),) * 2)
+        if not user_is_member:
+            choice = "User: {}".format(self.current_user.name)
+            choices.append((choice, choice))
 
         for _group, group_edge in get_groups_by_user(self.session, self.current_user):
             if group.name == _group.name:  # Don't add self.
@@ -191,6 +202,22 @@ class GroupJoin(GrouperHandler):
             if ("Group", _group.name) in members:
                 continue
 
-            choices.append(("Group: {}".format(_group.name),) * 2)
+            choice = "Group: {}".format(_group.name)
+            choices.append((choice, choice))
+
+        # If there are some choices but the user is already a member or has a pending request, add
+        # a blank option as the first choice to avoid the user requesting membership on behalf of a
+        # group by mistake.
+        if choices and user_is_member:
+            choices.insert(0, ("", ""))
 
         return choices
+
+    def _is_user_a_member(self, group, members):
+        # type: (Group, Mapping[Tuple[str, str], Any]) -> bool
+        """Returns whether the current user is a member or has a pending membership request."""
+        if ("User", self.current_user.name) in members:
+            return True
+        if count_requests_by_group(self.session, group, "pending", self.current_user) > 0:
+            return True
+        return False

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -21,6 +21,13 @@
                 <h3 class="panel-title">Join Group</h3>
            </div>
             <div class="panel-body">
+                {% if user_is_member %}
+                <div class="alert alert-warning">
+                    You are either already a member of this group or have a pending membership
+                    request. You can also request membership on behalf of a group, but be sure this
+                    is what you intended to do.
+                </div>
+                {% endif %}
                 {% if audited %}
                 <div class="alert alert-warning">
                     <strong>Membership in this group is audited.</strong> Your access to this
@@ -54,9 +61,9 @@
 {% else %}
     <div class="col-md-8 col-md-offset-2">
         <div class="alert alert-danger" role="alert">
-            You and all Groups you are a manager/owner/np-owner of are already members of
-            the <em>{{group.name}}</em> Group. You can modify memberships from the member
-            list <a href="/groups/{{group.name}}">here</a>.
+            You and all groups you are a manager/owner/np-owner of are either already members of
+            the <em>{{group.name}}</em> group or have pending requests to join. You can modify
+            memberships from the member list <a href="/groups/{{group.name}}">here</a>.
         </div>
     </div>
 {% endif %}

--- a/grouper/fe/templates/group-join.html
+++ b/grouper/fe/templates/group-join.html
@@ -24,8 +24,9 @@
                 {% if user_is_member %}
                 <div class="alert alert-warning">
                     You are either already a member of this group or have a pending membership
-                    request. You can also request membership on behalf of a group, but be sure this
-                    is what you intended to do.
+                    request. You can also request membership on behalf of a group in order to nest
+                    a group inside another, but be sure this is what you intended to do. (It
+                    usually is not.)
                 </div>
                 {% endif %}
                 {% if audited %}

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING
 
+import pytest
+from selenium.common.exceptions import NoSuchElementException
+
 from grouper.entities.group import GroupJoinPolicy
 from itests.pages.groups import GroupJoinPage, GroupRequestsPage, GroupsViewPage, GroupViewPage
 from itests.setup import frontend_server
@@ -34,6 +37,55 @@ def test_request_to_join_group(tmpdir, setup, browser):
         assert request_row.expiration == "12/31/2999"
         assert request_row.role == "member"
         assert request_row.reason == "Testing"
+
+
+def test_request_already_member(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+        setup.add_group_to_group("some-group", "other-group")
+        setup.add_user_to_group("gary@a.co", "other-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/other-group/join"))
+        page = GroupJoinPage(browser)
+
+        alerts = page.get_alerts()
+        assert len(alerts) == 1
+        assert "You and all groups" in alerts[0].text
+        with pytest.raises(NoSuchElementException):
+            page.set_reason("Testing")
+
+
+def test_request_options(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+        setup.create_group("other-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/other-group/join"))
+        page = GroupJoinPage(browser)
+
+        options = [o.get_attribute("value") for o in page.get_member_options()]
+        assert options == ["User: gary@a.co", "Group: some-group"]
+
+        page.set_reason("Testing")
+        page.submit()
+
+        # Now that there is a pending request, the first option should be blank and there should be
+        # a notice saying that there is already a pending membership request.
+        browser.get(url(frontend_url, "/groups/other-group/join"))
+        options = [o.get_attribute("value") for o in page.get_member_options()]
+        assert options == ["", "Group: some-group"]
+        alerts = page.get_alerts()
+        assert len(alerts) == 1
+        assert "already a member" in alerts[0].text
+
+        # Attempting to submit the form should fail, asking the user to select a value.
+        page.set_reason("Testing")
+        page.submit()
+        assert page.current_url == url(frontend_url, "/groups/other-group/join")
 
 
 def test_require_clickthru(tmpdir, setup, browser):

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -107,11 +107,20 @@ class GroupJoinPage(BasePage):
         # type: () -> WebElement
         return self.find_element_by_class_name("join-group-form")
 
+    def get_alerts(self):
+        # type: () -> List[WebElement]
+        return self.find_elements_by_class_name("alert")
+
     def get_clickthru_modal(self):
         # type: () -> GroupJoinClickthruModal
         element = self.find_element_by_id("clickthruModal")
         self.wait_until_visible(element)
         return GroupJoinClickthruModal(element)
+
+    def get_member_options(self):
+        # type: () -> List[WebElement]
+        element = self.find_element_by_name("member")
+        return element.find_elements_by_tag_name("option")
 
     def set_expiration(self, expiration):
         # type: (str) -> None


### PR DESCRIPTION
If the user already has a pending request to join a group, don't
allow them to request membership again for their user (but still
allow them to request membership for groups they own).  Change the
first prompt, for the member, to be empty if the user themselves
already has a pending request but can still request membership on
behalf of some other group.  Add a warning explaining that this is
the case.