### PR TITLE
Remove obsolete object inheritance

### DIFF
--- a/grouper/background/background_processor.py
+++ b/grouper/background/background_processor.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from typing import Dict, NoReturn, Set
 
 
-class BackgroundProcessor(object):
+class BackgroundProcessor:
     """Background process for running periodic tasks.
 
     Currently, this sends asynchronous mail messages and handles edge expiration and notification.

--- a/grouper/ctl/factory.py
+++ b/grouper/ctl/factory.py
@@ -20,7 +20,7 @@ class UnknownCommand(Exception):
     pass
 
 
-class CtlCommandFactory(object):
+class CtlCommandFactory:
     """Construct and add parsers for grouper-ctl commands."""
 
     @staticmethod

--- a/grouper/ctl/user_proxy.py
+++ b/grouper/ctl/user_proxy.py
@@ -29,7 +29,7 @@ class NoRedirectHandler(HTTPErrorProcessor):
         return response
 
 
-class ProxyServer(HTTPServer, object):
+class ProxyServer(HTTPServer):
     """Very simple proxy that adds the X-Grouper-User header.
 
     This is not intended for production use and should not be exposed to hostile requests.  It's

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -20,7 +20,7 @@ from grouper.entities.group_edge import GROUP_EDGE_ROLES
 GROUP_CANJOIN_CHOICES = [("canjoin", "Anyone"), ("canask", "Must Ask"), ("nobody", "Nobody")]
 
 
-class ValidateRegex(object):
+class ValidateRegex:
     def __init__(self, regex):
         # We assume any regex passed to us does not have line anchors.
         self.regex = r"^" + regex + r"$"
@@ -31,7 +31,7 @@ class ValidateRegex(object):
             raise ValidationError("Field must match '{}'".format(self.regex))
 
 
-class ValidateDate(object):
+class ValidateDate:
     def __call__(self, form, field):
         try:
             if field.data:

--- a/grouper/fe/handlers/github.py
+++ b/grouper/fe/handlers/github.py
@@ -28,7 +28,7 @@ def _get_github_http_client() -> AsyncHTTPClient:
     return AsyncHTTPClient()
 
 
-class GitHubClient(object):
+class GitHubClient:
     def __init__(
         self, http_client: AsyncHTTPClient, proxy_host: Optional[str], proxy_port: Optional[int]
     ) -> None:

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Dict, List, Optional, Sequence, Type
 
 
-class Alert(object):
+class Alert:
     def __init__(self, severity: str, message: str, heading: str = None) -> None:
         self.severity = severity
         self.message = message

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -56,7 +56,7 @@ class NoSuchGroup(Exception):
     pass
 
 
