### PR TITLE
Remove remaining uses of namedtuple

### DIFF
--- a/grouper/role_user.py
+++ b/grouper/role_user.py
@@ -4,7 +4,7 @@ FIXME(rra): Role users are deprecated and will be replaced by a new service acco
 not add any more logic to role users in the meantime.
 """
 
-from collections import namedtuple
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from grouper.constants import USER_ADMIN
@@ -23,7 +23,10 @@ class RoleUserNotFound(Exception):
     pass
 
 
-RoleUser = namedtuple("RoleUser", ["user", "group"])
+@dataclass(frozen=True)
+class RoleUser:
+    user: User
+    group: Group
 
 
 def create_role_user(session, actor, name, description, canjoin):
@@ -117,7 +120,11 @@ def get_role_user(session, user=None, group=None):
     else:
         assert group is not None
         name = group.name
-    return RoleUser(User.get(session, name=name), Group.get(session, name=name))
+    user_obj = User.get(session, name=name)
+    assert user_obj, "User object for role user not found"
+    group_obj = Group.get(session, name=name)
+    assert group_obj, "Group object for role user not found"
+    return RoleUser(user_obj, group_obj)
 
 
 def can_manage_role_user(session, user, tuser=None, tgroup=None):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -243,6 +243,7 @@ def groups(session):
             "user-admins",
             "group-admins",
             "permission-admins",
+            "role@a.co",  # group for a role user
         )
     }
     groups_with_emails = ("team-sre", "serving-team", "security-team")

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -1,5 +1,4 @@
 import unittest
-from collections import namedtuple
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
@@ -17,7 +16,7 @@ from grouper.constants import (
     PERMISSION_GRANT,
     PERMISSION_VALIDATION,
 )
-from grouper.fe.forms import ValidateRegex
+from grouper.fe.forms import PermissionGrantForm, ValidateRegex
 from grouper.models.async_notification import AsyncNotification
 from grouper.models.group import Group
 from grouper.models.permission_map import PermissionMap
@@ -153,10 +152,10 @@ class PermissionTests(unittest.TestCase):
         self.assertEqual(len(grouper.fe.util.test_reserved_names("admin.prefix.reserved")), 1)
         self.assertEqual(len(grouper.fe.util.test_reserved_names("test.prefix.reserved")), 1)
 
-        Field = namedtuple("field", "data")
-
         def eval_permission(perm):
-            ValidateRegex(PERMISSION_VALIDATION)(form=None, field=Field(data=perm))
+            form = PermissionGrantForm()
+            form.permission.data = perm
+            ValidateRegex(PERMISSION_VALIDATION)(form=None, field=form.permission)
 
         self.assertIsNone(eval_permission("foo.bar"))
         self.assertIsNone(eval_permission("foobar"))
@@ -166,7 +165,9 @@ class PermissionTests(unittest.TestCase):
         self.assertRaises(ValidationError, eval_permission, "foo._bar")
 
         def eval_argument(arg):
-            ValidateRegex(ARGUMENT_VALIDATION)(form=None, field=Field(data=arg))
+            form = PermissionGrantForm()
+            form.argument.data = arg
+            ValidateRegex(ARGUMENT_VALIDATION)(form=None, field=form.argument)
 
         self.assertIsNone(eval_argument("foo.bar"))
         self.assertIsNone(eval_argument("foobar"))


### PR DESCRIPTION
Replace the use in grouper.role_users with a dataclass object and
use a real WTForms object for permission validation.

Fix creation of the role user in the old test fixtures to properly
create a paired group.