### PR TITLE
Refresh the graph after a group rename

### DIFF
--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -48,14 +48,15 @@ class GroupEdit(GrouperHandler):
             )
 
         new_name = form.data["groupname"]
+        renamed = group.groupname != new_name
 
-        if group.groupname != new_name and is_role_user(self.session, group=group):
+        if renamed and is_role_user(self.session, group=group):
             form.groupname.errors.append("You cannot change the name of service account groups")
             return self.render(
                 "group-edit.html", group=group, form=form, alerts=self.get_form_alerts(form.errors)
             )
 
-        if group.groupname != new_name and Group.get(self.session, name=new_name):
+        if renamed and Group.get(self.session, name=new_name):
             message = f"A group named '{new_name}' already exists (possibly disabled)"
             form.groupname.errors.append(message)
             return self.render(
@@ -75,4 +76,7 @@ class GroupEdit(GrouperHandler):
             self.session, self.current_user.id, "edit_group", "Edited group.", on_group_id=group.id
         )
 
-        return self.redirect("/groups/{}".format(group.name))
+        url = f"/groups/{group.name}"
+        if renamed:
+            url += "?refresh=yes"
+        self.redirect(url)

--- a/itests/fe/group_view_test.py
+++ b/itests/fe/group_view_test.py
@@ -91,6 +91,24 @@ def test_edit_member_group_role(tmpdir: LocalPath, setup: SetupTest, browser: Ch
             edit_page.set_role("Owner")
 
 
+def test_rename(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group"))
+
+        view_page = GroupViewPage(browser)
+        view_page.click_edit_button()
+
+        edit_page = GroupEditPage(browser)
+        edit_page.set_name("other-group")
+        edit_page.submit()
+
+        assert browser.current_url.endswith("?refresh=yes")
+        assert view_page.subheading == "other-group"
+
+
 def test_rename_name_conflict(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
     with setup.transaction():
         setup.add_user_to_group("gary@a.co", "some-group", role="owner")


### PR DESCRIPTION
Renaming the group invalidates the graph, so force a refresh so
that we don't show stale or incorrect data.