### PR TITLE
Better handle group naming conflicts on rename

### DIFF
--- a/grouper/fe/templates/group-edit.html
+++ b/grouper/fe/templates/group-edit.html
@@ -17,7 +17,7 @@
             <h3 class="panel-title">Edit Group</h3>
        </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form"
+            <form id="edit-form" class="form-horizontal" role="form"
                   method="post" action="/groups/{{group.name}}/edit">
                 {% include "forms/group.html" %}
                 <div class="form-group">

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -57,7 +57,7 @@
     {% if current_user_role['is_approver'] %}
         <a href="/groups/{{group.name}}/add"
            class="btn btn-success"><i class="fa fa-plus-circle"></i> Add Member</a>
-        <a href="/groups/{{group.name}}/edit"
+        <a id="edit-group" href="/groups/{{group.name}}/edit"
            class="btn btn-primary"><i class="fa fa-edit"></i> Edit</a>
     {% endif %}
 

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -15,6 +15,20 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
+class GroupEditPage(BasePage):
+    @property
+    def form(self) -> WebElement:
+        return self.find_element_by_id("edit-form")
+
+    def set_name(self, name: str) -> None:
+        field = self.form.find_element_by_name("groupname")
+        field.clear()
+        field.send_keys(name)
+
+    def submit(self) -> None:
+        self.form.submit()
+
+
 class GroupEditMemberPage(BasePage):
     @property
     def form(self) -> WebElement:
@@ -93,6 +107,10 @@ class GroupViewPage(BasePage):
         element = self.find_element_by_id("auditModal")
         self.wait_until_visible(element)
         return AuditModal(element)
+
+    def click_edit_button(self) -> None:
+        button = self.find_element_by_id("edit-group")
+        button.click()
 
     def click_add_permission_button(self) -> None:
         button = self.find_element_by_id("add-permission")


### PR DESCRIPTION
There was some code that attempted to handle this by catching
IntegrityError on session commit, but it didn't work since the
IntegrityError was often thrown earlier, and I'm not a fan of
catching generic SQL errors and assuming you know what they mean.
Instead, add an explicit pre-check to see if the new name already
exists, and raise an explicit alert if that's the case.

This adds a race condition if someone creates a group under the
new name in the middle of the submission of the edit form, but we
live with race conditions like that throughout Grouper, and the
worst consequence will be an uncaught exception error page.