-class GroupGraph(object):
+class GroupGraph:
     """The cached permission graph.
 
     The graph is internally represented by four major components: the users, groups, and

--- a/grouper/models/base/model_base.py
+++ b/grouper/models/base/model_base.py
@@ -2,7 +2,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import object_session
 
 
-class _Model(object):
+class _Model:
     """ Custom model mixin with helper methods. """
 
     @property

--- a/grouper/models/comment.py
+++ b/grouper/models/comment.py
@@ -8,7 +8,7 @@ from grouper.models.base.constants import OBJ_TYPES
 from grouper.models.base.model_base import Model
 
 
-class CommentObjectMixin(object):
+class CommentObjectMixin:
     """Mixin used by models which show up as objects referenced by Comment entries."""
 
     @property

--- a/grouper/oneoff.py
+++ b/grouper/oneoff.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-class BaseOneOff(object):
+class BaseOneOff:
     def configure(self, service_name):
         # type: (str) -> None
         """

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 
-class BasePlugin(object):
+class BasePlugin:
     def configure(self, service_name):
         # type: (str) -> None
         """Configure the plugin.

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Iterable, Optional, Type, Tuple, Union
 
 
-class PluginProxy(object):
+class PluginProxy:
     """Wrapper to proxy a plugin method call to all loaded plugins."""
 
     @classmethod

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
-class AuditLogRepository(object):
+class AuditLogRepository:
     """SQL storage layer for audit log entries."""
 
     def __init__(self, session, plugins):

--- a/grouper/repositories/checkpoint.py
+++ b/grouper/repositories/checkpoint.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from grouper.models.base.session import Session
 
 
-class CheckpointRepository(object):
+class CheckpointRepository:
     """Manage the checkpoint counter used for graph reloading.
 
     On every change to any Grouper data, increment an updates counter stored in the database.  This

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-class SessionFactory(object):
+class SessionFactory:
     """Create database sessions.
 
     Eventually this will be used only by the RepositoryFactory to get a session to inject into

--- a/grouper/repositories/group.py
+++ b/grouper/repositories/group.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-class GroupRepository(object):
+class GroupRepository:
     """Storage layer for groups."""
 
     def __init__(self, session):

--- a/grouper/repositories/group_request.py
+++ b/grouper/repositories/group_request.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from typing import List
 
 
-class GroupRequestRepository(object):
+class GroupRequestRepository:
     """SQL storage layer for requests to join groups."""
 
     def __init__(self, session):

--- a/grouper/repositories/schema.py
+++ b/grouper/repositories/schema.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from grouper.settings import Settings
 
 
-class SchemaRepository(object):
+class SchemaRepository:
     """Manipulate the database schema."""
 
     def __init__(self, settings):

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from grouper.models.base.session import Session
 
 
-class ServiceAccountRepository(object):
+class ServiceAccountRepository:
     """Storage layer for service accounts."""
 
     def __init__(self, session):

--- a/grouper/repositories/transaction.py
+++ b/grouper/repositories/transaction.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-class SQLTransaction(object):
+class SQLTransaction:
     """Returned by a TransactionRepository as a context manager."""
 
     def __init__(self, session):
@@ -26,7 +26,7 @@ class SQLTransaction(object):
         return False
 
 
-class TransactionRepository(object):
+class TransactionRepository:
     """Manage storage layer transactions."""
 
     def __init__(self, session):

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     )
 
 
-class ServiceFactory(object):
+class ServiceFactory:
     """Construct backend services."""
 
     def __init__(self, settings, plugins, repository_factory):

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -35,7 +35,7 @@ class InvalidSettingsError(Exception):
     pass
 
 
-class Settings(object):
+class Settings:
     """Grouper configuration settings.
 
     Provides a parent class for settings objects, machinery for reading settings from the YAML

--- a/grouper/templating.py
+++ b/grouper/templating.py
@@ -23,7 +23,7 @@ def _utcnow():
     return datetime.now(UTC)
 
 
-class BaseTemplateEngine(object):
+class BaseTemplateEngine:
     """Lightweight wrapper around the Jinja2 template engine.
 
     Provides some date-formatting filters that honor global settings, and some global variables.

--- a/grouper/usecases/authorization.py
+++ b/grouper/usecases/authorization.py
@@ -1,4 +1,8 @@
-class Authorization(object):
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Authorization:
     """Indicates that an action has been authorized.
 
     This object is a required parameter to any write action on a backend service.  This pattern is
@@ -10,6 +14,4 @@ class Authorization(object):
         actor: Identity of the user performing the action
     """
 
-    def __init__(self, actor):
-        # type: (str) -> None
-        self.actor = actor
+    actor: str

--- a/grouper/usecases/convert_user_to_service_account.py
+++ b/grouper/usecases/convert_user_to_service_account.py
@@ -31,7 +31,7 @@ class ConvertUserToServiceAccountUI(metaclass=ABCMeta):
         pass
 
 
-class ConvertUserToServiceAccount(object):
+class ConvertUserToServiceAccount:
     """Delete a user and create a service account with the same name.
 
     The use case doesn't exactly do that now due to limitations of the data model, but semantically

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -51,7 +51,7 @@ class CreateServiceAccountUI(metaclass=ABCMeta):
         pass
 
 
