### PR TITLE
Strip whitespace surrounding permission arguments

### DIFF
--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -51,15 +51,12 @@ class PermissionRequest(GrouperHandler):
         if permission.name not in args_by_perm:
             raise HTTPError(status_code=400, reason="that permission was not in the form")
 
+        argument = form.argument.data.strip()
+
         # save off request
         try:
             request = permissions.create_request(
-                self.session,
-                self.current_user,
-                group,
-                permission,
-                form.argument.data,
-                form.reason.data,
+                self.session, self.current_user, group, permission, argument, form.reason.data
             )
         except permissions.RequestAlreadyGranted:
             alerts = [Alert("danger", "This group already has this permission and argument.")]
@@ -75,7 +72,7 @@ class PermissionRequest(GrouperHandler):
                 "prefilled perm+arg have no owner",
                 group_name=group.name,
                 permission_name=permission.name,
-                argument=form.argument.data,
+                argument=argument,
             )
             alerts = [
                 Alert(

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -55,10 +55,12 @@ class PermissionsGrant(GrouperHandler):
         if not permission:
             return self.notfound()  # Shouldn't happen.
 
+        argument = form.argument.data.strip()
+
         allowed = False
         for perm in grantable:
             if perm[0].name == permission.name:
-                if matches_glob(perm[1], form.data["argument"]):
+                if matches_glob(perm[1], argument):
                     allowed = True
                     break
         if not allowed:
@@ -93,7 +95,7 @@ class PermissionsGrant(GrouperHandler):
                 )
 
         try:
-            grant_permission(self.session, group.id, permission.id, argument=form.data["argument"])
+            grant_permission(self.session, group.id, permission.id, argument=argument)
         except IntegrityError:
             self.session.rollback()
             form.argument.errors.append("Permission and Argument already mapped to this group.")

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -295,7 +295,7 @@ enabled. Membership in this group is regularly reviewed.
         </div>
         {% if can_control %}
         <div class="panel-footer">
-            <a class="btn btn-default btn-sm add-service-account"
+            <a id="add-service-account" class="btn btn-default btn-sm add-service-account"
                href="/groups/{{ groupname }}/service/create">
                 <span class="glyphicon glyphicon-plus"></span> Add Service Account
             </a>
@@ -594,12 +594,14 @@ enabled. Membership in this group is regularly reviewed.
         {% if group and (can_grant or is_member) %}
         <div class='panel-footer'>
             {% if can_grant %}
-            <a class="btn btn-default btn-sm" href="/permissions/grant/{{ group.name }}">
+            <a id="add-permission" class="btn btn-default btn-sm"
+               href="/permissions/grant/{{ group.name }}">
                 <span class="glyphicon glyphicon-plus"></span> Add Permission
             </a>
             {% endif %}
             {% if is_member%}
-            <a class="btn btn-default btn-sm" href="/groups/{{ group.name }}/permission/request">
+            <a id="request-permission" class="btn btn-default btn-sm"
+               href="/groups/{{ group.name }}/permission/request">
                 <span class="glyphicon glyphicon-plus"></span> Request Permission
             </a>
             {% endif %}

--- a/grouper/fe/templates/permission-grant.html
+++ b/grouper/fe/templates/permission-grant.html
@@ -17,7 +17,7 @@
             <h3 class="panel-title">Grant Permission to {{ group.name }}</h3>
        </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form"
+            <form id="grant-form" class="form-horizontal" role="form"
                   method="post" action="/permissions/grant/{{ group.name }}">
                 {% include "forms/permission-grant.html" %}
                 <div class="form-permission">

--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -68,7 +68,7 @@
                     <h3 class="panel-title">Update Request</h3>
                </div>
                 <div class="panel-body">
-                    <form class="form-horizontal" role="form"
+                    <form id="update-form" class="form-horizontal" role="form"
                           method="post" action="/permissions/requests/{{request.id}}">
                         {% include "forms/permission-request-update.html" %}
                         <div class="form-group">

--- a/itests/fe/group_view_test.py
+++ b/itests/fe/group_view_test.py
@@ -147,7 +147,9 @@ def test_grant_permission(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) 
         assert rows[0].argument in ("arg u ment", "arg u  ment")  # browser messes with whitespace
 
     # Check directly in the database to make sure the whitespace is stripped, since we may not be
-    # able to see it via the browser.
+    # able to see it via the browser.  We need to explicitly reopen the database since otherwise
+    # SQLite doesn't always see changes written by the frontend.
+    setup.reopen_database()
     permission_grant_repository = setup.sql_repository_factory.create_permission_grant_repository()
     grants = permission_grant_repository.permission_grants_for_group("other-group")
     assert grants == [

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -122,7 +122,9 @@ def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
         assert grant.source == "(direct)"
 
     # Check directly in the database to make sure the whitespace is stripped, since we may not be
-    # able to see it via the browser.
+    # able to see it via the browser.  We need to explicitly reopen the database since otherwise
+    # SQLite doesn't always see changes written by the frontend.
+    setup.reopen_database()
     permission_grant_repository = setup.sql_repository_factory.create_permission_grant_repository()
     grants = permission_grant_repository.permission_grants_for_group("some-group")
     assert grants == [

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -1,7 +1,12 @@
 from typing import TYPE_CHECKING
 
+from mock import ANY
+
+from grouper.entities.permission_grant import GroupPermissionGrant
+from itests.pages.groups import GroupViewPage
 from itests.pages.permission import PermissionPage
 from itests.pages.permission_request import PermissionRequestPage
+from itests.pages.permission_requests import PermissionRequestsPage, PermissionRequestUpdatePage
 from itests.setup import frontend_server
 from tests.url_util import url
 
@@ -68,3 +73,64 @@ def test_limited_arguments(tmpdir, setup, browser):
         page.submit_request()
 
         assert browser.current_url.endswith("/permissions/requests/1")
+
+
+def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_group("some-group")
+        setup.create_permission("some-permission")
+        setup.add_user_to_group("gary@a.co", "some-group", "owner")
+        setup.add_user_to_group("zorkian@a.co", "admins")
+        setup.grant_permission_to_group("grouper.permission.grant", "some-permission", "admins")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/some-permission"))
+
+        permission_page = PermissionPage(browser)
+        assert permission_page.subheading == "some-permission"
+        permission_page.button_to_request_this_permission.click()
+
+        permission_request_page = PermissionRequestPage(browser)
+        permission_request_page.set_select_value("group_name", "some-group")
+        permission_request_page.fill_field("argument", "  arg u  ment  ")
+        permission_request_page.fill_field("reason", "testing whitespace")
+        permission_request_page.submit_request()
+
+    with frontend_server(tmpdir, "zorkian@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/requests?status=pending"))
+
+        requests_page = PermissionRequestsPage(browser)
+        request_rows = requests_page.request_rows
+        assert len(request_rows) == 1
+        request = request_rows[0]
+        request.click_modify_link()
+
+        modify_page = PermissionRequestUpdatePage(browser)
+        modify_page.set_status("actioned")
+        modify_page.set_reason("testing whitespace")
+        modify_page.submit()
+
+        browser.get(url(frontend_url, "/groups/some-group?refresh=yes"))
+        group_page = GroupViewPage(browser)
+        permission_rows = group_page.find_permission_rows("some-permission")
+        assert len(permission_rows) == 1
+        grant = permission_rows[0]
+        assert grant.name == "some-permission"
+        assert grant.argument in ("arg u ment", "arg u  ment")  # browser messes with whitespace
+        assert grant.source == "(direct)"
+
+    # Check directly in the database to make sure the whitespace is stripped, since we may not be
+    # able to see it via the browser.
+    permission_grant_repository = setup.sql_repository_factory.create_permission_grant_repository()
+    grants = permission_grant_repository.permission_grants_for_group("some-group")
+    assert grants == [
+        GroupPermissionGrant(
+            group="some-group",
+            permission="some-permission",
+            argument="arg u  ment",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    ]

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from mock import ANY
 
+from grouper.constants import PERMISSION_GRANT
 from grouper.entities.permission_grant import GroupPermissionGrant
 from itests.pages.groups import GroupViewPage
 from itests.pages.permission import PermissionPage
@@ -25,7 +26,7 @@ def test_requesting_permission(tmpdir, setup, browser):
         setup.create_user("brhodes@a.co")
 
         setup.add_user_to_group("brhodes@a.co", "front-end")
-        setup.grant_permission_to_group("grouper.permission.grant", "git.repo.read", "dev-infra")
+        setup.grant_permission_to_group(PERMISSION_GRANT, "git.repo.read", "dev-infra")
 
     with frontend_server(tmpdir, "brhodes@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/git.repo.read"))
@@ -82,7 +83,7 @@ def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
         setup.create_permission("some-permission")
         setup.add_user_to_group("gary@a.co", "some-group", "owner")
         setup.add_user_to_group("zorkian@a.co", "admins")
-        setup.grant_permission_to_group("grouper.permission.grant", "some-permission", "admins")
+        setup.grant_permission_to_group(PERMISSION_GRANT, "some-permission", "admins")
 
     with frontend_server(tmpdir, "gary@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/some-permission"))

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from selenium.webdriver.support.select import Select
@@ -63,8 +65,7 @@ class GroupsViewPage(BasePage):
 
 
 class GroupViewPage(BasePage):
-    def find_member_row(self, name):
-        # type: (str) -> MemberRow
+    def find_member_row(self, name: str) -> MemberRow:
         for row in self.find_elements_by_class_name("member-row"):
             member_row = MemberRow(row)
             if member_row.name == name:
@@ -72,8 +73,9 @@ class GroupViewPage(BasePage):
 
         raise NoSuchElementException("Can't find member with name {}".format(name))
 
-    def find_permission_rows(self, name, argument=None):
-        # type: (str, Optional[str]) -> List[PermissionGrantRow]
+    def find_permission_rows(
+        self, name: str, argument: Optional[str] = None
+    ) -> List[PermissionGrantRow]:
         elements = self.find_elements_by_class_name("permission-row")
         rows = [PermissionGrantRow(el) for el in elements]
 
@@ -84,20 +86,21 @@ class GroupViewPage(BasePage):
 
         return rows
 
-    def get_remove_user_modal(self):
-        # type: () -> RemoveMemberModal
+    def get_remove_user_modal(self) -> RemoveMemberModal:
         element = self.find_element_by_id("removeUserModal")
         return RemoveMemberModal(element)
 
-    def get_audit_modal(self):
-        # type: () -> AuditModal
+    def get_audit_modal(self) -> AuditModal:
         element = self.find_element_by_id("auditModal")
         self.wait_until_visible(element)
         return AuditModal(element)
 
-    def click_add_service_account_button(self):
-        # type: () -> None
-        button = self.find_element_by_class_name("add-service-account")
+    def click_add_permission_button(self) -> None:
+        button = self.find_element_by_id("add-permission")
+        button.click()
+
+    def click_add_service_account_button(self) -> None:
+        button = self.find_element_by_id("add-service-account")
         button.click()
 
 
@@ -139,6 +142,23 @@ class GroupJoinPage(BasePage):
     def submit(self):
         # type: () -> None
         self.form.find_element_by_id("join-btn").click()
+
+
+class PermissionGrantPage(BasePage):
+    @property
+    def form(self) -> WebElement:
+        return self.find_element_by_id("grant-form")
+
+    def set_permission(self, permission: str) -> None:
+        field = Select(self.form.find_element_by_name("permission"))
+        field.select_by_value(permission)
+
+    def set_argument(self, argument: str) -> None:
+        field = self.form.find_element_by_name("argument")
+        field.send_keys(argument)
+
+    def submit(self) -> None:
+        self.form.submit()
 
 
 class GroupRequestsPage(BasePage):

--- a/itests/pages/permission_requests.py
+++ b/itests/pages/permission_requests.py
@@ -1,55 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from selenium.webdriver.support.select import Select
+
 from itests.pages.base import BaseElement, BasePage
+
+if TYPE_CHECKING:
+    from selenium.webdriver.remote.webelement import WebElement
+    from typing import List
 
 
 class PermissionRequestsPage(BasePage):
     @property
-    def request_rows(self):
+    def request_rows(self) -> List[RequestViewRow]:
         all_request_rows = self.find_elements_by_class_name("request-row")
         return [RequestViewRow(row) for row in all_request_rows]
 
     @property
-    def status_change_rows(self):
+    def status_change_rows(self) -> List[StatusChangeRow]:
         all_sc_rows = self.find_elements_by_class_name("request-status-change-row")
         return [StatusChangeRow(row) for row in all_sc_rows]
 
     @property
-    def no_requests_row(self):
+    def no_requests_row(self) -> WebElement:
         return self.find_element_by_class_name("request-dne")
+
+
+class PermissionRequestUpdatePage(BasePage):
+    @property
+    def form(self) -> WebElement:
+        return self.find_element_by_id("update-form")
+
+    def set_status(self, status: str) -> None:
+        field = Select(self.form.find_element_by_name("status"))
+        field.select_by_value(status)
+
+    def set_reason(self, reason: str) -> None:
+        field = self.form.find_element_by_name("reason")
+        field.send_keys(reason)
+
+    def submit(self) -> None:
+        self.form.submit()
 
 
 class RequestViewRow(BaseElement):
     @property
-    def modify_link(self):
+    def modify_link(self) -> str:
         modify = self.find_element_by_class_name("request-modify")
         link = modify.find_element_by_tag_name("a")
         return link.get_attribute("href")
 
     @property
-    def requested(self):
+    def requested(self) -> str:
         return self.find_element_by_class_name("request-requested").text
 
     @property
-    def approvers(self):
+    def approvers(self) -> str:
         return self.find_element_by_class_name("request-approvers").text
 
     @property
-    def status(self):
+    def status(self) -> str:
         return self.find_element_by_class_name("request-status").text
 
     @property
-    def requested_at(self):
+    def requested_at(self) -> str:
         return self.find_element_by_class_name("request-requested-at").text
+
+    def click_modify_link(self) -> None:
+        modify = self.find_element_by_class_name("request-modify")
+        link = modify.find_element_by_tag_name("a")
+        link.click()
 
 
 class StatusChangeRow(BaseElement):
     @property
-    def group(self):
+    def group(self) -> str:
         return self.find_element_by_class_name("request-group").text
 
     @property
-    def who(self):
+    def who(self) -> str:
         return self.find_element_by_class_name("request-who").text
 
     @property
-    def reason(self):
+    def reason(self) -> str:
         return self.find_element_by_class_name("request-reason").text

--- a/itests/setup.py
+++ b/itests/setup.py
@@ -79,7 +79,7 @@ def api_server(tmpdir):
 
     yield "localhost:{}".format(api_port)
 
-    p.kill()
+    p.terminate()
 
 
 @contextmanager
@@ -140,7 +140,7 @@ def frontend_server(tmpdir, user):
     yield "http://localhost:{}".format(proxy_port)
 
     for p in subprocesses:
-        p.kill()
+        p.terminate()
 
 
 def selenium_browser():


### PR DESCRIPTION
Whitespace at the start or end of a permission argument is invisible on the web site but was stored in the database and visible via the API, which can cause all sorts of confusing problems. Strip it when permission grants are requested or created.

Take this approach rather than rejecting it because it's easy to accidentally introduce whitespace while cutting and pasting, and removing leading and trailing whitespace doesn't feel surprising.

The new permission request page uses Tornado's get_argument(), which strips whitespace by default, but it's not obvious that it always goes through that code path.  Explicitly strip the argument and add an end-to-end test of the permission request and approval flow that confirms that leading and trailing whitespace in the permission grant argument is stripped but internal whitespace is preserved.

Use PERMISSION_GRANT in a few more places rather than hard-coding the permission name.