### PR TITLE
Modernize all API itests

### DIFF
--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -16,9 +16,11 @@ class GroupRepository(object):
         # type: (Session) -> None
         self.session = session
 
-    def create_group(self, name, description, join_policy):
-        # type: (str, str, GroupJoinPolicy) -> None
-        group = SQLGroup(groupname=name, description=description, canjoin=join_policy.value)
+    def create_group(self, name, description, join_policy, email):
+        # type: (str, str, GroupJoinPolicy, Optional[str]) -> None
+        group = SQLGroup(
+            groupname=name, description=description, canjoin=join_policy.value, email_address=email
+        )
         group.add(self.session)
 
     def get_group(self, name):

--- a/grouper/services/group.py
+++ b/grouper/services/group.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from grouper.entities.permission_grant import GroupPermissionGrant
     from grouper.repositories.group import GroupRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
-    from typing import List
+    from typing import List, Optional
 
 
 class GroupService(GroupInterface):
@@ -21,11 +21,11 @@ class GroupService(GroupInterface):
         self.group_repository = group_repository
         self.permission_grant_repository = permission_grant_repository
 
-    def create_group(self, name, description, join_policy):
-        # type: (str, str, GroupJoinPolicy) -> None
+    def create_group(self, name, description, join_policy, email=None):
+        # type: (str, str, GroupJoinPolicy, Optional[str]) -> None
         if not self.is_valid_group_name(name):
             raise InvalidGroupNameException(name)
-        self.group_repository.create_group(name, description, join_policy)
+        self.group_repository.create_group(name, description, join_policy, email)
 
     def group_has_matching_permission_grant(self, group, permission, argument):
         # type: (str, str, str) -> bool

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -131,8 +131,8 @@ class GroupInterface(metaclass=ABCMeta):
     """Abstract base class for group operations and queries."""
 
     @abstractmethod
-    def create_group(self, name, description, join_policy):
-        # type: (str, str, GroupJoinPolicy) -> None
+    def create_group(self, name, description, join_policy, email=None):
+        # type: (str, str, GroupJoinPolicy, Optional[str]) -> None
         pass
 
     @abstractmethod

