### PR TITLE
Convert service account permission grant to a usecase

### DIFF
--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -85,6 +85,10 @@ HANDLERS = [
     (r"/github/link_complete/(?P<user_id>[0-9]+)", GitHubLinkCompleteView),
     (r"/groups", GroupsView),
     (r"/groups/{}/service/create".format(NAME_VALIDATION), ServiceAccountCreate),
+    (
+        r"/groups/{}/service/{}/grant".format(NAME_VALIDATION, SERVICE_ACCOUNT_VALIDATION),
+        ServiceAccountPermissionGrant,
+    ),
     (r"/permissions/create", PermissionsCreate),
     (r"/permissions/request", PermissionRequest),
     (r"/permissions/requests", PermissionsRequests),
@@ -167,10 +171,6 @@ for regex in (r"(?P<group_id>[0-9]+)", NAME_VALIDATION):
                     ServiceAccountDisable,
                 ),
                 (r"/groups/{}/service/{}/edit".format(regex, service_regex), ServiceAccountEdit),
-                (
-                    r"/groups/{}/service/{}/grant".format(regex, service_regex),
-                    ServiceAccountPermissionGrant,
-                ),
                 (
                     r"/groups/{}/service/{}/revoke/(?P<mapping_id>[0-9]+)".format(
                         regex, service_regex

--- a/grouper/fe/templates/service-account-permission-grant.html
+++ b/grouper/fe/templates/service-account-permission-grant.html
@@ -1,24 +1,24 @@
 {% extends "base.html" %}
 
-{% block subtitle %} grant permission to {{user.username}}{% endblock %}
+{% block subtitle %} grant permission to {{service}}{% endblock %}
 
 {% block heading %}
     <a href="/groups">Groups</a>
 {% endblock %}
 
 {% block subheading %}
-    Grant Permission to {{user.username}}
+    Grant Permission to {{service}}
 {% endblock %}
 
 {% block content %}
 <div class="col-md-6 col-md-offset-3">
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h3 class="panel-title">Grant Permission to {{user.username}}</h3>
+            <h3 class="panel-title">Grant Permission to {{service}}</h3>
         </div>
         <div class="panel-body">
             <form id="grant-permission-form" class="form-horizontal" role="form" method="post"
-                  action="/groups/{{group.name}}/service/{{user.username}}/grant">
+                  action="/groups/{{owner}}/service/{{service}}/grant">
                 {% include "forms/service-account-permission-grant.html" %}
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-4">

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -76,13 +76,18 @@ class PermissionGrantRepository(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def grant_permission_to_service_account(self, permission, argument, service):
+        # type: (str, str, str) -> None
+        pass
+
+    @abstractmethod
     def group_grants_for_permission(self, name, include_disabled_groups=False):
         # type: (str, bool) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
+    def permission_grants_for_group(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod
@@ -102,6 +107,11 @@ class PermissionGrantRepository(metaclass=ABCMeta):
 
     @abstractmethod
     def revoke_all_service_account_grants(self, permission):
+        # type: (str) -> List[ServiceAccountPermissionGrant]
+        pass
+
+    @abstractmethod
+    def service_account_grants_for_permission(self, name):
         # type: (str) -> List[ServiceAccountPermissionGrant]
         pass
 

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -107,4 +107,4 @@ class ServiceAccountRepository(object):
     def service_account_is_enabled(self, name):
         # type: (str) -> bool
         user = SQLUser.get(self.session, name=name)
-        return bool(user and user.is_service_account and user.enabled)
+        return bool(user and user.is_service_account and user.enabled)  # bool() is for mypy

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -84,6 +84,27 @@ class ServiceAccountRepository(object):
 
         user.is_service_account = True
 
+    def owner_of_service_account(self, name):
+        # type: (str) -> str
+        owner = (
+            self.session.query(Group.groupname)
+            .filter(
+                SQLServiceAccount.user_id == SQLUser.id,
+                SQLUser.name == name,
+                GroupServiceAccount.service_account_id == SQLServiceAccount.id,
+                Group.id == GroupServiceAccount.group_id,
+            )
+            .scalar()
+        )
+        if not owner:
+            raise ServiceAccountNotFoundException(name)
+        return owner
+
     def service_account_exists(self, name):
         # type: (str) -> bool
         return SQLServiceAccount.get(self.session, name=name) is not None
+
+    def service_account_is_enabled(self, name):
+        # type: (str) -> bool
+        user = SQLUser.get(self.session, name=name)
+        return bool(user and user.is_service_account and user.enabled)

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -97,6 +97,23 @@ class AuditLogService(AuditLogInterface):
             date=date,
         )
 
+    def log_grant_permission_to_service_account(
+        self,
+        permission,  # type: str
+        argument,  # type: str
+        service,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="grant_permission",
+            description="Granted permission with argument: {}".format(argument),
+            on_permission=permission,
+            on_user=service,
+        )
+
     def log_revoke_group_permission_grant(
         self,
         group,  # type: str

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -4,10 +4,13 @@ from typing import TYPE_CHECKING
 from grouper.constants import NAME_VALIDATION
 from grouper.entities.group import GroupJoinPolicy, InvalidGroupNameException
 from grouper.usecases.interfaces import GroupInterface
+from grouper.util import matches_glob
 
 if TYPE_CHECKING:
+    from grouper.entities.permission_grant import GroupPermissionGrant
     from grouper.repositories.group import GroupRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
+    from typing import List
 
 
 class GroupService(GroupInterface):
@@ -24,6 +27,15 @@ class GroupService(GroupInterface):
             raise InvalidGroupNameException(name)
         self.group_repository.create_group(name, description, join_policy)
 
+    def group_has_matching_permission_grant(self, group, permission, argument):
+        # type: (str, str, str) -> bool
+        grants = self.permission_grant_repository.permission_grants_for_group(group)
+        for grant in grants:
+            if grant.permission == permission:
+                if matches_glob(grant.argument, argument):
+                    return True
+        return False
+
     def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
         self.permission_grant_repository.grant_permission_to_group(permission, argument, group)
@@ -35,3 +47,7 @@ class GroupService(GroupInterface):
     def is_valid_group_name(self, name):
         # type: (str) -> bool
         return re.match("^{}$".format(NAME_VALIDATION), name) is not None
+
+    def permission_grants_for_group(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
+        return self.permission_grant_repository.permission_grants_for_group(name)

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -1,6 +1,7 @@
+import re
 from typing import TYPE_CHECKING
 
-from grouper.constants import SYSTEM_PERMISSIONS
+from grouper.constants import ARGUMENT_VALIDATION, SYSTEM_PERMISSIONS
 from grouper.usecases.interfaces import PermissionInterface
 
 if TYPE_CHECKING:
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.list_permissions import ListPermissionsSortKey
     from grouper.usecases.interfaces import AuditLogInterface
-    from typing import Dict, List, Optional
+    from typing import Dict, List, Optional, Tuple
 
 
 class PermissionService(PermissionInterface):
@@ -82,6 +83,21 @@ class PermissionService(PermissionInterface):
     def is_system_permission(self, name):
         # type: (str) -> bool
         return name in (entry[0] for entry in SYSTEM_PERMISSIONS)
+
+    def is_valid_permission_argument(self, permission, argument):
+        # type: (str, str) -> Tuple[bool, Optional[str]]
+        """Check whether a permission argument is valid.
+
+        Returns:
+            Tuple of a bool (whether or not the permission argument is valid) and, if False, a
+            string error message explaining why it isn't valid.
+        """
+        if not re.match(ARGUMENT_VALIDATION + r"$", argument):
+            error = "Permission argument is not valid (does not match {})".format(
+                ARGUMENT_VALIDATION
+            )
+            return (False, error)
+        return (True, None)
 
     def list_permissions(self, pagination, audited_only):
         # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -1,7 +1,12 @@
 import re
 from typing import TYPE_CHECKING
 
-from grouper.constants import MAX_NAME_LENGTH, SERVICE_ACCOUNT_VALIDATION, USER_ADMIN
+from grouper.constants import (
+    MAX_NAME_LENGTH,
+    PERMISSION_ADMIN,
+    SERVICE_ACCOUNT_VALIDATION,
+    USER_ADMIN,
+)
 from grouper.entities.user import (
     UserHasPendingRequestsException,
     UserIsEnabledException,
@@ -79,6 +84,15 @@ class ServiceAccountService(ServiceAccountInterface):
 
         self.audit_log.log_enable_service_account(user, owner, authorization)
 
+    def grant_permission_to_service_account(self, permission, argument, service, authorization):
+        # type: (str, str, str, Authorization) -> None
+        self.permission_grant_repository.grant_permission_to_service_account(
+            permission, argument, service
+        )
+        self.audit_log.log_grant_permission_to_service_account(
+            permission, argument, service, authorization
+        )
+
     def is_valid_service_account_name(self, name):
         # type: (str) -> Tuple[bool, Optional[str]]
         """Check if the given name is valid for use as a service account.
@@ -110,6 +124,10 @@ class ServiceAccountService(ServiceAccountInterface):
 
         return (True, None)
 
+    def owner_of_service_account(self, service):
+        # type: (str) -> str
+        return self.service_account_repository.owner_of_service_account(service)
+
     def permission_grants_for_service_account(self, service):
         # type: (str) -> List[ServiceAccountPermissionGrant]
         return self.permission_grant_repository.permission_grants_for_service_account(service)
@@ -117,6 +135,16 @@ class ServiceAccountService(ServiceAccountInterface):
     def service_account_exists(self, service):
         # type: (str) -> bool
         return self.service_account_repository.service_account_exists(service)
+
+    def service_account_is_enabled(self, service):
+        # type: (str) -> bool
+        return self.service_account_repository.service_account_is_enabled(service)
+
+    def service_account_is_permission_admin(self, service):
+        # type: (str) -> bool
+        return self.permission_grant_repository.service_account_has_permission(
+            service, PERMISSION_ADMIN
+        )
 
     def service_account_is_user_admin(self, service):
         # type: (str) -> bool

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -4,6 +4,7 @@ from grouper.usecases.convert_user_to_service_account import ConvertUserToServic
 from grouper.usecases.create_service_account import CreateServiceAccount
 from grouper.usecases.disable_permission import DisablePermission
 from grouper.usecases.dump_schema import DumpSchema
+from grouper.usecases.grant_permission_to_service_account import GrantPermissionToServiceAccount
 from grouper.usecases.initialize_schema import InitializeSchema
 from grouper.usecases.list_grants import ListGrants
 from grouper.usecases.list_permissions import ListPermissions
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
     from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccountUI
     from grouper.usecases.disable_permission import DisablePermissionUI
     from grouper.usecases.dump_schema import DumpSchemaUI
+    from grouper.usecases.grant_permission_to_service_account import (
+        GrantPermissionToServiceAccountUI,
+    )
     from grouper.usecases.list_grants import ListGrantsUI
     from grouper.usecases.list_users import ListUsersUI
     from grouper.usecases.list_permissions import ListPermissionsUI
@@ -74,6 +78,23 @@ class UseCaseFactory(object):
         # type: (DumpSchemaUI) -> DumpSchema
         schema_service = self.service_factory.create_schema_service()
         return DumpSchema(ui, schema_service)
+
+    def create_grant_permission_to_service_account_usecase(self, actor, ui):
+        # type: (str, GrantPermissionToServiceAccountUI) -> GrantPermissionToServiceAccount
+        permission_service = self.service_factory.create_permission_service()
+        service_account_service = self.service_factory.create_service_account_service()
+        user_service = self.service_factory.create_user_service()
+        group_service = self.service_factory.create_group_service()
+        transaction_service = self.service_factory.create_transaction_service()
+        return GrantPermissionToServiceAccount(
+            actor,
+            ui,
+            permission_service,
+            service_account_service,
+            user_service,
+            group_service,
+            transaction_service,
+        )
 
     def create_list_grants_usecase(self, ui):
         # type: (ListGrantsUI) -> ListGrants

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -1,0 +1,155 @@
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING
+
+from grouper.entities.permission import PermissionNotFoundException
+from grouper.usecases.authorization import Authorization
+
+if TYPE_CHECKING:
+    from grouper.entities.permission_grant import GroupPermissionGrant
+    from grouper.usecases.interfaces import (
+        GroupInterface,
+        PermissionInterface,
+        ServiceAccountInterface,
+        TransactionInterface,
+        UserInterface,
+    )
+    from typing import List
+
+
+class GrantPermissionToServiceAccountUI(metaclass=ABCMeta):
+    @abstractmethod
+    def grant_permission_to_service_account_failed_invalid_argument(
+        self, permission, argument, service, message
+    ):
+        # type: (str, str, str, str) -> None
+        pass
+
+    @abstractmethod
+    def grant_permission_to_service_account_failed_permission_denied(
+        self, permission, argument, service, message
+    ):
+        # type: (str, str, str, str) -> None
+        pass
+
+    @abstractmethod
+    def grant_permission_to_service_account_failed_permission_not_found(self, permission, service):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def grant_permission_to_service_account_failed_service_account_not_found(self, service):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def granted_permission_to_service_account(self, permission, argument, service):
+        # type; (str, str, str) -> None
+        pass
+
+
+class GrantPermissionToServiceAccount(object):
+    def __init__(
+        self,
+        actor,  # type: str
+        ui,  # type: GrantPermissionToServiceAccountUI
+        permission_service,  # type: PermissionInterface
+        service_account_service,  # type: ServiceAccountInterface
+        user_service,  # type: UserInterface
+        group_service,  # type: GroupInterface
+        transaction_service,  # type: TransactionInterface
+    ):
+        # type: (...) -> None
+        self.actor = actor
+        self.ui = ui
+        self.permission_service = permission_service
+        self.service_account_service = service_account_service
+        self.user_service = user_service
+        self.group_service = group_service
+        self.transaction_service = transaction_service
+
+    def can_grant_permissions_for_service_account(self, service):
+        # type: (str) -> bool
+        if not self.service_account_service.service_account_is_enabled(service):
+            return False
+
+        # If the actor is a permission admin, they can grant any permission to the service account.
+        # Otherwise, they have to be a member of the owning group.
+        if self.service_account_service.service_account_exists(self.actor):
+            return self.service_account_service.service_account_is_permission_admin(self.actor)
+        elif self.user_service.user_is_permission_admin(self.actor):
+            return True
+        else:
+            owner = self.service_account_service.owner_of_service_account(service)
+            return owner in self.user_service.groups_of_user(self.actor)
+
+    def grant_permission_to_service_account(self, permission, argument, service):
+        # type: (str, str, str) -> None
+        if not self.service_account_service.service_account_is_enabled(service):
+            self.ui.grant_permission_to_service_account_failed_service_account_not_found(service)
+            return
+
+        valid, error = self.permission_service.is_valid_permission_argument(permission, argument)
+        if not valid:
+            assert error
+            self.ui.grant_permission_to_service_account_failed_invalid_argument(
+                permission, argument, service, error
+            )
+            return
+
+        # If the actor is a permission admin, they can grant any permission to the service account.
+        # Otherwise, they have to be a member of the owning group and the permission and argument
+        # being granted must have been granted to the owning group.
+        if self.service_account_service.service_account_exists(self.actor):
+            allowed = self.service_account_service.service_account_is_permission_admin(self.actor)
+        elif self.user_service.user_is_permission_admin(self.actor):
+            allowed = True
+        else:
+            owner = self.service_account_service.owner_of_service_account(service)
+            if owner in self.user_service.groups_of_user(self.actor):
+                allowed = self.group_service.group_has_matching_permission_grant(
+                    owner, permission, argument
+                )
+                if not allowed:
+                    message = "The group {} does not have that permission".format(owner)
+                    self.ui.grant_permission_to_service_account_failed_permission_denied(
+                        permission, argument, service, message
+                    )
+                    return
+            else:
+                allowed = False
+        if not allowed:
+            self.ui.grant_permission_to_service_account_failed_permission_denied(
+                permission, argument, service, "Permission denied"
+            )
+            return
+
+        authorization = Authorization(self.actor)
+        with self.transaction_service.transaction():
+            try:
+                self.service_account_service.grant_permission_to_service_account(
+                    permission, argument, service, authorization
+                )
+            except PermissionNotFoundException:
+                self.ui.grant_permission_to_service_account_failed_permission_not_found(
+                    permission, service
+                )
+                return
+        self.ui.granted_permission_to_service_account(permission, argument, service)
+
+    def service_account_exists_with_owner(self, service, owner):
+        # type: (str, str) -> bool
+        """Returns True if the given service account exists, is enabled, and has that owner."""
+        if not self.service_account_service.service_account_is_enabled(service):
+            return False
+        if not self.service_account_service.owner_of_service_account(service) == owner:
+            return False
+        return True
+
+    def permission_grants_for_group(self, group):
+        # type: (str) -> List[GroupPermissionGrant]
+        """List of all permissions granted to a group.
+
+        Used by the UI to populate the dropdown list of permissions that are eligible for
+        delegation to the service account.
+        """
+        return self.group_service.permission_grants_for_group(group)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -86,6 +86,18 @@ class AuditLogInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def log_grant_permission_to_service_account(
+        self,
+        permission,  # type: str
+        argument,  # type: str
+        service,  # type: str
+        authorization,  # type: Authorization
+        date=None,  # type: Optional[datetime]
+    ):
+        # type: (...) -> None
+        pass
+
+    @abstractmethod
     def log_revoke_group_permission_grant(
         self,
         group,  # type: str
@@ -134,8 +146,18 @@ class GroupInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def group_has_matching_permission_grant(self, group, permission, argument):
+        # type: (str, str, str) -> bool
+        pass
+
+    @abstractmethod
     def is_valid_group_name(self, name):
         # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def permission_grants_for_group(self, name):
+        # type: (str) -> List[GroupPermissionGrant]
         pass
 
 
@@ -192,6 +214,11 @@ class PermissionInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def is_valid_permission_argument(self, permission, argument):
+        # type: (str, str) -> Tuple[bool, Optional[str]]
+        pass
+
+    @abstractmethod
     def list_permissions(self, pagination, audited_only):
         # type: (Pagination[ListPermissionsSortKey], bool) -> PaginatedList[Permission]
         pass
@@ -240,8 +267,18 @@ class ServiceAccountInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def grant_permission_to_service_account(self, permission, argument, service, authorization):
+        # type: (str, str, str, Authorization) -> None
+        pass
+
+    @abstractmethod
     def is_valid_service_account_name(self, name):
         # type: (str) -> Tuple[bool, Optional[str]]
+        pass
+
+    @abstractmethod
+    def owner_of_service_account(self, service):
+        # type: (str) -> str
         pass
 
     @abstractmethod
@@ -251,6 +288,16 @@ class ServiceAccountInterface(metaclass=ABCMeta):
 
     @abstractmethod
     def service_account_exists(self, service):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def service_account_is_enabled(self, service):
+        # type: (str) -> bool
+        pass
+
+    @abstractmethod
+    def service_account_is_permission_admin(self, user):
         # type: (str) -> bool
         pass
 

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -206,7 +206,9 @@ def test_permission_revoke_denied(tmpdir, setup, browser):
             permission.click_revoke_button()
 
     # Add the user to the group so that the revoke button will show up, and then revoke it before
-    # attempting to click the button.
+    # attempting to click the button.  We can't just directly initiate a request to the revoke URL
+    # without making the button appear because Python Selenium doesn't support a test-initiated
+    # POST (only GET).
     with setup.transaction():
         setup.add_user_to_group("gary@a.co", "some-group")
 

--- a/itests/pages/service_accounts.py
+++ b/itests/pages/service_accounts.py
@@ -113,6 +113,10 @@ class ServiceAccountGrantPermissionPage(BasePage):
         # type: () -> WebElement
         return self.find_element_by_id("grant-permission-form")
 
+    def get_alerts(self):
+        # type: () -> List[WebElement]
+        return self.find_elements_by_class_name("alert")
+
     def select_permission(self, permission):
         # type: (str) -> None
         form = self._get_grant_permission_form()

--- a/tests/repositories/permission_grant_test.py
+++ b/tests/repositories/permission_grant_test.py
@@ -38,3 +38,32 @@ def test_permission_grants_for_user(setup):
         ("perm", "one"),
         ("perm", "two"),
     ]
+
+
+def test_permission_grants_for_group(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_group("one-group")
+
+    permission_grant_repository = setup.sql_repository_factory.create_permission_grant_repository()
+    assert permission_grant_repository.permission_grants_for_group("one-group") == []
+
+    # Build a bit of a group hierarchy with some nested inheritance.
+    with setup.transaction():
+        setup.grant_permission_to_group("perm", "one", "one-group")
+        setup.add_group_to_group("one-group", "parent")
+        setup.grant_permission_to_group("other-perm", "arg", "parent")
+        setup.add_group_to_group("parent", "grandparent")
+        setup.grant_permission_to_group("other-perm", "arg", "grandparent")
+        setup.grant_permission_to_group("other-perm", "*", "grandparent")
+        setup.grant_permission_to_group("perm", "two", "two-group")
+        setup.grant_permission_to_group("another-perm", "foo", "np-group")
+
+    # Check the returned permissions.
+    permission_grants = permission_grant_repository.permission_grants_for_group("one-group")
+    assert sorted([(p.permission, p.argument) for p in permission_grants]) == [
+        ("other-perm", "*"),
+        ("other-perm", "arg"),
+        ("other-perm", "arg"),
+        ("perm", "one"),
+    ]

--- a/tests/service_accounts_test.py
+++ b/tests/service_accounts_test.py
@@ -1,22 +1,20 @@
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 import pytest
 from tornado.httpclient import HTTPError
 
+from grouper.constants import USER_ADMIN
 from grouper.group_service_account import get_service_accounts
-from grouper.models.service_account import ServiceAccount
-from grouper.permissions import grant_permission_to_service_account
+from grouper.models.group import Group
+from grouper.models.user import User
 from grouper.plugin import get_plugin_proxy
 from grouper.plugin.base import BasePlugin
 from grouper.plugin.exceptions import PluginRejectedMachineSet
 from grouper.service_account import (
     can_manage_service_account,
-    create_service_account,
     disable_service_account,
-    DuplicateServiceAccount,
     enable_service_account,
-    is_service_account,
-    service_account_permissions,
 )
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
@@ -30,82 +28,77 @@ from tests.fixtures import (  # noqa: F401
 )
 from tests.url_util import url
 
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
 
-def test_service_accounts(
-    session, standard_graph, graph, users, groups, permissions  # noqa: F811
-):
-    # Create a service account.
-    service_account = ServiceAccount.get(session, name="service@a.co")
-    assert service_account.description == "some service account"
-    assert service_account.machine_set == "some machines"
-    assert service_account.user.name == "service@a.co"
-    assert service_account.user.enabled == True
-    assert service_account.user.is_service_account == True
-    accounts = get_service_accounts(session, groups["team-sre"])
-    assert len(accounts) == 1
-    assert accounts[0].user.name == "service@a.co"
-    assert is_service_account(session, service_account.user)
 
-    # Duplicates should raise an exception.
-    with pytest.raises(DuplicateServiceAccount):
-        create_service_account(
-            session, users["zay@a.co"], "service@a.co", "dup", "dup", groups["team-sre"]
+def test_service_accounts(setup):
+    # type: (SetupTest) -> None
+    """Tests remaining non-usecase service account functions."""
+    with setup.transaction():
+        setup.create_service_account(
+            "service@a.co", "team-sre", "some machines", "some service account"
         )
+        setup.add_user_to_group("zorkian@a.co", "team-sre", "owner")
+        setup.add_user_to_group("zorkian@a.co", "admins")
+        setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+        setup.add_user_to_group("gary@a.co", "team-sre")
+        setup.create_user("oliver@a.co")
+        setup.grant_permission_to_service_account("team-sre", "*", "service@a.co")
+        setup.create_group("security-team")
+
+    group = Group.get(setup.session, name="team-sre")
+    assert group
+    accounts = get_service_accounts(setup.session, group)
+    assert len(accounts) == 1
+    service_account = accounts[0]
+    assert service_account.user.name == "service@a.co"
+    assert service_account.user.is_service_account
 
     # zorkian should be able to manage the account, as should gary, but oliver (not a member of the
     # group) should not.
-    assert can_manage_service_account(session, service_account, users["zorkian@a.co"])
-    assert can_manage_service_account(session, service_account, users["gary@a.co"])
-    assert not can_manage_service_account(session, service_account, users["oliver@a.co"])
-
-    # Check that the user appears in the graph.
-    graph.update_from_db(session)
-    metadata = graph.user_metadata["service@a.co"]
-    assert metadata["enabled"]
-    assert metadata["service_account"]["description"] == "some service account"
-    assert metadata["service_account"]["machine_set"] == "some machines"
-    assert metadata["service_account"]["owner"] == "team-sre"
-    group_details = graph.get_group_details("team-sre")
-    assert group_details["service_accounts"] == ["service@a.co"]
-
-    # Grant a permission to the service account and check it in the graph.
-    grant_permission_to_service_account(session, service_account, permissions["team-sre"], "*")
-    graph.update_from_db(session)
-    user_details = graph.get_user_details("service@a.co")
-    assert user_details["permissions"][0]["permission"] == "team-sre"
-    assert user_details["permissions"][0]["argument"] == "*"
+    zorkian_user = User.get(setup.session, name="zorkian@a.co")
+    assert zorkian_user
+    gary_user = User.get(setup.session, name="gary@a.co")
+    assert gary_user
+    oliver_user = User.get(setup.session, name="oliver@a.co")
+    assert oliver_user
+    assert can_manage_service_account(setup.session, service_account, zorkian_user)
+    assert can_manage_service_account(setup.session, service_account, gary_user)
+    assert not can_manage_service_account(setup.session, service_account, oliver_user)
 
     # Diabling the service account should remove the link to the group.
-    disable_service_account(session, users["zorkian@a.co"], service_account)
+    disable_service_account(setup.session, zorkian_user, service_account)
     assert service_account.user.enabled == False
-    assert get_service_accounts(session, groups["team-sre"]) == []
+    assert get_service_accounts(setup.session, group) == []
 
     # The user should also be gone from the graph and have its permissions removed.
-    graph.update_from_db(session)
-    group_details = graph.get_group_details("team-sre")
+    setup.graph.update_from_db(setup.session)
+    group_details = setup.graph.get_group_details("team-sre")
     assert "service_accounts" not in group_details
-    metadata = graph.user_metadata["service@a.co"]
+    metadata = setup.graph.user_metadata["service@a.co"]
     assert not metadata["enabled"]
     assert "owner" not in metadata["service_account"]
-    user_details = graph.get_user_details("service@a.co")
+    user_details = setup.graph.get_user_details("service@a.co")
     assert user_details["permissions"] == []
 
     # We can re-enable and attach to a different group.
-    new_group = groups["security-team"]
-    enable_service_account(session, users["zorkian@a.co"], service_account, new_group)
+    new_group = Group.get(setup.session, name="security-team")
+    assert new_group
+    enable_service_account(setup.session, zorkian_user, service_account, new_group)
     assert service_account.user.enabled == True
-    assert get_service_accounts(session, groups["team-sre"]) == []
-    accounts = get_service_accounts(session, new_group)
+    assert get_service_accounts(setup.session, group) == []
+    accounts = get_service_accounts(setup.session, new_group)
     assert len(accounts) == 1
     assert accounts[0].user.name == "service@a.co"
 
     # Check that this is reflected in the graph and the user has no permissions.
-    graph.update_from_db(session)
-    group_details = graph.get_group_details("security-team")
+    setup.graph.update_from_db(setup.session)
+    group_details = setup.graph.get_group_details("security-team")
     assert group_details["service_accounts"] == ["service@a.co"]
-    metadata = graph.user_metadata["service@a.co"]
+    metadata = setup.graph.user_metadata["service@a.co"]
     assert metadata["service_account"]["owner"] == "security-team"
-    user_details = graph.get_user_details("service@a.co")
+    user_details = setup.graph.get_user_details("service@a.co")
     assert user_details["permissions"] == []
 
 
@@ -205,125 +198,6 @@ def test_service_account_fe_edit(
     graph.update_from_db(session)
     metadata = graph.user_metadata["service@a.co"]
     assert metadata["service_account"]["description"] == "done by admin"
-
-
-@pytest.mark.gen_test
-def test_service_account_fe_perms(
-    session, standard_graph, graph, http_client, base_url  # noqa: F811
-):
-    admin = "cbguder@a.co"
-    owner = "zay@a.co"
-    plebe = "oliver@a.co"
-
-    # Unrelated people cannot create a service account
-    fe_url = url(base_url, "/groups/team-sre/service/create")
-    with pytest.raises(HTTPError):
-        yield http_client.fetch(
-            fe_url,
-            method="POST",
-            headers={"X-Grouper-User": plebe},
-            body=urlencode({"name": "service_account", "description": "*", "machine_set": "*"}),
-        )
-    # But group members can create service accounts
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": owner},
-        body=urlencode({"name": "service_account", "description": "*", "machine_set": "*"}),
-    )
-    assert resp.code == 200
-
-    # Unrelated people cannot grant a permission.
-    fe_url = url(base_url, "/groups/team-sre/service/service@a.co/grant")
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": plebe},
-        body=urlencode({"permission": "team-sre", "argument": "*"}),
-    )
-    assert resp.code == 200
-    graph.update_from_db(session)
-    metadata = graph.get_user_details("service@a.co")
-    assert metadata["permissions"] == []
-
-    # Even group owners cannot grant an unrelated permission.
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": owner},
-        body=urlencode({"permission": "other-perm", "argument": "*"}),
-    )
-    assert resp.code == 200
-    graph.update_from_db(session)
-    metadata = graph.get_user_details("service@a.co")
-    assert metadata["permissions"] == []
-
-    # Group owners can delegate a team permission.
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": owner},
-        body=urlencode({"permission": "team-sre", "argument": "*"}),
-    )
-    assert resp.code == 200
-
-    # Global permission admins still cannot grant an unrelated permission.
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": admin},
-        body=urlencode({"permission": "other-perm", "argument": "*"}),
-    )
-    assert resp.code == 200
-    graph.update_from_db(session)
-    metadata = graph.get_user_details("service@a.co")
-    assert len(metadata["permissions"]) == 1
-
-    # But can delegate a team permission.
-    resp = yield http_client.fetch(
-        fe_url,
-        method="POST",
-        headers={"X-Grouper-User": admin},
-        body=urlencode({"permission": "ssh", "argument": "*"}),
-    )
-    assert resp.code == 200
-
-    # Check that the permissions are reflected in the graph.
-    graph.update_from_db(session)
-    metadata = graph.get_user_details("service@a.co")
-    perms = [(p["permission"], p["argument"]) for p in metadata["permissions"]]
-    assert sorted(perms) == [("ssh", "*"), ("team-sre", "*")]
-
-    # Find the mapping IDs of the two permissions.
-    service_account = ServiceAccount.get(session, name="service@a.co")
-    perms = service_account_permissions(session, service_account)
-
-    # Unrelated people cannot revoke a permission.
-    fe_url = url(
-        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[0].grant_id)
-    )
-    with pytest.raises(HTTPError):
-        yield http_client.fetch(
-            fe_url, method="POST", headers={"X-Grouper-User": plebe}, body=urlencode({})
-        )
-
-    # But the group owner and a global admin can.
-    resp = yield http_client.fetch(
-        fe_url, method="POST", headers={"X-Grouper-User": admin}, body=urlencode({})
-    )
-    assert resp.code == 200
-    fe_url = url(
-        base_url, "/groups/team-sre/service/service@a.co/revoke/{}".format(perms[1].grant_id)
-    )
-    resp = yield http_client.fetch(
-        fe_url, method="POST", headers={"X-Grouper-User": owner}, body=urlencode({})
-    )
-    assert resp.code == 200
-
-    # This should have removed all the permissions.
-    graph.update_from_db(session)
-    metadata = graph.get_user_details("service@a.co")
-    assert metadata["permissions"] == []
 
 
 class MachineSetPlugin(BasePlugin):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -187,6 +187,18 @@ class SetupTest(object):
         )
         edge.add(self.session)
 
+    def remove_user_from_group(self, user, group):
+        # type: (str, str) -> None
+        user_obj = User.get(self.session, name=user)
+        assert user_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+        self.session.query(GroupEdge).filter(
+            GroupEdge.group_id == group_obj.id,
+            GroupEdge.member_type == OBJ_TYPES["User"],
+            GroupEdge.member_pk == user_obj.id,
+        ).delete()
+
     def grant_permission_to_group(self, permission, argument, group):
         # type: (str, str, str) -> None
         self.create_group(group)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -233,17 +233,10 @@ class SetupTest(object):
     def grant_permission_to_service_account(self, permission, argument, service_account):
         # type: (str, str, str) -> None
         self.create_permission(permission)
-        permission_obj = Permission.get(self.session, name=permission)
-        assert permission_obj
-        user_obj = User.get(self.session, name=service_account)
-        assert user_obj, "Must create the service account first"
-        assert user_obj.is_service_account
-        grant = ServiceAccountPermissionMap(
-            permission_id=permission_obj.id,
-            service_account_id=user_obj.service_account.id,
-            argument=argument,
+        permission_grant_repository = self.repository_factory.create_permission_grant_repository()
+        permission_grant_repository.grant_permission_to_service_account(
+            permission, argument, service_account
         )
-        grant.add(self.session)
 
     def add_metadata_to_user(self, key, value, user):
         # type: (str, str, str) -> None

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -79,6 +79,16 @@ def test_success(setup):
     assert linkage is not None
     assert linkage.group_id == group.id
 
+    # Check that the user appears in the graph.
+    setup.graph.update_from_db(setup.session)
+    metadata = setup.graph.user_metadata["service@svc.localhost"]
+    assert metadata["enabled"]
+    assert metadata["service_account"]["description"] == "description"
+    assert metadata["service_account"]["machine_set"] == "machine-set"
+    assert metadata["service_account"]["owner"] == "some-group"
+    group_details = setup.graph.get_group_details("some-group")
+    assert group_details["service_accounts"] == ["service@svc.localhost"]
+
 
 def test_add_domain(setup):
     # type: (SetupTest) -> None

--- a/tests/usecases/grant_permission_to_service_account_test.py
+++ b/tests/usecases/grant_permission_to_service_account_test.py
@@ -1,0 +1,336 @@
+from typing import TYPE_CHECKING
+
+from mock import ANY, call, MagicMock
+
+from grouper.constants import ARGUMENT_VALIDATION, PERMISSION_ADMIN
+from grouper.entities.permission_grant import GroupPermissionGrant, ServiceAccountPermissionGrant
+
+if TYPE_CHECKING:
+    from tests.setup import SetupTest
+
+
+def test_permission_grants_for_group(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group("some-permission", "one", "some-group")
+        setup.grant_permission_to_group("some-permission", "two", "some-group")
+        setup.grant_permission_to_group("other-permission", "*", "some-group")
+        setup.grant_permission_to_group("parent-permission", "foo", "parent-group")
+        setup.add_group_to_group("some-group", "parent-group")
+        setup.create_group("other-group")
+        setup.create_user("gary@a.co")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    expected = [
+        GroupPermissionGrant(
+            group="some-group",
+            permission="other-permission",
+            argument="*",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="parent-permission",
+            argument="foo",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="some-permission",
+            argument="one",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="some-permission",
+            argument="two",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+    ]
+    assert sorted(usecase.permission_grants_for_group("some-group")) == expected
+    assert usecase.permission_grants_for_group("other-group") == []
+
+
+def test_service_account_exists_with_owner(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_service_account("service@svc.localhost", "some-group")
+        setup.create_service_account("other@svc.localhost", "some-group")
+        setup.create_group("other-group")
+        setup.disable_service_account("other@svc.localhost")
+        setup.create_user("gary@a.co")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    assert usecase.service_account_exists_with_owner("service@svc.localhost", "some-group")
+    assert not usecase.service_account_exists_with_owner("service@svc.localhost", "bogus-group")
+    assert not usecase.service_account_exists_with_owner("service@svc.localhost", "other-group")
+    assert not usecase.service_account_exists_with_owner("other@svc.localhost", "some-group")
+    assert not usecase.service_account_exists_with_owner("bogus@svc.localhost", "some-group")
+
+
+def test_success(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+        setup.grant_permission_to_group("some-permission", "argument", "some-group")
+        setup.create_permission("other-permission")
+        setup.add_user_to_group("zorkian@a.co", "admins")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.create_service_account("service@svc.localhost", "some-group")
+        setup.create_service_account("admin@svc.localhost", "admins")
+        setup.grant_permission_to_service_account(PERMISSION_ADMIN, "", "admin@svc.localhost")
+
+    service = setup.service_factory.create_service_account_service()
+    assert service.permission_grants_for_service_account("service@svc.localhost") == []
+
+    # Delegation from a group member.
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.granted_permission_to_service_account(
+            "some-permission", "argument", "service@svc.localhost"
+        )
+    ]
+    expected = [
+        ServiceAccountPermissionGrant(
+            service_account="service@svc.localhost",
+            permission="some-permission",
+            argument="argument",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    ]
+    setup.graph.update_from_db(setup.session)
+    assert service.permission_grants_for_service_account("service@svc.localhost") == expected
+
+    # Delegation from permission admin.
+    mock_ui.reset_mock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "zorkian@a.co", mock_ui
+    )
+    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase.grant_permission_to_service_account(
+        "other-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.granted_permission_to_service_account(
+            "other-permission", "argument", "service@svc.localhost"
+        )
+    ]
+    expected.append(
+        ServiceAccountPermissionGrant(
+            service_account="service@svc.localhost",
+            permission="other-permission",
+            argument="argument",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    )
+    setup.graph.update_from_db(setup.session)
+    assert service.permission_grants_for_service_account("service@svc.localhost") == expected
+
+    # Delegation from a permission admin that happens to be a service account.
+    mock_ui.reset_mock()
+    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "admin@svc.localhost", mock_ui
+    )
+    usecase.grant_permission_to_service_account("other-permission", "*", "service@svc.localhost")
+    assert mock_ui.mock_calls == [
+        call.granted_permission_to_service_account(
+            "other-permission", "*", "service@svc.localhost"
+        )
+    ]
+    expected.append(
+        ServiceAccountPermissionGrant(
+            service_account="service@svc.localhost",
+            permission="other-permission",
+            argument="*",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    )
+    setup.graph.update_from_db(setup.session)
+    assert service.permission_grants_for_service_account("service@svc.localhost") == expected
+
+
+def test_wildcard(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+        setup.grant_permission_to_group("some-permission", "*", "some-group")
+        setup.create_service_account("service@svc.localhost", "some-group")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.granted_permission_to_service_account(
+            "some-permission", "argument", "service@svc.localhost"
+        )
+    ]
+    expected = [
+        ServiceAccountPermissionGrant(
+            service_account="service@svc.localhost",
+            permission="some-permission",
+            argument="argument",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    ]
+    setup.graph.update_from_db(setup.session)
+    service = setup.service_factory.create_service_account_service()
+    assert service.permission_grants_for_service_account("service@svc.localhost") == expected
+
+
+def test_invalid_argument(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.create_service_account("service@svc.localhost", "some-group")
+        setup.create_permission("some-permission")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.grant_permission_to_service_account("some-permission", "@@@@", "service@svc.localhost")
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_invalid_argument(
+            "some-permission",
+            "@@@@",
+            "service@svc.localhost",
+            "Permission argument is not valid (does not match {})".format(ARGUMENT_VALIDATION),
+        )
+    ]
+
+
+def test_permission_denied(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+        setup.create_service_account("service@svc.localhost", "some-group")
+        setup.create_permission("some-permission")
+
+    # User with no special permissions.
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    assert not usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_permission_denied(
+            "some-permission", "argument", "service@svc.localhost", "Permission denied"
+        )
+    ]
+
+    # Service account with no special permissions.
+    mock_ui.reset_mock()
+    assert not usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "service@svc.localhost", mock_ui
+    )
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_permission_denied(
+            "some-permission", "argument", "service@svc.localhost", "Permission denied"
+        )
+    ]
+
+    # Add the user to the group, but don't delegate the permission to the group.  The user should
+    # now be able to grant permissions in general, but not this permission in particular.
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    mock_ui.reset_mock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_permission_denied(
+            "some-permission",
+            "argument",
+            "service@svc.localhost",
+            "The group some-group does not have that permission",
+        )
+    ]
+
+
+def test_unknown_permission(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.create_service_account("service@svc.localhost", "some-group")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_permission_not_found(
+            "some-permission", "service@svc.localhost"
+        )
+    ]
+
+
+def test_unknown_service_account(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "admins")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
+        setup.create_permission("some-permission")
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.grant_permission_to_service_account(
+        "some-permission", "argument", "service@svc.localhost"
+    )
+    assert mock_ui.mock_calls == [
+        call.grant_permission_to_service_account_failed_service_account_not_found(
+            "service@svc.localhost"
+        )
+    ]


### PR DESCRIPTION
Since this now uses the graph properly, it also allows delegating
permissions that are inherited by the group from a parent, rather
than forcing the permission to be granted directly to the group.

I'm doing something a little unusual here in the handler by stashing
some information into the handler object in the post() method that's
then used by the callback methods.  Ideally, everything in the
callback comes from the use case, but in this case the group owner
and the list of permissable permissions to grant are quite strange
to return as part of every error message from the usecase, and (in
the case of the list of grantable permissions) potentially expensive
to recalculate.  This seemed less awkward than forcing the usecase
to calculate and pass them around.