### PR TITLE
Don't allow automatically joining as a non-member

### DIFF
--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -120,12 +120,23 @@ class GroupJoin(GrouperHandler):
         elif group.auto_expire:
             expiration = datetime.utcnow() + group.auto_expire
 
+        # If the requested role is member, set the status based on the group's canjoin setting,
+        # which automatically actions the request if the group can be joined by anyone and
+        # otherwise sets it pending.
+        #
+        # However, we don't want to let people autojoin as owner or np-owner even to otherwise open
+        # groups, so if the role is not member, force the status to pending.
+        if form.data["role"] == "member":
+            status = GROUP_JOIN_CHOICES[group.canjoin]
+        else:
+            status = "pending"
+
         try:
             request = group.add_member(
                 requester=self.current_user,
                 user_or_group=member,
                 reason=form.data["reason"],
-                status=GROUP_JOIN_CHOICES[group.canjoin],
+                status=status,
                 expiration=expiration,
                 role=form.data["role"],
             )
@@ -138,7 +149,7 @@ class GroupJoin(GrouperHandler):
             )
         self.session.commit()
 
-        if group.canjoin == "canask":
+        if status == "pending":
             AuditLog.log(
                 self.session,
                 self.current_user.id,
@@ -169,7 +180,7 @@ class GroupJoin(GrouperHandler):
             )
             send_email(self.session, mail_to, subj, "pending_request", settings(), email_context)
 
-        elif group.canjoin == "canjoin":
+        elif status == "actioned":
             AuditLog.log(
                 self.session,
                 self.current_user.id,
@@ -178,7 +189,7 @@ class GroupJoin(GrouperHandler):
                 on_group_id=group.id,
             )
         else:
-            raise Exception("Need to update the GroupJoin.post audit logging")
+            raise Exception(f"Unknown join status {status}")
 
         return self.redirect("/groups/{}?refresh=yes".format(group.name))
 

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -132,6 +132,23 @@ def test_group_join_group(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) 
         assert group_page.find_member_row("some-group")
 
 
+def test_group_join_as_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.create_group("some-group", join_policy=GroupJoinPolicy.CAN_JOIN)
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/join"))
+        join_page = GroupJoinPage(browser)
+
+        join_page.set_role("Owner")
+        join_page.set_reason("Testing")
+        join_page.submit()
+
+        view_page = GroupViewPage(browser)
+        with pytest.raises(NoSuchElementException):
+            view_page.find_member_row("gary@a.co")
+
+
 def test_group_join_group_as_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
     with setup.transaction():
         setup.add_user_to_group("gary@a.co", "some-group", "owner")


### PR DESCRIPTION
Even in groups open for anyone to join, we don't want someone to
be able to join as an owner, np-owner, or manager and be able to
make changes to the group.  Force such requests to get approval.