-class CreateServiceAccount(object):
+class CreateServiceAccount:
     """Create a new service account."""
 
     def __init__(

--- a/grouper/usecases/disable_permission.py
+++ b/grouper/usecases/disable_permission.py
@@ -50,7 +50,7 @@ class DisablePermissionUI(metaclass=ABCMeta):
         pass
 
 
-class DisablePermission(object):
+class DisablePermission:
     """Disable a permission."""
 
     def __init__(

--- a/grouper/usecases/dump_schema.py
+++ b/grouper/usecases/dump_schema.py
@@ -14,7 +14,7 @@ class DumpSchemaUI(metaclass=ABCMeta):
         pass
 
 
-class DumpSchema(object):
+class DumpSchema:
     """Dump the database schema as a string."""
 
     def __init__(self, ui, schema_service):

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from grouper.usecases.view_permission import ViewPermissionUI
 
 
-class UseCaseFactory(object):
+class UseCaseFactory:
     """Create use cases with dependency injection."""
 
     def __init__(self, settings, plugins, service_factory):

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -47,7 +47,7 @@ class GrantPermissionToServiceAccountUI(metaclass=ABCMeta):
         pass
 
 
-class GrantPermissionToServiceAccount(object):
+class GrantPermissionToServiceAccount:
     def __init__(
         self,
         actor,  # type: str

--- a/grouper/usecases/initialize_schema.py
+++ b/grouper/usecases/initialize_schema.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from grouper.usecases.interfaces import TransactionInterface
 
 
-class InitializeSchema(object):
+class InitializeSchema:
     """Initialize the schema for a fresh database."""
 
     def __init__(

--- a/grouper/usecases/list_grants.py
+++ b/grouper/usecases/list_grants.py
@@ -21,7 +21,7 @@ class ListGrantsUI(metaclass=ABCMeta):
         pass
 
 
-class ListGrants(object):
+class ListGrants:
     """List all permission grants by permission, expanding the graph."""
 
     def __init__(self, ui, permission_service):

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -25,7 +25,7 @@ class ListPermissionsUI(metaclass=ABCMeta):
         pass
 
 
-class ListPermissions(object):
+class ListPermissions:
     """List all permissions."""
 
     def __init__(self, ui, permission_service, user_service):

--- a/grouper/usecases/list_users.py
+++ b/grouper/usecases/list_users.py
@@ -16,7 +16,7 @@ class ListUsersUI(metaclass=ABCMeta):
         pass
 
 
-class ListUsers(object):
+class ListUsers:
     """List all users."""
 
     def __init__(self, ui, user_service):

--- a/grouper/usecases/view_permission.py
+++ b/grouper/usecases/view_permission.py
@@ -33,7 +33,7 @@ class ViewPermissionUI(metaclass=ABCMeta):
         pass
 
 
-class ViewPermission(object):
+class ViewPermission:
     """View a single permission."""
 
     def __init__(self, ui, permission_service, user_service, audit_log_service):

--- a/itests/pages/base.py
+++ b/itests/pages/base.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from selenium.webdriver.remote.webelement import WebElement
 
 
-class BaseFinder(object):
+class BaseFinder:
     def __init__(self, root):
         # type: (Chrome) -> None
         self.root = root

--- a/tests/ctl/misc_test.py
+++ b/tests/ctl/misc_test.py
@@ -98,7 +98,7 @@ def test_oneoff(mock_load_plugins, session, tmpdir):  # noqa: F811
     other_username = "fake_user2@a.co"
     groupname = "fake_group"
 
-    class FakeOneOff(object):
+    class FakeOneOff:
         def configure(self, service_name):
             pass
 

--- a/tests/github_test.py
+++ b/tests/github_test.py
@@ -26,7 +26,7 @@ from tests.fixtures import (  # noqa: F401
 from tests.url_util import url
 
 
-class FakeGitHubHttpClient(object):
+class FakeGitHubHttpClient:
     def __init__(self):
         self.requests = []
 
@@ -48,7 +48,7 @@ class FakeGitHubHttpClient(object):
         return f
 
 
-class SecretPlugin(object):
+class SecretPlugin:
     def get_github_app_client_secret(self):
         return b"client-secret"
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
     from typing import Iterator, Optional
 
 
-class SetupTest(object):
+class SetupTest:
     """Set up the environment for a test.
 
     Most actions should be done inside of a transaction, created via the transaction() method and


### PR DESCRIPTION
Since the code is now pure Python 3, classes no longer have to
inherit from object to trigger the new class implementation.

Convert Authorization to a dataclass object.