### PR TITLE
Fix URL in pending request email template

### DIFF
--- a/grouper/fe/templates/email/pending_request.txt
+++ b/grouper/fe/templates/email/pending_request.txt
@@ -10,7 +10,7 @@
     Reason: {{ reason }}
 
 Take action:
-    {{url}}/groups/{{group_name}}/requests/requests/{{ request_id }}
+    {{url}}/groups/{{group_name}}/requests/{{ request_id }}
 
 {% if requester != requested_by %}This request was made by {{ requested_by }}.{% endif %}
 {% endblock %}


### PR DESCRIPTION
The text version of the email had a doubled URL element.