### PR TITLE
Add test for group join request with Unicode reason

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -6,7 +6,7 @@ wget 'https://chromedriver.storage.googleapis.com/2.37/chromedriver_linux64.zip'
 unzip chromedriver_linux64.zip -d chromedriver
 
 if [ "$DB" = 'mysql' ]; then
-    mysql -e 'CREATE DATABASE merou;'
+    mysql -e 'CREATE DATABASE merou CHARACTER SET utf8mb4;'
 fi
 
 pip install -r requirements.txt

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -9,7 +9,7 @@ export PATH="${PWD}/chromedriver:$PATH"
 # static analysis (no need to run it twice).
 case "$DB" in
     mysql)
-        MEROU_TEST_DATABASE='mysql://travis:@localhost/merou' pytest -x -v
+        MEROU_TEST_DATABASE='mysql://travis:@localhost/merou?charset=utf8mb4' pytest -x -v
         ;;
     sqlite)
         pytest -x -v

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -145,3 +147,17 @@ def test_group_join_group_as_owner(tmpdir: LocalPath, setup: SetupTest, browser:
             join_page.set_role(role)
             join_page.submit()
             assert join_page.has_alert("Groups can only have the role of 'member'")
+
+
+def test_request_join_unicode(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", "owner")
+
+    with frontend_server(tmpdir, "cbguder@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/join"))
+        page = GroupJoinPage(browser)
+
+        page.set_reason("защото причини")
+        page.submit()
+
+        assert browser.current_url.endswith("/groups/some-group?refresh=yes")


### PR DESCRIPTION
This previously failed when generating the email message with an
encoding error.  It now works, probably because Grouper is pure
Python 3.