### PR TITLE
Remove all mypy Text types

### DIFF
--- a/grouper/fe/templating.py
+++ b/grouper/fe/templating.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 from base64 import b64encode
 from hashlib import sha256
-from typing import cast, NamedTuple, Optional, Text, TYPE_CHECKING
+from typing import cast, NamedTuple, Optional, TYPE_CHECKING
 
 from grouper.fe.settings import FrontendSettings
 from grouper.templating import BaseTemplateEngine
@@ -10,7 +12,7 @@ if TYPE_CHECKING:
     from typing import Iterable, List
 
 # A web resource that needs to be included in CSP headers.
-Resource = NamedTuple("Resource", [("url", str), ("integrity", Optional[Text])])
+Resource = NamedTuple("Resource", [("url", str), ("integrity", Optional[str])])
 
 # External CSS loaded on every Grouper page.  All URLs are relative to a CDNJS mirror.
 EXTERNAL_CSS = [


### PR DESCRIPTION
Text is no longer necessary since Grouper is Python 3 only and we
can just use str.  Also convert all the files I had to touch to the
new-style type annotation syntax.