--- a/itests/api/groups_test.py
+++ b/itests/api/groups_test.py
@@ -1,28 +1,65 @@
-from itests.fixtures import api_client, async_api_server  # noqa: F401
-from tests.fixtures import (  # noqa: F401
-    graph,
-    groups,
-    permissions,
-    service_accounts,
-    session,
-    standard_graph,
-    users,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from groupy.client import Groupy
+
+from itests.setup import api_server
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from tests.setup import SetupTest
 
 
-def test_get_groups(api_client, groups):  # noqa: F811
-    api_groups = list(api_client.groups)
-    assert sorted(api_groups) == sorted(groups)
+def create_graph(setup: SetupTest) -> None:
+    """Create a simple graph structure with some nesting and permissions."""
+    setup.create_group("team-sre", email="team-sre@a.co")
+    setup.add_user_to_group("gary@a.co", "team-sre", role="owner")
+    setup.add_user_to_group("zay@a.co", "team-sre")
+    setup.add_user_to_group("zorkian@a.co", "team-sre")
+    setup.grant_permission_to_group("ssh", "*", "team-sre")
+    setup.grant_permission_to_group("team-sre", "*", "team-sre")
+    setup.add_group_to_group("team-sre", "serving-team")
+    setup.add_user_to_group("zorkian@a.co", "serving-team", role="owner")
+    setup.create_permission("audited", audited=True)
+    setup.grant_permission_to_group("audited", "", "serving-team")
+    setup.add_group_to_group("serving-team", "team-infra")
+    setup.add_user_to_group("gary@a.co", "team-infra", role="owner")
+    setup.grant_permission_to_group("sudo", "shell", "team-infra")
+    setup.add_group_to_group("serving-team", "all-teams")
+    setup.add_user_to_group("testuser@a.co", "all-teams", role="owner")
 
 
-def test_get_group(api_client):  # noqa: F811
-    group = api_client.groups.get("team-sre")
-    assert sorted(group.groups) == ["all-teams", "serving-team", "team-infra"]
-    assert sorted(group.users) == ["gary@a.co", "zay@a.co", "zorkian@a.co"]
-    assert group.subgroups == {}
+def test_get_groups(tmpdir: LocalPath, setup: SetupTest) -> None:
+    with setup.transaction():
+        create_graph(setup)
 
-    perms = [(p.permission, p.argument) for p in group.permissions]
-    assert sorted(perms) == [("audited", ""), ("ssh", "*"), ("sudo", "shell"), ("team-sre", "*")]
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        assert sorted(api_client.groups) == ["all-teams", "serving-team", "team-infra", "team-sre"]
 
-    assert group.audited
-    assert group.contacts == {"email": "team-sre@a.co"}
+
+def test_get_group(tmpdir: LocalPath, setup: SetupTest) -> None:
+    with setup.transaction():
+        create_graph(setup)
+
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+
+        group = api_client.groups.get("team-sre")
+        assert sorted(group.groups) == ["all-teams", "serving-team", "team-infra"]
+        assert sorted(group.users) == ["gary@a.co", "zay@a.co", "zorkian@a.co"]
+        assert group.subgroups == {}
+        assert group.audited
+        assert group.contacts == {"email": "team-sre@a.co"}
+
+        permissions = [(p.permission, p.argument) for p in group.permissions]
+        assert sorted(permissions) == [
+            ("audited", ""),
+            ("ssh", "*"),
+            ("sudo", "shell"),
+            ("team-sre", "*"),
+        ]
+
+        group = api_client.groups.get("serving-team")
+        assert sorted(group.subgroups) == ["team-sre"]

--- a/itests/api/service_accounts_test.py
+++ b/itests/api/service_accounts_test.py
@@ -1,69 +1,75 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from groupy.client import Groupy
 
-from itests.fixtures import api_client, async_api_server  # noqa: F401
 from itests.setup import api_server
-from tests.fixtures import (  # noqa: F401
-    graph,
-    groups,
-    permissions,
-    service_accounts,
-    session,
-    standard_graph,
-    users,
-)
 
 if TYPE_CHECKING:
     from py.local import LocalPath
     from tests.setup import SetupTest
 
 
-def test_get_service_accounts(api_client, users, service_accounts):  # noqa: F811
-    role_users = [username for username, u in users.items() if u.role_user]
-    assert len(role_users) > 0
+def test_get_service_accounts(tmpdir: LocalPath, setup: SetupTest) -> None:
+    with setup.transaction():
+        setup.create_user("gary@a.co")
+        setup.create_role_user("role@a.co")
+        setup.create_service_account("service@a.co", "team-sre")
 
-    expected = role_users + list(service_accounts.keys())
-
-    api_service_accounts = list(api_client.service_accounts)
-    assert sorted(api_service_accounts) == sorted(expected)
-
-
-def test_get_service_account(api_client):  # noqa: F811
-    service_account = api_client.service_accounts.get("service@a.co")
-    assert service_account.groups == {}
-    assert service_account.passwords == []
-    assert service_account.public_keys == []
-    assert service_account.enabled
-    assert service_account.service_account == {
-        "description": "some service account",
-        "machine_set": "some machines",
-        "owner": "team-sre",
-    }
-    assert service_account.permissions == []
-    assert service_account.metadata == {}
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        assert sorted(api_client.service_accounts) == ["role@a.co", "service@a.co"]
 
 
-def test_get_role_user(api_client):  # noqa: F811
-    role_user = api_client.service_accounts.get("role@a.co")
-    assert role_user.groups == {}
-    assert role_user.passwords == []
-    assert role_user.public_keys == []
-    assert role_user.enabled
-    assert role_user.service_account is None
-    assert role_user.permissions == []
-    assert role_user.metadata == {}
+def test_get_service_account(tmpdir: LocalPath, setup: SetupTest) -> None:
+    with setup.transaction():
+        setup.create_service_account(
+            "service@a.co",
+            owner="team-sre",
+            machine_set="some machines",
+            description="some service account",
+        )
+
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        service_account = api_client.service_accounts.get("service@a.co")
+        assert service_account.groups == {}
+        assert service_account.passwords == []
+        assert service_account.public_keys == []
+        assert service_account.enabled
+        assert service_account.service_account == {
+            "description": "some service account",
+            "machine_set": "some machines",
+            "owner": "team-sre",
+        }
+        assert service_account.permissions == []
+        assert service_account.metadata == {}
 
 
-def test_includes_disabled_service_accounts(tmpdir, setup):
-    # type: (LocalPath, SetupTest) -> None
+def test_get_role_user(tmpdir: LocalPath, setup: SetupTest) -> None:
+    with setup.transaction():
+        setup.create_role_user("role@a.co")
+
+    with api_server(tmpdir) as api_url:
+        api_client = Groupy(api_url)
+        role_user = api_client.service_accounts.get("role@a.co")
+        assert sorted(role_user.groups) == ["role@a.co"]
+        assert role_user.passwords == []
+        assert role_user.public_keys == []
+        assert role_user.enabled
+        assert role_user.service_account is None
+        assert role_user.permissions == []
+        assert role_user.metadata == {}
+
+
+def test_includes_disabled_service_accounts(tmpdir: LocalPath, setup: SetupTest) -> None:
     with setup.transaction():
         setup.create_service_account("service@a.co", "some-group", "some machines", "an account")
-    with setup.transaction():
         setup.disable_service_account("service@a.co")
 
     with api_server(tmpdir) as api_url:
-        api_client = Groupy(api_url)  # noqa: F811
+        api_client = Groupy(api_url)
         assert list(api_client.service_accounts) == ["service@a.co"]
 
         service_account = api_client.service_accounts.get("service@a.co")

--- a/itests/fixtures.py
+++ b/itests/fixtures.py
@@ -8,9 +8,8 @@ functions to provide them as fixtures for older tests until the refactoring is c
 from typing import TYPE_CHECKING
 
 import pytest
-from groupy.client import Groupy
 
-from itests.setup import api_server, frontend_server
+from itests.setup import frontend_server
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
@@ -23,14 +22,3 @@ def async_server(standard_graph, tmpdir):
     # type: (GroupGraph, LocalPath) -> Iterator[str]
     with frontend_server(tmpdir, "cbguder@a.co") as frontend_url:
         yield frontend_url
-
-
-@pytest.fixture
-def async_api_server(standard_graph, tmpdir):
-    with api_server(tmpdir) as api_url:
-        yield api_url
-
-
-@pytest.fixture
-def api_client(async_api_server):
-    return Groupy(async_api_server)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,6 +20,8 @@ instead of directly manipulating the model.  Eventually, it should just be anoth
 service and repository layers.
 """
 
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
@@ -137,12 +139,17 @@ class SetupTest(object):
             yield
         self.graph.update_from_db(self.session)
 
-    def create_group(self, name, description="", join_policy=GroupJoinPolicy.CAN_ASK):
-        # type: (str, str, GroupJoinPolicy) -> None
+    def create_group(
+        self,
+        name: str,
+        description: str = "",
+        join_policy: GroupJoinPolicy = GroupJoinPolicy.CAN_ASK,
+        email: Optional[str] = None,
+    ) -> None:
         """Create a group, does nothing if it already exists."""
         group_service = self.service_factory.create_group_service()
         if not group_service.group_exists(name):
-            group_service.create_group(name, description, join_policy)
+            group_service.create_group(name, description, join_policy, email)
 
     def create_permission(
         self, name, description="", audited=False, enabled=True, created_on=None


### PR DESCRIPTION
Convert all remaining API itests to the modern test framework and
retire the old fixtures.  Required adding support for setting an
email address for a group during group creation.