### PR TITLE
Remove mailing list reference from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,6 @@ currently).
 <https://github.com/Internet2/grouper>`_, but it isn't reflected in the
 codebase yet.
 
-To get updates about Merou, `join our mailing list
-<https://goo.gl/forms/mbw70IQ26Mj188pi1>`_.
-
 Installation
 ------------
 


### PR DESCRIPTION
The list isn't currently used (was it ever?)