### PR TITLE
Don't allow editing the role of a member group

### DIFF
--- a/itests/fe/groups_test.py
+++ b/itests/fe/groups_test.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING
 
 import pytest
+from selenium.common.exceptions import NoSuchElementException
 
 from grouper.entities.group import GroupJoinPolicy
-from itests.pages.exceptions import NoSuchElementException
 from itests.pages.groups import GroupsViewPage
 from itests.setup import frontend_server
 from tests.url_util import url

--- a/itests/fe/users_test.py
+++ b/itests/fe/users_test.py
@@ -1,10 +1,10 @@
 import pytest
+from selenium.common.exceptions import NoSuchElementException
 
 from grouper.constants import AUDIT_SECURITY
 from grouper.models.public_key import PublicKey
 from grouper.permissions import get_or_create_permission
 from itests.fixtures import async_server  # noqa: F401
-from itests.pages.exceptions import NoSuchElementException
 from itests.pages.users import PublicKeysPage, UserViewPage
 from plugins import group_ownership_policy
 from tests.fixtures import (  # noqa: F401

--- a/itests/pages/exceptions.py
+++ b/itests/pages/exceptions.py
@@ -1,2 +1,0 @@
-class NoSuchElementException(Exception):
-    pass

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
 
 from grouper.entities.group import GroupJoinPolicy
 from itests.pages.base import BaseElement, BaseModal, BasePage
-from itests.pages.exceptions import NoSuchElementException
 from itests.pages.permissions import PermissionGrantRow
 
 if TYPE_CHECKING:
@@ -16,26 +16,24 @@ if TYPE_CHECKING:
 
 
 class GroupEditMemberPage(BasePage):
-    def _get_edit_member_form(self):
-        # type: () -> WebElement
+    @property
+    def form(self) -> WebElement:
         return self.find_element_by_class_name("edit-member-form")
 
-    def set_expiration(self, expiration):
-        # type: (str) -> None
-        form = self._get_edit_member_form()
-        field = form.find_element_by_name("expiration")
+    def set_role(self, role: str) -> None:
+        field = Select(self.form.find_element_by_name("role"))
+        field.select_by_visible_text(role)
+
+    def set_expiration(self, expiration: str) -> None:
+        field = self.form.find_element_by_name("expiration")
         field.send_keys(expiration)
 
-    def set_reason(self, reason):
-        # type: (str) -> None
-        form = self._get_edit_member_form()
-        field = form.find_element_by_name("reason")
+    def set_reason(self, reason: str) -> None:
+        field = self.form.find_element_by_name("reason")
         field.send_keys(reason)
 
-    def submit(self):
-        # type: () -> None
-        form = self._get_edit_member_form()
-        form.submit()
+    def submit(self) -> None:
+        self.form.submit()
 
 
 class GroupsViewPage(BasePage):

--- a/itests/pages/users.py
+++ b/itests/pages/users.py
@@ -1,5 +1,6 @@
+from selenium.common.exceptions import NoSuchElementException
+
 from itests.pages.base import BaseElement, BaseModal, BasePage
-from itests.pages.exceptions import NoSuchElementException
 from itests.pages.permissions import PermissionGrantRow
 
 


### PR DESCRIPTION
Limit the choices of role for a member that is a group to only
member, and disable the field.  This avoids uncaught exceptions when
someone tries to change the role to something else.

Add mypy typing to the relevant frontend handler and fix a few other
issues.

Use the standard Selenium exception for NoSuchElementException so
there aren't two exceptions with the same name floating around.