### PR TITLE
Remove all remaining NamedTuples

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -286,10 +286,7 @@ Testing
 Most testing, including exercising the failures, can be done at the use
 case level using a mock UI.  Often, a `MagicMock` object is sufficient;
 sometimes it will be easier to define a class that implements the UI to
-make comparing returned data against expected data easier.  (Note that
-mypy `NamedTuple` objects unfortunately can't be compared directly with
-`==`, so you may need to write helper functions to compare their
-components.)
+make comparing returned data against expected data easier.
 
 The `setup` fixture provides a `SetupTest` object, which provides a test
 database session, methods to quickly assemble a test environment, and

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -100,14 +100,10 @@ class GroupAdd(GrouperHandler):
             form.member.errors.append("By definition, this group is a member of itself already.")
 
         # Ensure this doesn't violate auditing constraints
-        fail_message = "This join is denied with this role at this time."
         try:
-            user_can_join = assert_can_join(group, member, role=form.data["role"])
+            assert_can_join(group, member, role=form.data["role"])
         except UserNotAuditor as e:
-            user_can_join = False
-            fail_message = str(e)
-        if not user_can_join:
-            form.member.errors.append(fail_message)
+            form.member.errors.append(str(e))
 
         if form.member.errors:
             return self.render(

--- a/grouper/fe/handlers/group_edit_member.py
+++ b/grouper/fe/handlers/group_edit_member.py
@@ -121,20 +121,16 @@ class GroupEditMember(GrouperHandler):
                 alerts=self.get_form_alerts(form.errors),
             )
 
-        fail_message = "This join is denied with this role at this time."
         try:
-            user_can_join = assert_can_join(group, user_or_group, role=form.data["role"])
+            assert_can_join(group, user_or_group, role=form.data["role"])
         except UserNotAuditor as e:
-            user_can_join = False
-            fail_message = str(e)
-        if not user_can_join:
             return self.render(
                 "group-edit-member.html",
                 form=form,
                 group=group,
                 member=member,
                 edge=edge,
-                alerts=[Alert("danger", fail_message, "Audit Policy Enforcement")],
+                alerts=[Alert("danger", str(e), "Audit Policy Enforcement")],
             )
 
         expiration = None

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -73,18 +73,14 @@ class GroupJoin(GrouperHandler):
                 alerts=[Alert("danger", "Unknown user or group: {}".format(form.data["member"]))],
             )
 
-        fail_message = "This join is denied with this role at this time."
         try:
-            user_can_join = assert_can_join(group, member, role=form.data["role"])
+            assert_can_join(group, member, role=form.data["role"])
         except UserNotAuditor as e:
-            user_can_join = False
-            fail_message = str(e)
-        if not user_can_join:
             return self.render(
                 "group-join.html",
                 form=form,
                 group=group,
-                alerts=[Alert("danger", fail_message, "Audit Policy Enforcement")],
+                alerts=[Alert("danger", str(e), "Audit Policy Enforcement")],
             )
 
         if group.canjoin == "nobody":

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -111,15 +111,9 @@ class GroupRequestUpdate(GrouperHandler):
         # We have to test this here, too, to ensure that someone can't sneak in with a pending
         # request that used to be allowed.
         if form.data["status"] != "cancelled":
-            fail_message = "This join is denied with this role at this time."
             try:
-                user_can_join = assert_can_join(
-                    request.requesting, on_behalf, role=request.edge.role
-                )
+                assert_can_join(request.requesting, on_behalf, role=request.edge.role)
             except UserNotAuditor as e:
-                user_can_join = False
-                fail_message = str(e)
-            if not user_can_join:
                 return self.render(
                     "group-request-update.html",
                     group=group,
@@ -129,7 +123,7 @@ class GroupRequestUpdate(GrouperHandler):
                     form=form,
                     statuses=REQUEST_STATUS_CHOICES,
                     updates=updates,
-                    alerts=[Alert("danger", fail_message, "Audit Policy Enforcement")],
+                    alerts=[Alert("danger", str(e), "Audit Policy Enforcement")],
                 )
 
         request.update_status(self.current_user, form.data["status"], form.data["reason"])

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -76,17 +76,10 @@ class PermissionsGrant(GrouperHandler):
 
         # If the permission is audited, then see if the subtree meets auditing requirements.
         if permission.audited:
-            fail_message = (
-                "Permission is audited and this group (or a subgroup) contains "
-                + "owners, np-owners, or managers who have not received audit training."
-            )
             try:
-                permission_ok = assert_controllers_are_auditors(group)
+                assert_controllers_are_auditors(group)
             except UserNotAuditor as e:
-                permission_ok = False
-                fail_message = e
-            if not permission_ok:
-                form.permission.errors.append(fail_message)
+                form.permission.errors.append(str(e))
                 return self.render(
                     "permission-grant.html",
                     form=form,

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -10,7 +10,7 @@ from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermis
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest
-    from typing import Any, List
+    from typing import List
 
 
 class MockUI(ListPermissionsUI):
@@ -23,14 +23,6 @@ class MockUI(ListPermissionsUI):
         else:
             self.permissions = permissions
         self.can_create = can_create
-
-
-def assert_paginated_list_equal(left, right):
-    # type: (PaginatedList[Any], PaginatedList[Any]) -> None
-    """mypy NamedTuples don't compare with simple equality."""
-    assert left.values == right.values
-    assert left.total == right.total
-    assert left.offset == right.offset
 
 
 def create_test_data(setup):
@@ -83,7 +75,7 @@ def test_simple_list_permissions(setup):
     usecase.simple_list_permissions()
     assert not mock_ui.can_create
     expected = PaginatedList(values=sorted(permissions), total=3, offset=0, limit=None)
-    assert_paginated_list_equal(mock_ui.permissions, expected)
+    assert mock_ui.permissions == expected
 
 
 def test_list_permissions_pagination(setup):
@@ -98,7 +90,7 @@ def test_list_permissions_pagination(setup):
     )
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     expected = PaginatedList(values=sorted(permissions)[:2], total=3, offset=0, limit=2)
-    assert_paginated_list_equal(mock_ui.permissions, expected)
+    assert mock_ui.permissions == expected
 
     # Sorted by date, using offset, limit longer than remaining items.
     pagination = Pagination(
@@ -107,7 +99,7 @@ def test_list_permissions_pagination(setup):
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     expected_values = sorted(permissions, key=lambda p: p.created_on)[2:]
     expected = PaginatedList(values=expected_values, total=3, offset=2, limit=10)
-    assert_paginated_list_equal(mock_ui.permissions, expected)
+    assert mock_ui.permissions == expected
 
     # Sorted by name, reversed, limit of one 1 and offset of 1.
     pagination = Pagination(
@@ -116,7 +108,7 @@ def test_list_permissions_pagination(setup):
     usecase.list_permissions("gary@a.co", pagination, audited_only=False)
     expected_values = sorted(permissions, reverse=True)[1:2]
     expected = PaginatedList(values=expected_values, total=3, offset=1, limit=1)
-    assert_paginated_list_equal(mock_ui.permissions, expected)
+    assert mock_ui.permissions == expected
 
 
 def test_list_permissions_audited_only(setup):
@@ -130,7 +122,7 @@ def test_list_permissions_audited_only(setup):
     usecase.list_permissions("gary@a.co", pagination, audited_only=True)
     expected_values = [p for p in permissions if p.name == "audited-permission"]
     expected = PaginatedList(values=expected_values, total=1, offset=0, limit=None)
-    assert_paginated_list_equal(mock_ui.permissions, expected)
+    assert mock_ui.permissions == expected
 
 
 def test_list_permissions_can_create(setup):


### PR DESCRIPTION
Replace all remaining NamedTuples with dataclasses.  Modernize the
Python code (mostly) in the files most affected by this change.

dataclasses allow equality comparison, so remove some test
machinery working around the fact that NamedTuples didn't, and
update CONTRIBUTING.rst accordingly.