### PR TITLE
Add typing to grouper.permissions

### DIFF
--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -13,7 +13,6 @@ from grouper.permissions import get_grantable_permissions, get_permission
 from grouper.user_group import get_groups_by_user
 
 if TYPE_CHECKING:
-    from grouper.models.permission import Permission
     from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
@@ -97,7 +96,7 @@ class PermissionRequest(GrouperHandler):
             return self.redirect("/permissions/requests/{}".format(request.id))
 
     def _build_form(self, data):
-        # type: (Optional[int]) -> Tuple[PermissionRequestForm, Dict[Permission, List[str]]]
+        # type: (Optional[int]) -> Tuple[PermissionRequestForm, Dict[str, List[str]]]
         """Build the permission request form given the request and POST data.
 
         Normally all fields of the form will be editable.  But if the URL

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -551,14 +551,25 @@ def can_approve_request(
     owner: User,
     group_ids: Optional[Set[int]] = None,
     owners_by_arg_by_perm: Optional[Dict[object, Dict[str, List[Group]]]] = None,
-) -> Set[int]:
+) -> bool:
+    """Determine whether the given owner can approve a permission request.
+
+    Args:
+        session: Database session
+        request: Pending permission request
+        owner: User who may or may not be able to approve the request
+        group_ids: If given, the IDs of the groups of which the user is a member (solely so that we
+            can avoid another database query if this information is already available)
+        owners_by_arg_by_perm: List of permission granters by permission and argument (solely so
+            that we can avoid another database query if this information is already available)
+    """
     owner_arg_list = get_owner_arg_list(
         session, request.permission, request.argument, owners_by_arg_by_perm
     )
     if group_ids is None:
         group_ids = {g.id for g, _ in get_groups_by_user(session, owner)}
 
-    return group_ids.intersection([o.id for o, arg in owner_arg_list])
+    return bool(group_ids.intersection([o.id for o, arg in owner_arg_list]))
 
 
 def get_requests(


### PR DESCRIPTION
Convert a namedtuple to a dataclass object and get rid of some
dead code.  Some compromises had to be made with the typing because
this code does some odd things, like using a singleton object as a
key in an otherwise uniform dict.