### PR TITLE
Enable chosen search picker for permission names

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -209,7 +209,7 @@ class GroupPermissionRequestDropdownForm(Form):
     """permission request form using a dropdown field for the argument."""
 
     # Caller of form will add permission choices.
-    permission_name = SelectField("Permission", [validators.DataRequired()])
+    permission = SelectField("Permission", [validators.DataRequired()])
     argument = SelectField(
         "Argument",
         [
@@ -226,7 +226,7 @@ class GroupPermissionRequestTextForm(Form):
     """permission request form using a text field for the argument."""
 
     # Caller of form will add permission choices.
-    permission_name = SelectField("Permission", [validators.DataRequired()])
+    permission = SelectField("Permission", [validators.DataRequired()])
     argument = StringField(
         "Argument",
         [
@@ -242,7 +242,7 @@ class GroupPermissionRequestTextForm(Form):
 class PermissionRequestForm(Form):
     # Caller will add <select> field choices.
     group_name = SelectField("Group", [validators.DataRequired()])
-    permission_name = SelectField("Permission", [validators.DataRequired()])
+    permission = SelectField("Permission", [validators.DataRequired()])
     argument = StringField(
         "Argument",
         [

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -44,7 +44,7 @@ class PermissionRequest(GrouperHandler):
         if group is None:
             raise HTTPError(status_code=400, reason="that group does not exist")
 
-        permission = get_permission(self.session, form.permission_name.data)
+        permission = get_permission(self.session, form.permission.data)
         if permission is None:
             raise HTTPError(status_code=400, reason="that permission does not exist")
 
@@ -71,7 +71,7 @@ class PermissionRequest(GrouperHandler):
             self.log_message(
                 "prefilled perm+arg have no owner",
                 group_name=group.name,
-                permission_name=permission.name,
+                permission=permission.name,
                 argument=argument,
             )
             alerts = [
@@ -139,11 +139,11 @@ class PermissionRequest(GrouperHandler):
                 raise HTTPError(
                     status_code=404, reason="an unrecognized permission is specified in the URL"
                 )
-            form.permission_name.choices = pairs([permission_param])
-            form.permission_name.render_kw = {"readonly": "readonly"}
-            form.permission_name.data = permission_param
+            form.permission.choices = pairs([permission_param])
+            form.permission.render_kw = {"readonly": "readonly"}
+            form.permission.data = permission_param
         else:
-            form.permission_name.choices = pairs([""] + sorted(permission_names))
+            form.permission.choices = pairs(sorted(permission_names))
 
         argument_param = self.get_argument("argument", "")
         if argument_param:

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -21,6 +21,7 @@ $(function () {
     }
 
     $("select#member").attr("data-placeholder", "Select a user or group").chosen();
+    $("select#permission").attr("data-placeholder", "Select a permission").chosen();
 
     $('#add-form-expiration').datetimepicker({
         pickTime: false,
@@ -126,7 +127,7 @@ $(function () {
         var $reason_div = $form.find('.form-group-reason');
 
         var $group_input = $form.find('#group_name');
-        var $permission_input = $form.find('#permission_name');
+        var $permission_input = $form.find('#permission');
         var $argument_input = $form.find('#argument');
 
         // Supplement the <input> "argument" field with an adjacent

--- a/grouper/fe/templates/permission-request.html
+++ b/grouper/fe/templates/permission-request.html
@@ -22,7 +22,7 @@
                   method="post" action="{{ uri }}"
                   {{ { "data-permission" : args_by_perm_json } | xmlattr }}>
                 {{ form_field(form.group_name, 3, 8, class_="form-control") }}
-                {{ form_field(form.permission_name, 3, 8, class_="form-control") }}
+                {{ form_field(form.permission, 3, 8, class_="form-control") }}
                 {{ form_field(form.argument, 3, 8, class_="form-control") }}
                 {{ form_field(form.reason, 3, 8, class_="form-control") }}
                 {{ xsrf_form() | safe }}

--- a/itests/fe/group_view_test.py
+++ b/itests/fe/group_view_test.py
@@ -221,10 +221,10 @@ def test_request_permission(tmpdir: LocalPath, setup: SetupTest, browser: Chrome
         group_page.click_request_permission_button()
 
         request_page = PermissionRequestPage(browser)
-        request_page.set_select_value("permission_name", "some-permission")
-        request_page.fill_field("argument", "some-argument")
-        request_page.fill_field("reason", "testing")
-        request_page.submit_request()
+        request_page.set_permission("some-permission")
+        request_page.set_argument_freeform("some-argument")
+        request_page.set_reason("testing")
+        request_page.submit()
 
         assert browser.current_url.endswith("/permissions/requests/1")
         update_page = PermissionRequestUpdatePage(browser)

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -39,13 +39,13 @@ def test_requesting_permission(tmpdir, setup, browser):
         page2 = PermissionRequestPage(browser)
         assert page2.heading == "Permissions"
         assert page2.subheading == "Request Permission"
-        assert page2.get_option_values("group_name") == ["", "front-end"]
-        assert page2.get_option_values("permission_name") == ["git.repo.read"]
+        assert page2.get_group_values() == ["", "front-end"]
+        assert page2.get_permission_values() == ["git.repo.read"]
 
-        page2.set_select_value("group_name", "front-end")
-        page2.fill_field("argument", "server")
-        page2.fill_field("reason", "So they can do development")
-        page2.submit_request()
+        page2.set_group("front-end")
+        page2.set_argument_freeform("server")
+        page2.set_reason("So they can do development")
+        page2.submit()
 
         text = " ".join(browser.find_element_by_tag_name("body").text.split())
         assert browser.current_url.endswith("/permissions/requests/1")
@@ -68,10 +68,10 @@ def test_limited_arguments(tmpdir, setup, browser):
         browser.get(url(frontend_url, "/permissions/request?permission=sample.permission"))
         page = PermissionRequestPage(browser)
 
-        page.set_select_value("group_name", "test-group")
-        page.set_select_value("argument", "Option A")
-        page.fill_field("reason", "Some testing reason")
-        page.submit_request()
+        page.set_group("test-group")
+        page.set_argument_dropdown("Option A")
+        page.set_reason("Some testing reason")
+        page.submit()
 
         assert browser.current_url.endswith("/permissions/requests/1")
 
@@ -93,10 +93,10 @@ def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
         permission_page.button_to_request_this_permission.click()
 
         permission_request_page = PermissionRequestPage(browser)
-        permission_request_page.set_select_value("group_name", "some-group")
-        permission_request_page.fill_field("argument", "  arg u  ment  ")
-        permission_request_page.fill_field("reason", "testing whitespace")
-        permission_request_page.submit_request()
+        permission_request_page.set_group("some-group")
+        permission_request_page.set_argument_freeform("  arg u  ment  ")
+        permission_request_page.set_reason("testing whitespace")
+        permission_request_page.submit()
 
     with frontend_server(tmpdir, "zorkian@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/requests?status=pending"))

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -183,8 +183,10 @@ class PermissionGrantPage(BasePage):
         return self.find_element_by_id("grant-form")
 
     def set_permission(self, permission: str) -> None:
-        field = Select(self.form.find_element_by_name("permission"))
-        field.select_by_value(permission)
+        permission_select = self.form.find_element_by_id("permission_chosen")
+        permission_select.click()
+        permission_search = permission_select.find_element_by_tag_name("input")
+        permission_search.send_keys(permission, Keys.ENTER)
 
     def set_argument(self, argument: str) -> None:
         field = self.form.find_element_by_name("argument")

--- a/itests/pages/permission_request.py
+++ b/itests/pages/permission_request.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import Select
 
 from itests.pages.base import BasePage
@@ -11,25 +14,38 @@ if TYPE_CHECKING:
 
 class PermissionRequestPage(BasePage):
     @property
-    def permission_request_form(self):
-        # type: () -> WebElement
+    def form(self) -> WebElement:
         return self.find_element_by_id("permission-request")
 
-    def get_option_values(self, name):
-        # type: (str) -> List[str]
-        select = Select(self.permission_request_form.find_element_by_name(name))
-        return [option.get_attribute("value") for option in select.options]
+    def get_group_values(self) -> List[str]:
+        field = Select(self.form.find_element_by_name("group_name"))
+        return [option.get_attribute("value") for option in field.options]
 
-    def set_select_value(self, name, value):
-        # type: (str, str) -> None
-        select = Select(self.permission_request_form.find_element_by_name(name))
-        select.select_by_value(value)
+    def get_permission_values(self) -> List[str]:
+        field = Select(self.form.find_element_by_name("permission"))
+        return [option.get_attribute("value") for option in field.options]
 
-    def fill_field(self, name, value):
-        # type: (str, str) -> None
-        self.permission_request_form.find_element_by_name(name).send_keys(value)
+    def set_group(self, group: str) -> None:
+        field = Select(self.form.find_element_by_name("group_name"))
+        field.select_by_value(group)
 
-    def submit_request(self):
-        # type: () -> None
-        button = self.permission_request_form.find_element_by_tag_name("button")
-        button.click()
+    def set_permission(self, permission: str) -> None:
+        permission_select = self.form.find_element_by_id("permission_chosen")
+        permission_select.click()
+        permission_search = permission_select.find_element_by_tag_name("input")
+        permission_search.send_keys(permission, Keys.ENTER)
+
+    def set_argument_dropdown(self, argument: str) -> None:
+        field = Select(self.form.find_element_by_name("argument"))
+        field.select_by_value(argument)
+
+    def set_argument_freeform(self, argument: str) -> None:
+        field = self.form.find_element_by_name("argument")
+        field.send_keys(argument)
+
+    def set_reason(self, reason: str) -> None:
+        field = self.form.find_element_by_name("reason")
+        field.send_keys(reason)
+
+    def submit(self) -> None:
+        self.form.submit()

--- a/itests/pages/service_accounts.py
+++ b/itests/pages/service_accounts.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
 
 from itests.pages.base import BaseElement, BaseModal, BasePage
@@ -120,8 +121,10 @@ class ServiceAccountGrantPermissionPage(BasePage):
     def select_permission(self, permission):
         # type: (str) -> None
         form = self._get_grant_permission_form()
-        permission_select = form.find_element_by_name("permission")
-        Select(permission_select).select_by_visible_text(permission)
+        permission_select = form.find_element_by_id("permission_chosen")
+        permission_select.click()
+        permission_search = permission_select.find_element_by_tag_name("input")
+        permission_search.send_keys(permission, Keys.ENTER)
 
     def set_argument(self, argument):
         # type: (str) -> None

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -331,7 +331,7 @@ def test_permission_request_flow(
         method="POST",
         body=urlencode(
             {
-                "permission_name": "grantable.one",
+                "permission": "grantable.one",
                 "argument": "some argument?",
                 "reason": "blah blah black sheep",
             }
@@ -349,7 +349,7 @@ def test_permission_request_flow(
         method="POST",
         body=urlencode(
             {
-                "permission_name": "grantable.one",
+                "permission": "grantable.one",
                 "argument": "some argument",
                 "reason": "blah blah black sheep",
             }
@@ -401,7 +401,7 @@ def test_permission_request_flow(
         method="POST",
         body=urlencode(
             {
-                "permission_name": "grantable.one",
+                "permission": "grantable.one",
                 "argument": "some argument",
                 "reason": "blah blah black sheep",
             }
@@ -423,7 +423,7 @@ def test_permission_request_flow(
         method="POST",
         body=urlencode(
             {
-                "permission_name": "grantable.two",
+                "permission": "grantable.two",
                 "argument": "some argument",
                 "reason": "blah blah black sheep",
             }
@@ -489,7 +489,7 @@ def test_limited_permissions(
         method="POST",
         body=urlencode(
             {
-                "permission_name": perm1.name,
+                "permission": perm1.name,
                 "argument": "specific_arg",
                 "reason": "blah blah black sheep",
             }
@@ -519,7 +519,7 @@ def test_limited_permissions_global_approvers(
         method="POST",
         body=urlencode(
             {
-                "permission_name": perm1.name,
+                "permission": perm1.name,
                 "argument": "specific_arg",
                 "reason": "blah blah black sheep",
                 "argument_type": "text",


### PR DESCRIPTION
There are enough permission names that chosen is useful to make
searching easier.  Enable it for permissions, change the field name
to be permission uniformly (not permission_name), and adjust the
Selenium tests as needed.

Change the conventions for the permission request page model in
Selenium to match what we do elsewhere, with separate methods for
every form field.