### PR TITLE
Remove explicit u markings on strings

### DIFF
--- a/grouper/fe/handlers/users_public_key.py
+++ b/grouper/fe/handlers/users_public_key.py
@@ -5,7 +5,7 @@ from grouper.models.user import User
 
 
 class UsersPublicKey(GrouperHandler):
-    @ensure_audit_security(u"public_keys")
+    @ensure_audit_security("public_keys")
     def get(self):
         form = UsersPublicKeyForm(self.request.arguments)
 

--- a/grouper/fe/handlers/users_user_tokens.py
+++ b/grouper/fe/handlers/users_user_tokens.py
@@ -5,7 +5,7 @@ from grouper.models.user_token import UserToken
 
 
 class UsersUserTokens(GrouperHandler):
-    @ensure_audit_security(u"user_tokens")
+    @ensure_audit_security("user_tokens")
     def get(self):
         form = UsersUserTokenForm(self.request.arguments)
 

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -33,8 +33,8 @@ def test_requesting_permission(tmpdir, setup, browser):
         page2 = PermissionRequestPage(browser)
         assert page2.heading == "Permissions"
         assert page2.subheading == "Request Permission"
-        assert page2.get_option_values("group_name") == [u"", u"front-end"]
-        assert page2.get_option_values("permission_name") == [u"git.repo.read"]
+        assert page2.get_option_values("group_name") == ["", "front-end"]
+        assert page2.get_option_values("permission_name") == ["git.repo.read"]
 
         page2.set_select_value("group_name", "front-end")
         page2.fill_field("argument", "server")

--- a/itests/pages/permission.py
+++ b/itests/pages/permission.py
@@ -5,4 +5,4 @@ class PermissionPage(BasePage):
     @property
     def button_to_request_this_permission(self):
         buttons = self.find_elements_by_class_name("btn")
-        return next(b for b in buttons if b.text == u"Request this permission")
+        return next(b for b in buttons if b.text == "Request this permission")

--- a/tests/api/handlers_test.py
+++ b/tests/api/handlers_test.py
@@ -43,7 +43,7 @@ def test_health(session, http_client, base_url):  # noqa: F811
 @pytest.mark.gen_test
 def test_users(users, http_client, base_url):  # noqa: F811
     all_users = sorted(list(users.keys()) + ["service@a.co"])
-    users_wo_role = sorted([u for u in users if u != u"role@a.co"])
+    users_wo_role = sorted([u for u in users if u != "role@a.co"])
 
     api_url = url(base_url, "/users")
     resp = yield http_client.fetch(api_url)

--- a/tests/ctl/group_test.py
+++ b/tests/ctl/group_test.py
@@ -17,16 +17,16 @@ def test_group_add_remove_member(session, tmpdir, users, groups):  # noqa: F811
     groupname = "team-sre"
 
     # add
-    assert (u"User", username) not in groups[groupname].my_members()
+    assert ("User", username) not in groups[groupname].my_members()
     call_main(session, tmpdir, "group", "add_member", "--member", groupname, username)
     all_members = Group.get(session, name=groupname).my_members()
-    assert (u"User", username) in all_members
-    _, _, _, role, _, _ = all_members[(u"User", username)]
+    assert ("User", username) in all_members
+    _, _, _, role, _, _ = all_members[("User", username)]
     assert GROUP_EDGE_ROLES[role] == "member"
 
     # remove
     call_main(session, tmpdir, "group", "remove_member", groupname, username)
-    assert (u"User", username) not in Group.get(session, name=groupname).my_members()
+    assert ("User", username) not in Group.get(session, name=groupname).my_members()
 
 
 @patch("grouper.group_member.get_plugin_proxy")
