### PR TITLE
Improve username validation

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -13,7 +13,7 @@ NAME2_VALIDATION = _NAME_VALIDATION.format("name2")
 # These regexes are specifically to validate usernames.  SERVICE_ACCOUNT_VALIDATION is the same as
 # USERNAME_VALIDATION but with a distinct capture group name so that it doesn't conflict with a
 # NAME_VALIDATION regex in the same URL.
-USERNAME_VALIDATION = r"(?P<name>[\w-]+@\w+[\.\w]+)"
+USERNAME_VALIDATION = r"(?P<name>[\w-]+@(?:[\w\-]+\.)+\w{2,})"
 SERVICE_ACCOUNT_VALIDATION = r"(?P<accountname>[\w-]+@\w+[\.\w]+)"
 
 # UserToken validators

--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -13,8 +13,16 @@ NAME2_VALIDATION = _NAME_VALIDATION.format("name2")
 # These regexes are specifically to validate usernames.  SERVICE_ACCOUNT_VALIDATION is the same as
 # USERNAME_VALIDATION but with a distinct capture group name so that it doesn't conflict with a
 # NAME_VALIDATION regex in the same URL.
+#
+# This matches a subset of valid email addresses, currently matching Dropbox internal needs, and
+# may need to become more flexible in the future (via configuration, for instance).  It disallows
+# periods in the LHS of the identity for Dropbox policy reasons.
+#
+# + is disallowed in the LHS of the email address on the grounds that for the internal corporate
+# use case, it doesn't make sense to allow people to create a user whose identity is an alias, or
+# to allow people to potentially create multiple users mapping to the same underlying account.
 USERNAME_VALIDATION = r"(?P<name>[\w-]+@(?:[\w\-]+\.)+\w{2,})"
-SERVICE_ACCOUNT_VALIDATION = r"(?P<accountname>[\w-]+@\w+[\.\w]+)"
+SERVICE_ACCOUNT_VALIDATION = r"(?P<accountname>[\w-]+@(?:[\w\-]+\.)+\w{2,})"
 
 # UserToken validators
 TOKEN_SECRET_VALIDATION = r"(?P<token_secret>[a-f0-9]{40})"

--- a/tests/constants_test.py
+++ b/tests/constants_test.py
@@ -1,18 +1,25 @@
 import re
 
-from grouper.constants import USERNAME_VALIDATION
+from grouper.constants import SERVICE_ACCOUNT_VALIDATION, USERNAME_VALIDATION
 
 
 def test_username_validation() -> None:
-    regex = f"^{USERNAME_VALIDATION}$"
+    user_regex = f"^{USERNAME_VALIDATION}$"
+    service_regex = f"^{SERVICE_ACCOUNT_VALIDATION}$"
 
     good_users = [
         "example@example.com",
         "jane@a.b.c.d.co",  # subdomains
         "bobby@yahoo-inc.com",  # dashes in domains
+        "under_sco_re@a.co",  # underscores
     ]
     for user in good_users:
-        assert re.match(regex, user)
+        match = re.match(user_regex, user)
+        assert match
+        assert match.group("name") == user
+        match = re.match(service_regex, user)
+        assert match
+        assert match.group("accountname") == user
 
     bad_users = [
         "nodomain",  # no domain part
@@ -24,4 +31,5 @@ def test_username_validation() -> None:
         "example@.example.com",  # period after @
     ]
     for user in bad_users:
-        assert not re.match(regex, user)
+        assert not re.match(user_regex, user)
+        assert not re.match(service_regex, user)

--- a/tests/constants_test.py
+++ b/tests/constants_test.py
@@ -1,0 +1,27 @@
+import re
+
+from grouper.constants import USERNAME_VALIDATION
+
+
+def test_username_validation() -> None:
+    regex = f"^{USERNAME_VALIDATION}$"
+
+    good_users = [
+        "example@example.com",
+        "jane@a.b.c.d.co",  # subdomains
+        "bobby@yahoo-inc.com",  # dashes in domains
+    ]
+    for user in good_users:
+        assert re.match(regex, user)
+
+    bad_users = [
+        "nodomain",  # no domain part
+        "bad@domain",  # invalid domain part
+        "foo@u.s",  # single character top-level domain
+        "johnny.appleseed@a.co",  # period in username
+        "jackbrown+new@a.co",  # gmail style aliases
+        "example@example..com",  # doubled period
+        "example@.example.com",  # period after @
+    ]
+    for user in bad_users:
+        assert not re.match(regex, user)


### PR DESCRIPTION
Allow dashes in domain names, and check that the RHS of the username
is a superficially valid domain (has at least two parts, final TLD is
at least two characters long, no empty segments of domain).