### PR TITLE
Fix string handling of database URL from program

### DIFF
--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytz
 import yaml
-from six import iteritems
+from six import iteritems, PY2
 from six.moves.urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -172,7 +172,10 @@ class Settings(object):
             try:
                 self._logger.debug("Getting database URL by running %s", self.database_source)
                 raw_url = subprocess.check_output([self.database_source], stderr=subprocess.STDOUT)
-                url = str(raw_url).strip()
+                if PY2:
+                    url = raw_url.strip()
+                else:
+                    url = raw_url.decode().strip()
                 if not url:
                     raise DatabaseSourceException("Returned URL is empty")
                 self._logger.debug("New database URL is %s", self._url_without_password(url))

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -94,7 +94,7 @@ def test_database():
     settings.database = ""
     settings.database_source = "/path/to/program"
     with patch("subprocess.check_output") as mock_subprocess:
-        mock_subprocess.return_value = "sqlite:///other.sqlite\n"
+        mock_subprocess.return_value = b"sqlite:///other.sqlite\n"
         assert settings.database == "sqlite:///other.sqlite"
         assert mock_subprocess.call_args_list == [
             call(["/path/to/program"], stderr=subprocess.STDOUT)
@@ -106,7 +106,7 @@ def test_database():
     with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
         with patch("subprocess.check_output") as mock_subprocess:
             exception = subprocess.CalledProcessError(1, "/path/to/program")
-            mock_subprocess.side_effect = [exception, "sqlite:///third.sqlite"]
+            mock_subprocess.side_effect = [exception, b"sqlite:///third.sqlite"]
             assert settings.database == "sqlite:///third.sqlite"
             assert mock_subprocess.call_count == 2
 
@@ -115,7 +115,7 @@ def test_database():
     settings.database_source = "/path/to/program"
     with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
         with patch("subprocess.check_output") as mock_subprocess:
-            mock_subprocess.side_effect = ["", "sqlite:///notempty.sqlite"]
+            mock_subprocess.side_effect = [b"", b"sqlite:///notempty.sqlite"]
             assert settings.database == "sqlite:///notempty.sqlite"
             assert mock_subprocess.call_count == 2
 
@@ -124,7 +124,7 @@ def test_database():
     settings.database_source = "/path/to/program"
     with patch.object(Settings, "DB_URL_RETRY_DELAY", new=0):
         with patch("subprocess.check_output") as mock_subprocess:
-            mock_subprocess.return_value = ""
+            mock_subprocess.return_value = b""
             with pytest.raises(DatabaseSourceException):
                 assert settings.database
 
@@ -139,7 +139,7 @@ def test_mask_passsword_in_logs(caplog):
 
     # Reading settings.database will run the external program and trigger the logging.
     with patch("subprocess.check_output") as mock_subprocess:
-        mock_subprocess.return_value = "mysql://user:password@example.com:8888/merou"
+        mock_subprocess.return_value = b"mysql://user:password@example.com:8888/merou"
         assert settings.database == test_url
 
     assert test_url not in caplog.text


### PR DESCRIPTION
Don't convert to str via str(), since that adds the b'' around the
value when it's in bytes.  Instead, use decode().  Fix the test to
mock subprocess with a bytes return value so that this handling is
correctly tested.