### PR TITLE
Remove unused parameter to notification function

### DIFF
--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -117,9 +117,7 @@ class BackgroundProcessor(object):
                 user = User.get(session, name=username)
                 assert user
                 auditors_group.add_member(user, user, reason, status="actioned")
-                notify_nonauditor_promoted(
-                    self.settings, session, user, auditors_group, group_names
-                )
+                notify_nonauditor_promoted(self.settings, session, user, auditors_group)
 
         session.commit()
 

--- a/grouper/email_util.py
+++ b/grouper/email_util.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from grouper.models.group import Group
     from grouper.models.group_edge import GroupEdge
     from grouper.settings import Settings
-    from typing import Dict, Iterable, Optional, Set, Union
+    from typing import Dict, Iterable, Optional, Union
 
     Context = Dict[str, Union[bool, int, str, Optional[datetime]]]
 
@@ -313,7 +313,7 @@ def notify_edge_expiration(settings: Settings, session: Session, edge: GroupEdge
 
 
 def notify_nonauditor_promoted(
-    settings: Settings, session: Session, user: User, auditors_group: Group, group_names: Set[str]
+    settings: Settings, session: Session, user: User, auditors_group: Group
 ) -> None:
     """Send notification that a nonauditor has been promoted to be an auditor.
 
@@ -324,7 +324,6 @@ def notify_nonauditor_promoted(
         session: Object for db session.
         user: The user that has been promoted.
         auditors_group: The auditors group
-        group_names: The audited groups in which the user was previously a non-auditor approver.
     """
     member_name = user.username
     recipients = [member_name]


### PR DESCRIPTION
notify_nonauditor_promoted didn't do anything with the set of
group names that explained why the user was promoted.  Remove the
unused parameter.