@@ -37,16 +37,16 @@ def test_group_add_remove_owner(get_plugin_proxy, session, tmpdir, users, groups
     groupname = "team-sre"
 
     # add
-    assert (u"User", username) not in groups[groupname].my_members()
+    assert ("User", username) not in groups[groupname].my_members()
     call_main(session, tmpdir, "group", "add_member", "--owner", groupname, username)
     all_members = Group.get(session, name=groupname).my_members()
-    assert (u"User", username) in all_members
-    _, _, _, role, _, _ = all_members[(u"User", username)]
+    assert ("User", username) in all_members
+    _, _, _, role, _, _ = all_members[("User", username)]
     assert GROUP_EDGE_ROLES[role] == "owner"
 
     # remove (fails)
     call_main(session, tmpdir, "group", "remove_member", groupname, username)
-    assert (u"User", username) in Group.get(session, name=groupname).my_members()
+    assert ("User", username) in Group.get(session, name=groupname).my_members()
 
 
 def test_group_bulk_add_remove(session, tmpdir, users, groups):  # noqa: F811
@@ -70,11 +70,11 @@ def test_group_name_checks(session, tmpdir, users, groups):  # noqa: F811
 
     # check user/group name
     call_main(session, tmpdir, "group", "add_member", "--member", "invalid group name", username)
-    assert (u"User", username) not in Group.get(session, name=groupname).my_members()
+    assert ("User", username) not in Group.get(session, name=groupname).my_members()
 
     bad_username = "not_a_valid_username"
     call_main(session, tmpdir, "group", "add_member", "--member", groupname, bad_username)
-    assert (u"User", bad_username) not in Group.get(session, name=groupname).my_members()
+    assert ("User", bad_username) not in Group.get(session, name=groupname).my_members()
 
 
 def test_group_logdump(session, tmpdir, users, groups):  # noqa: F811

--- a/tests/ctl/misc_test.py
+++ b/tests/ctl/misc_test.py
@@ -54,7 +54,7 @@ def test_user_status_changes(session, tmpdir, users, groups):  # noqa: F811
     # re-enable the account, preserving memberships
     call_main(session, tmpdir, "user", "enable", "--preserve-membership", username)
     assert User.get(session, name=username).enabled
-    assert (u"User", username) in groups[groupname].my_members()
+    assert ("User", username) in groups[groupname].my_members()
 
     # enabling an active account is a no-op
     call_main(session, tmpdir, "user", "enable", username)
@@ -64,7 +64,7 @@ def test_user_status_changes(session, tmpdir, users, groups):  # noqa: F811
     call_main(session, tmpdir, "user", "disable", username)
     call_main(session, tmpdir, "user", "enable", username)
     assert User.get(session, name=username).enabled
-    assert (u"User", username) not in groups[groupname].my_members()
+    assert ("User", username) not in groups[groupname].my_members()
 
 
 def test_user_public_key(session, tmpdir, users):  # noqa: F811

--- a/tests/ctl/user_test.py
+++ b/tests/ctl/user_test.py
@@ -16,8 +16,8 @@ def test_group_disable_group_owner(get_plugin_proxy, session, tmpdir, users, gro
 
     # add
     call_main(session, tmpdir, "group", "add_member", "--owner", groupname, username)
-    assert (u"User", username) in Group.get(session, name=groupname).my_members()
+    assert ("User", username) in Group.get(session, name=groupname).my_members()
 
     # disable (fails)
     call_main(session, tmpdir, "user", "disable", username)
-    assert (u"User", username) in Group.get(session, name=groupname).my_members()
+    assert ("User", username) in Group.get(session, name=groupname).my_members()

--- a/tests/groups_test.py
+++ b/tests/groups_test.py
@@ -256,7 +256,7 @@ def test_graph_cycle_indirect(session, graph, users, groups):  # noqa: F811
 @pytest.mark.gen_test
 def test_graph_disable(session, graph, groups, http_client, base_url):  # noqa: F811
     """ Test that disabled groups work with the graph as expected."""
-    groupname = u"serving-team"
+    groupname = "serving-team"
 
     graph.update_from_db(session)
     old_groups = graph.groups

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -361,7 +361,7 @@ def test_permission_request_flow(
     assert resp.code == 200
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
-    assert_same_recipients(emails, [u"testuser@a.co", u"security-team@a.co"])
+    assert_same_recipients(emails, ["testuser@a.co", "security-team@a.co"])
 
     perms = _load_permissions_by_group_name(session, "serving-team")
     assert len(perms) == 1
@@ -392,7 +392,7 @@ def test_permission_request_flow(
     assert "grantable.one" in perms, "requested permission shouldn't be granted immediately"
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
-    assert_same_recipients(emails, [u"zorkian@a.co"])
+    assert_same_recipients(emails, ["zorkian@a.co"])
 
     # (re)REQUEST: 'grantable.one', 'some argument' for 'serving-team'
     groupname = "serving-team"
@@ -438,9 +438,7 @@ def test_permission_request_flow(
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
     # because tech-ops team doesn't have an email, all of its members should get emailed instead
-    assert_same_recipients(
-        emails, [u"testuser@a.co", u"zay@a.co", u"gary@a.co", u"figurehead@a.co"]
-    )
+    assert_same_recipients(emails, ["testuser@a.co", "zay@a.co", "gary@a.co", "figurehead@a.co"])
 
     perms = _load_permissions_by_group_name(session, "serving-team")
     assert len(perms) == 2
@@ -466,7 +464,7 @@ def test_permission_request_flow(
     assert resp.code == 200
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
-    assert_same_recipients(emails, [u"zorkian@a.co"])
+    assert_same_recipients(emails, ["zorkian@a.co"])
 
     perms = _load_permissions_by_group_name(session, "serving-team")
     assert len(perms) == 2
@@ -506,7 +504,7 @@ def test_limited_permissions(
     assert resp.code == 200
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
-    assert_same_recipients(emails, [u"security-team@a.co"])
+    assert_same_recipients(emails, ["security-team@a.co"])
 
 
 @pytest.mark.gen_test
@@ -537,7 +535,7 @@ def test_limited_permissions_global_approvers(
     assert resp.code == 200
 
     emails = _get_unsent_and_mark_as_sent_emails(session)
-    assert_same_recipients(emails, [u"security-team@a.co"])
+    assert_same_recipients(emails, ["security-team@a.co"])
 
 
 @pytest.mark.gen_test

--- a/tests/users_test.py
+++ b/tests/users_test.py
@@ -144,7 +144,7 @@ def test_graph_disable(
     assert sorted(old_users) == sorted(list(users.keys()) + ["service@a.co"])
 
     # disable a user
-    username = u"oliver@a.co"
+    username = "oliver@a.co"
     fe_url = url(base_url, "/users/{}/disable".format(username))
     resp = yield http_client.fetch(
         fe_url, method="POST", headers={"X-Grouper-User": "zorkian@a.co"}, body=urlencode({})
@@ -166,7 +166,7 @@ def test_user_enable_disable(
     http_client,
     base_url,
 ):
-    username = u"oliver@a.co"
+    username = "oliver@a.co"
     old_groups = sorted(get_groups(graph, username))
     headers_admin = {"X-Grouper-User": "zorkian@a.co"}
     headers_enable = {"X-Grouper-User": "zay@a.co"}


### PR DESCRIPTION
Now that we assume Python 3, everything is unicode, so we can remove
all the explicit markup.