### PR TITLE
Disallow @ in group names

### DIFF
--- a/grouper/fe/handlers/groups_view.py
+++ b/grouper/fe/handlers/groups_view.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import IntegrityError
@@ -12,8 +14,7 @@ if TYPE_CHECKING:
 
 
 class GroupsView(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def get(self, *args: Any, **kwargs: Any) -> None:
         self.handle_refresh()
         offset = int(self.get_argument("offset", 0))
         limit = int(self.get_argument("limit", 100))
@@ -51,10 +52,15 @@ class GroupsView(GrouperHandler):
             enabled=enabled,
         )
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def post(self, *args: Any, **kwargs: Any) -> None:
         form = GroupCreateForm(self.request.arguments)
         if not form.validate():
+            return self.render(
+                "group-create.html", form=form, alerts=self.get_form_alerts(form.errors)
+            )
+
+        if "@" in form.data["groupname"]:
+            form.groupname.errors.append("Group names cannot contain @")
             return self.render(
                 "group-create.html", form=form, alerts=self.get_form_alerts(form.errors)
             )

--- a/grouper/fe/templates/group-create.html
+++ b/grouper/fe/templates/group-create.html
@@ -17,7 +17,7 @@
             <h3 class="panel-title">Create Group</h3>
        </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form"
+            <form id="create-form" class="form-horizontal" role="form"
                   method="post" action="/groups">
                 {% include "forms/group.html" %}
                 <div class="form-group">

--- a/itests/fe/group_create_test.py
+++ b/itests/fe/group_create_test.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from itests.pages.groups import GroupCreatePage, GroupsViewPage, GroupViewPage
+from itests.setup import frontend_server
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_group_create(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups"))
+
+        # First create a group from the view page with an error (an invalid name, doubling as a
+        # test that @ in group names is rejected).  This should leave that page and go to the
+        # dedicated group creation page with the form already set up.
+        groups_page = GroupsViewPage(browser)
+        groups_page.click_create_group_button()
+        create_group_modal = groups_page.get_create_group_modal()
+        create_group_modal.set_group_name("test-group@something")
+        create_group_modal.set_description("some description")
+        create_group_modal.confirm()
+
+        create_page = GroupCreatePage(browser)
+        create_page.has_alert("Group names cannot contain @")
+        create_page.set_group_name("test-group")
+        create_page.submit()
+
+        view_page = GroupViewPage(browser)
+        assert view_page.subheading == "test-group"
+
+        row = view_page.find_member_row("gary@a.co")
+        assert row.role == "owner"
+        assert row.href.endswith("/users/gary@a.co")

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -15,6 +15,20 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
+class GroupCreatePage(BasePage):
+    @property
+    def form(self) -> WebElement:
+        return self.find_element_by_id("create-form")
+
+    def set_group_name(self, name: str) -> None:
+        field = self.form.find_element_by_name("groupname")
+        field.clear()
+        field.send_keys(name)
+
+    def submit(self) -> None:
+        self.form.submit()
+
+
 class GroupEditPage(BasePage):
     @property
     def form(self) -> WebElement:
@@ -232,6 +246,11 @@ class CreateGroupModal(BaseModal):
         # type: (str) -> None
         field = self.form.find_element_by_name("groupname")
         field.send_keys(name)
+
+    def set_description(self, description):
+        # type: (str) -> None
+        field = self.form.find_element_by_name("description")
+        field.send_keys(description)
 
     def set_join_policy(self, join_policy):
         # type: (GroupJoinPolicy) -> None


### PR DESCRIPTION
We cannot remove it from the validation regex because it's used
by role users, and it would make it impossible to view role users.
(We can do this once role users are completely removed.)  Until
then, check for @ specifically in the group creation handler and
reject it.

Add a test for group creation.