### PR TITLE
Don't allow viewing service accounts under wrong group

### DIFF
--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -25,6 +25,12 @@ class ServiceAccountView(GrouperHandler):
         if not service_account:
             return self.notfound()
 
+        # We don't need the group to be valid to find the service account, but ensure that the
+        # group is the owner of the service account so that we don't generate confusing URLs and
+        # broken information on the view page.
+        if service_account.owner.group_id != group.id:
+            return self.notfound()
+
         user = service_account.user
         self.render(
             "service-account.html",

--- a/tests/service_accounts_test.py
+++ b/tests/service_accounts_test.py
@@ -172,7 +172,7 @@ def test_service_account_fe_edit(
     plebe = "oliver@a.co"
 
     # Unrelated people cannot edit the service account.
-    fe_url = url(base_url, "/groups/security-team/service/service@a.co/edit")
+    fe_url = url(base_url, "/groups/team-sre/service/service@a.co/edit")
     update = {"description": "desc", "machine_set": "machines"}
     with pytest.raises(HTTPError):
         yield http_client.fetch(


### PR DESCRIPTION
Nothing was checking that the group mentioned in the URL when
viewing a service account matched the owner.  Worse, the group from
the URL was used in the page template, so the page would claim the
account was owned by the wrong group.

Verify that the group in the URL matches the owner and return a 404
error if not.