### PR TITLE
Increase the timeout for starting Chrome

### DIFF
--- a/itests/setup.py
+++ b/itests/setup.py
@@ -30,7 +30,7 @@ def _bind_socket():
     return s
 
 
-def _wait_until_accept(port, timeout=3.0):
+def _wait_until_accept(port, timeout=5.0):
     # type: (int, float) -> None
     """Wait until a server accepts connections on the specified port."""
     deadline = time.time() + timeout


### PR DESCRIPTION
On slower systems, Selenium tests periodically fail because the
web driver doesn't start before the timeout expires.  Bump it to
five seconds from three, which seems to help.