### PR TITLE
Parallelize Travis-CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
   chrome: stable
 services:
   - mysql
+env:
+  - DB=sqlite
+  - DB=mysql
 python:
   - 3.7
 cache:

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -5,7 +5,9 @@ set -eux
 wget 'https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip'
 unzip chromedriver_linux64.zip -d chromedriver
 
-mysql -e 'CREATE DATABASE merou;'
+if [ "$DB" = 'mysql' ]; then
+    mysql -e 'CREATE DATABASE merou;'
+fi
 
 pip install -r requirements.txt
 pip install -r requirements-dev.txt

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -5,9 +5,20 @@ set -eux
 # Add chromedriver to PATH, manually installed by ci/setup.sh.
 export PATH="${PWD}/chromedriver:$PATH"
 
-# `Run once with SQLite and again with MySQL, and also do static analysis.
-MEROU_TEST_DATABASE='mysql://travis:@localhost/merou' pytest -x -v
-pytest -x -v
-mypy .
-black --check .
-flake8
+# Pick the database based on the DB setting.  For the SQLite build, also run
+# static analysis (no need to run it twice).
+case "$DB" in
+    mysql)
+        MEROU_TEST_DATABASE='mysql://travis:@localhost/merou' pytest -x -v
+        ;;
+    sqlite)
+        pytest -x -v
+        mypy .
+        black --check .
+        flake8
+        ;;
+    *)
+        echo "Unknown DB setting: $DB" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Now that we're not parallelizing for Python 2 and Python 3,
instead run the MySQL and SQLite tests in parallel.  Run static
analysis only for the SQLite test.