### PR TITLE
Overhaul route handling

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -1,14 +1,8 @@
 # These regexes must not include line anchors ('^', '$'). Those will be added by the
 # ValidateRegex library function and anybody else who needs them.
 
-_NAME_VALIDATION = r"(?P<{}>[@\-\w\.]+)"
-NAME_VALIDATION = _NAME_VALIDATION.format("name")
-
-# This regex needs to exactly match the above, EXCEPT that the name should be "name2".
-# This is kind of gross. :\ We have to do this because the name of the capture group becomes the
-# argument to route handler, named arguments have to be unique, and at least one route (edit
-# member) requires occurrences of the name validation regex.
-NAME2_VALIDATION = _NAME_VALIDATION.format("name2")
+# Used for group names.
+NAME_VALIDATION = r"(?P<name>[@\-\w\.]+)"
 
 # These regexes are specifically to validate usernames.  SERVICE_ACCOUNT_VALIDATION is the same as
 # USERNAME_VALIDATION but with a distinct capture group name so that it doesn't conflict with a

--- a/grouper/fe/handlers/github.py
+++ b/grouper/fe/handlers/github.py
@@ -5,7 +5,7 @@ import hmac
 import json
 import os
 from typing import cast, TYPE_CHECKING
-from urllib.parse import unquote, urlencode
+from urllib.parse import urlencode
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPResponse
@@ -83,13 +83,15 @@ class GitHubClient:
 
 class GitHubLinkBeginView(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
+        user_id = int(self.get_path_argument("user_id"))
+
         # Redirect the user to GitHub to authorize our app.
         state = binascii.hexlify(os.urandom(16))
         self.set_cookie("github-link-state", state, httponly=True)
         params = {
             "client_id": settings().github_app_client_id,
             "state": state,
-            "redirect_uri": "{}/github/link_complete/{}".format(settings().url, kwargs["user_id"]),
+            "redirect_uri": f"{settings().url}/github/link_complete/{user_id}",
         }
         self.redirect("https://github.com/login/oauth/authorize?" + urlencode(params))
 
@@ -97,6 +99,8 @@ class GitHubLinkBeginView(GrouperHandler):
 class GitHubLinkCompleteView(GrouperHandler):
     @gen.coroutine
     def get(self, *args: Any, **kwargs: Any) -> Iterator[Future]:
+        user_id = int(self.get_path_argument("user_id"))
+
         # Check that the state parameter is correct.
         state = self.request.query_arguments.get("state", [b""])[-1]
         expected_state = self.get_cookie("github-link-state", "").encode("utf-8")
@@ -108,7 +112,6 @@ class GitHubLinkCompleteView(GrouperHandler):
         code = self.get_query_argument("code")
 
         # Make sure we're modifying the authenticated user before doing more.
-        user_id = kwargs["user_id"]
         user = User.get(self.session, user_id)
         if not user:
             self.notfound()
@@ -146,7 +149,7 @@ class UserClearGitHub(GrouperHandler):
         return actor.name == target.name
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/github.py
+++ b/grouper/fe/handlers/github.py
@@ -5,7 +5,7 @@ import hmac
 import json
 import os
 from typing import cast, TYPE_CHECKING
-from urllib.parse import urlencode
+from urllib.parse import unquote, urlencode
 
 from tornado import gen
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPResponse
@@ -146,10 +146,9 @@ class UserClearGitHub(GrouperHandler):
         return actor.name == target.name
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        user_id: Optional[int] = kwargs.get("user_id")
-        name: Optional[str] = kwargs.get("name")
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import operator
 from datetime import datetime
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -16,18 +19,15 @@ from grouper.user import get_all_enabled_users, get_user_or_group, user_role
 from grouper.user_group import user_can_manage_group
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupAdd(GrouperHandler):
-    def get_form(self, role=None):
+    def get_form(self, role: str) -> GroupAddForm:
         """Helper to create a GroupAddForm populated with all users and groups as options.
 
         Note that the first choice is blank so the first user alphabetically
         isn't always selected.
-
-        Returns:
-            GroupAddForm object.
         """
 
         form = GroupAddForm(self.request.arguments)
@@ -52,12 +52,10 @@ class GroupAdd(GrouperHandler):
         )
         return form
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -68,12 +66,10 @@ class GroupAdd(GrouperHandler):
         my_role = user_role(self.current_user, members)
         return self.render("group-add.html", form=self.get_form(role=my_role), group=group)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import operator
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -53,7 +52,7 @@ class GroupAdd(GrouperHandler):
         return form
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -67,7 +66,7 @@ class GroupAdd(GrouperHandler):
         return self.render("group-add.html", form=self.get_form(role=my_role), group=group)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_disable.py
+++ b/grouper/fe/handlers/group_disable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.email_util import cancel_async_emails
 from grouper.fe.util import GrouperHandler
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 
 class GroupDisable(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_disable.py
+++ b/grouper/fe/handlers/group_disable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.email_util import cancel_async_emails
 from grouper.fe.util import GrouperHandler
@@ -10,15 +11,14 @@ from grouper.role_user import is_role_user
 from grouper.user import user_role
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupDisable(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        group_id: Optional[int] = kwargs.get("group_id")
-        name: Optional[str] = kwargs.get("name")
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.forms import GroupEditForm
 from grouper.fe.util import GrouperHandler
@@ -11,15 +12,14 @@ from grouper.role_user import is_role_user
 from grouper.user_group import user_can_manage_group
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupEdit(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        group_id: Optional[int] = kwargs.get("group_id")
-        name: Optional[str] = kwargs.get("name")
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -31,10 +31,9 @@ class GroupEdit(GrouperHandler):
         self.render("group-edit.html", group=group, form=form)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        group_id: Optional[int] = kwargs.get("group_id")
-        name: Optional[str] = kwargs.get("name")
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_edit.py
+++ b/grouper/fe/handlers/group_edit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.forms import GroupEditForm
 from grouper.fe.util import GrouperHandler
@@ -17,7 +16,7 @@ if TYPE_CHECKING:
 
 class GroupEdit(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -31,7 +30,7 @@ class GroupEdit(GrouperHandler):
         self.render("group-edit.html", group=group, form=form)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_edit_member.py
+++ b/grouper/fe/handlers/group_edit_member.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.fe.forms import GroupEditMemberForm
@@ -21,9 +20,9 @@ if TYPE_CHECKING:
 
 class GroupEditMember(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        member_name: str = unquote(kwargs["member_name"])
-        member_type: str = kwargs["member_type"]
+        name = self.get_path_argument("name")
+        member_name = self.get_path_argument("member_name")
+        member_type = self.get_path_argument("member_type")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -54,9 +53,9 @@ class GroupEditMember(GrouperHandler):
         self.render("group-edit-member.html", group=group, member=member, edge=edge, form=form)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        member_name: str = unquote(kwargs["member_name"])
-        member_type: str = kwargs["member_type"]
+        name = self.get_path_argument("name")
+        member_name = self.get_path_argument("member_name")
+        member_type = self.get_path_argument("member_type")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_edit_member.py
+++ b/grouper/fe/handlers/group_edit_member.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.fe.forms import GroupEditMemberForm
@@ -15,17 +16,16 @@ from grouper.plugin.exceptions import PluginRejectedGroupMembershipUpdate
 from grouper.user import user_role
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupEditMember(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        group_id: Optional[int] = kwargs.get("group_id")
-        group_name: Optional[str] = kwargs.get("name")
-        user: str = kwargs["name2"]
+        name: str = unquote(kwargs["name"])
+        member_name: str = unquote(kwargs["member_name"])
         member_type: str = kwargs["member_type"]
 
-        group = Group.get(self.session, group_id, group_name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -34,7 +34,7 @@ class GroupEditMember(GrouperHandler):
         if my_role not in ("manager", "owner", "np-owner"):
             return self.forbidden()
 
-        member = members.get((member_type.capitalize(), user), None)
+        member = members.get((member_type.capitalize(), member_name), None)
         if not member:
             return self.notfound()
 
@@ -47,19 +47,18 @@ class GroupEditMember(GrouperHandler):
         if not edge:
             return self.notfound()
 
-        form = self._get_form(user, my_role, member_type)
+        form = self._get_form(member_name, my_role, member_type)
         form.role.data = edge.role
         form.expiration.data = edge.expiration.strftime("%m/%d/%Y") if edge.expiration else None
 
         self.render("group-edit-member.html", group=group, member=member, edge=edge, form=form)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        group_id: Optional[int] = kwargs.get("group_id")
-        group_name: Optional[str] = kwargs.get("name")
-        user: str = kwargs["name2"]
+        name: str = unquote(kwargs["name"])
+        member_name: str = unquote(kwargs["member_name"])
         member_type: str = kwargs["member_type"]
 
-        group = Group.get(self.session, group_id, group_name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -68,7 +67,7 @@ class GroupEditMember(GrouperHandler):
         if my_role not in ("manager", "owner", "np-owner"):
             return self.forbidden()
 
-        member = members.get((member_type.capitalize(), user), None)
+        member = members.get((member_type.capitalize(), member_name), None)
         if not member:
             return self.notfound()
 
@@ -88,7 +87,7 @@ class GroupEditMember(GrouperHandler):
         if not edge:
             return self.notfound()
 
-        form = self._get_form(user, my_role, member_type)
+        form = self._get_form(member_name, my_role, member_type)
         if not form.validate():
             return self.render(
                 "group-edit-member.html",

--- a/grouper/fe/handlers/group_enable.py
+++ b/grouper/fe/handlers/group_enable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 class GroupEnable(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_enable.py
+++ b/grouper/fe/handlers/group_enable.py
@@ -1,13 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 from grouper.role_user import is_role_user
 from grouper.user import user_role
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class GroupEnable(GrouperHandler):
-    def post(self, group_id=None, name=None):
-        group = Group.get(self.session, group_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
 
 class GroupJoin(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group or not group.enabled:
@@ -46,7 +45,7 @@ class GroupJoin(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group or not group.enabled:

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -19,12 +22,10 @@ if TYPE_CHECKING:
 
 
 class GroupJoin(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group or not group.enabled:
             return self.notfound()
 
@@ -44,12 +45,10 @@ class GroupJoin(GrouperHandler):
             user_is_member=user_is_member,
         )
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group or not group.enabled:
             return self.notfound()
 
@@ -189,8 +188,7 @@ class GroupJoin(GrouperHandler):
 
         return self.redirect("/groups/{}?refresh=yes".format(group.name))
 
-    def _get_member(self, member_choice):
-        # type: (str) -> Optional[Union[User, Group]]
+    def _get_member(self, member_choice: str) -> Optional[Union[User, Group]]:
         member_type, member_name = member_choice.split(": ", 1)
         resource = None
 
@@ -204,8 +202,9 @@ class GroupJoin(GrouperHandler):
 
         return self.session.query(resource).filter_by(name=member_name, enabled=True).one()
 
-    def _get_choices(self, group, member_groups, user_is_member):
-        # type: (Group, Set[str], bool) -> List[Tuple[str, str]]
+    def _get_choices(
+        self, group: Group, member_groups: Set[str], user_is_member: bool
+    ) -> List[Tuple[str, str]]:
         choices = []
 
         if not user_is_member:
@@ -231,8 +230,7 @@ class GroupJoin(GrouperHandler):
 
         return choices
 
-    def _is_user_a_member(self, group, members):
-        # type: (Group, Mapping[Tuple[str, str], Any]) -> bool
+    def _is_user_a_member(self, group: Group, members: Mapping[Tuple[str, str], Any]) -> bool:
         """Returns whether the current user is a member or has a pending membership request."""
         if ("User", self.current_user.name) in members:
             return True

--- a/grouper/fe/handlers/group_leave.py
+++ b/grouper/fe/handlers/group_leave.py
@@ -1,12 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 from grouper.user import user_role
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class GroupLeave(GrouperHandler):
-    def get(self, group_id=None, name=None):
-        group = Group.get(self.session, group_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -16,8 +26,10 @@ class GroupLeave(GrouperHandler):
 
         return self.render("group-leave.html", group=group)
 
-    def post(self, group_id=None, name=None):
-        group = Group.get(self.session, group_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_leave.py
+++ b/grouper/fe/handlers/group_leave.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -14,7 +13,7 @@ if TYPE_CHECKING:
 
 class GroupLeave(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -27,7 +26,7 @@ class GroupLeave(GrouperHandler):
         return self.render("group-leave.html", group=group)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.forms import GroupRemoveForm
 from grouper.fe.util import Alert, GrouperHandler
@@ -18,7 +17,7 @@ if TYPE_CHECKING:
 
 class GroupRemove(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.forms import GroupRemoveForm
 from grouper.fe.util import Alert, GrouperHandler
@@ -10,15 +13,14 @@ from grouper.user import get_user_or_group
 from grouper.user_group import user_can_manage_group
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupRemove(GrouperHandler):
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id", None)  # type: Optional[int]
-        name = kwargs.get("name", None)  # type: Optional[str]
-        group = Group.get(self.session, group_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -22,8 +21,8 @@ if TYPE_CHECKING:
 
 class GroupRequestUpdate(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        request_id: str = kwargs["request_id"]
-        name: str = unquote(kwargs["name"])
+        request_id = self.get_path_argument("request_id")
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -57,8 +56,8 @@ class GroupRequestUpdate(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        request_id: str = kwargs["request_id"]
-        name: str = unquote(kwargs["name"])
+        request_id = self.get_path_argument("request_id")
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
@@ -14,17 +17,15 @@ from grouper.request import get_on_behalf_by_request
 from grouper.user import user_role
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any, List, Tuple
 
 
 class GroupRequestUpdate(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        request_id = kwargs["request_id"]  # type: int
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        request_id: str = kwargs["request_id"]
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -55,13 +56,11 @@ class GroupRequestUpdate(GrouperHandler):
             updates=updates,
         )
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        request_id = kwargs["request_id"]  # type: int
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        request_id: str = kwargs["request_id"]
+        name: str = unquote(kwargs["name"])
 
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -204,5 +203,5 @@ class GroupRequestUpdate(GrouperHandler):
         else:
             return self.redirect("/groups/{}/requests".format(group.name))
 
-    def _get_choices(self, current_status):
-        return [[status] * 2 for status in REQUEST_STATUS_CHOICES[current_status]]
+    def _get_choices(self, current_status: str) -> List[Tuple[str, str]]:
+        return [(status, status) for status in REQUEST_STATUS_CHOICES[current_status]]

--- a/grouper/fe/handlers/group_requests.py
+++ b/grouper/fe/handlers/group_requests.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.fe.util import GrouperHandler
 from grouper.group_requests import get_requests_by_group
@@ -6,10 +11,15 @@ from grouper.models.group import Group
 from grouper.models.request import Request
 from grouper.user import user_role, user_role_index
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class GroupRequests(GrouperHandler):
-    def get(self, group_id=None, name=None):
-        group = Group.get(self.session, group_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/group_requests.py
+++ b/grouper/fe/handlers/group_requests.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
 from grouper.fe.util import GrouperHandler
@@ -17,7 +16,7 @@ if TYPE_CHECKING:
 
 class GroupRequests(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import get_group_audit_members_infos
 from grouper.fe.handlers.template_variables import get_group_view_template_vars
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 class GroupView(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         self.handle_refresh()
         group = Group.get(self.session, name=name)

--- a/grouper/fe/handlers/group_view.py
+++ b/grouper/fe/handlers/group_view.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import get_group_audit_members_infos
 from grouper.fe.handlers.template_variables import get_group_view_template_vars
@@ -7,17 +10,15 @@ from grouper.models.group import Group
 from grouper.role_user import is_role_user
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class GroupView(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
         self.handle_refresh()
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/perf_profile.py
+++ b/grouper/fe/handlers/perf_profile.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
-from tornado.web import RequestHandler
-
+from grouper.fe.util import GrouperHandler
 from grouper.models.base.session import Session
 from grouper.perf_profile import FLAMEGRAPH_SUPPORTED, get_flamegraph_svg, InvalidUUID
 
@@ -9,11 +10,10 @@ if TYPE_CHECKING:
     from typing import Any
 
 
-# Don't use GrouperHandler here as we don't want to count these as requests.
-class PerfProfile(RequestHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        trace_uuid = kwargs["trace_uuid"]  # type: str
+class PerfProfile(GrouperHandler):
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        trace_uuid = self.get_path_argument("trace_uuid")
+
         if not FLAMEGRAPH_SUPPORTED:
             return self.send_error(
                 status_code=404,

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from grouper.fe.util import Alert, GrouperHandler
@@ -8,23 +10,21 @@ if TYPE_CHECKING:
         GroupPermissionGrant,
         ServiceAccountPermissionGrant,
     )
-    from typing import List
+    from typing import Any, List
 
 
 class PermissionDisable(GrouperHandler, DisablePermissionUI):
     """Disable a permission via the browser UI."""
 
-    def disabled_permission(self, name):
-        # type: (str) -> None
+    def disabled_permission(self, name: str) -> None:
         self.redirect("/permissions/{}".format(name))
 
     def disable_permission_failed_existing_grants(
         self,
-        name,  # type: str
-        group_grants,  # type: List[GroupPermissionGrant]
-        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
-    ):
-        # type: (...) -> None
+        name: str,
+        group_grants: List[GroupPermissionGrant],
+        service_account_grants: List[ServiceAccountPermissionGrant],
+    ) -> None:
         """The permission view page will show the grants, so we don't include them in the error."""
         alert = Alert(
             "danger",
@@ -35,21 +35,17 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         )
         self.redirect("/permissions/{}".format(name), alerts=[alert])
 
-    def disable_permission_failed_not_found(self, name):
-        # type: (str) -> None
+    def disable_permission_failed_not_found(self, name: str) -> None:
         return self.notfound()
 
-    def disable_permission_failed_permission_denied(self, name):
-        # type: (str) -> None
+    def disable_permission_failed_permission_denied(self, name: str) -> None:
         return self.forbidden()
 
-    def disable_permission_failed_system_permission(self, name):
-        # type: (str) -> None
+    def disable_permission_failed_system_permission(self, name: str) -> None:
         return self.forbidden()
 
-    def post(self, *args, **kwargs):
-        # type: (*str, **str) -> None
-        name = kwargs["name"]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = kwargs["name"]
         usecase = self.usecase_factory.create_disable_permission_usecase(
             self.current_user.username, self
         )

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -45,7 +45,7 @@ class PermissionDisable(GrouperHandler, DisablePermissionUI):
         return self.forbidden()
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = kwargs["name"]
+        name = self.get_path_argument("name")
         usecase = self.usecase_factory.create_disable_permission_usecase(
             self.current_user.username, self
         )

--- a/grouper/fe/handlers/permission_disable_auditing.py
+++ b/grouper/fe/handlers/permission_disable_auditing.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from grouper.constants import AUDIT_MANAGER
 from grouper.fe.util import GrouperHandler
 from grouper.permissions import disable_permission_auditing, NoSuchPermission
 from grouper.user_permissions import user_has_permission, user_is_permission_admin
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class PermissionDisableAuditing(GrouperHandler):
-    def post(self, user_id=None, name=None):
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = kwargs["name"]
+
         if not (
             user_is_permission_admin(self.session, self.current_user)
             or user_has_permission(self.session, self.current_user, AUDIT_MANAGER)

--- a/grouper/fe/handlers/permission_disable_auditing.py
+++ b/grouper/fe/handlers/permission_disable_auditing.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class PermissionDisableAuditing(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = kwargs["name"]
+        name = self.get_path_argument("name")
 
         if not (
             user_is_permission_admin(self.session, self.current_user)

--- a/grouper/fe/handlers/permission_enable_auditing.py
+++ b/grouper/fe/handlers/permission_enable_auditing.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from grouper.constants import AUDIT_MANAGER
 from grouper.fe.util import GrouperHandler
 from grouper.permissions import enable_permission_auditing, NoSuchPermission
 from grouper.user_permissions import user_has_permission, user_is_permission_admin
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class PermissionEnableAuditing(GrouperHandler):
-    def post(self, name=None):
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = kwargs["name"]
+
         if not (
             user_is_permission_admin(self.session, self.current_user)
             or user_has_permission(self.session, self.current_user, AUDIT_MANAGER)

--- a/grouper/fe/handlers/permission_enable_auditing.py
+++ b/grouper/fe/handlers/permission_enable_auditing.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class PermissionEnableAuditing(GrouperHandler):
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = kwargs["name"]
+        name = self.get_path_argument("name")
 
         if not (
             user_is_permission_admin(self.session, self.current_user)

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -37,6 +37,6 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = kwargs["name"]
+        name = self.get_path_argument("name")
         usecase = self.usecase_factory.create_view_permission_usecase(self)
         usecase.view_permission(name, self.current_user.username, audit_log_limit=20)

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from grouper.fe.util import GrouperHandler
@@ -14,15 +16,17 @@ if TYPE_CHECKING:
 
 
 class PermissionView(GrouperHandler, ViewPermissionUI):
+    def view_permission_failed_not_found(self, name: str) -> None:
+        self.notfound()
+
     def viewed_permission(
         self,
-        permission,  # type: Permission
-        group_grants,  # type: List[GroupPermissionGrant]
-        service_account_grants,  # type: List[ServiceAccountPermissionGrant]
-        access,  # type: PermissionAccess
-        audit_log_entries,  # type: List[AuditLogEntry]
-    ):
-        # type (...) -> None
+        permission: Permission,
+        group_grants: List[GroupPermissionGrant],
+        service_account_grants: List[ServiceAccountPermissionGrant],
+        access: PermissionAccess,
+        audit_log_entries: List[AuditLogEntry],
+    ) -> None:
         self.render(
             "permission.html",
             permission=permission,
@@ -32,12 +36,7 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
             audit_log_entries=audit_log_entries,
         )
 
-    def view_permission_failed_not_found(self, name):
-        # type: (str) -> None
-        self.notfound()
-
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        name = kwargs["name"]  # type: str
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = kwargs["name"]
         usecase = self.usecase_factory.create_view_permission_usecase(self)
         usecase.view_permission(name, self.current_user.username, audit_log_limit=20)

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from sqlalchemy.exc import IntegrityError
 
 from grouper.audit import assert_controllers_are_auditors, UserNotAuditor
@@ -9,14 +14,19 @@ from grouper.permissions import get_permission, grant_permission
 from grouper.user_permissions import user_grantable_permissions
 from grouper.util import matches_glob
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class PermissionsGrant(GrouperHandler):
-    def get(self, name=None):
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
         grantable = user_grantable_permissions(self.session, self.current_user)
         if not grantable:
             return self.forbidden()
 
-        group = Group.get(self.session, None, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 
@@ -28,12 +38,14 @@ class PermissionsGrant(GrouperHandler):
 
         return self.render("permission-grant.html", form=form, group=group)
 
-    def post(self, name=None):
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
         grantable = user_grantable_permissions(self.session, self.current_user)
         if not grantable:
             return self.forbidden()
 
-        group = Group.get(self.session, None, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
 

--- a/grouper/fe/handlers/permissions_grant.py
+++ b/grouper/fe/handlers/permissions_grant.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from sqlalchemy.exc import IntegrityError
 
@@ -20,7 +19,7 @@ if TYPE_CHECKING:
 
 class PermissionsGrant(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         grantable = user_grantable_permissions(self.session, self.current_user)
         if not grantable:
@@ -39,7 +38,7 @@ class PermissionsGrant(GrouperHandler):
         return self.render("permission-grant.html", form=form, group=group)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         grantable = user_grantable_permissions(self.session, self.current_user)
         if not grantable:

--- a/grouper/fe/handlers/permissions_revoke.py
+++ b/grouper/fe/handlers/permissions_revoke.py
@@ -34,7 +34,7 @@ class PermissionsRevoke(GrouperHandler):
         return False
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        mapping_id = int(kwargs["mapping_id"])
+        mapping_id = int(self.get_path_argument("mapping_id"))
         mapping = PermissionMap.get(self.session, id=mapping_id)
 
         if not mapping:
@@ -46,7 +46,7 @@ class PermissionsRevoke(GrouperHandler):
         self.render("permission-revoke.html", mapping=mapping)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        mapping_id = int(kwargs["mapping_id"])
+        mapping_id = int(self.get_path_argument("mapping_id"))
         mapping = PermissionMap.get(self.session, id=mapping_id)
 
         if not mapping:

--- a/grouper/fe/handlers/permissions_revoke.py
+++ b/grouper/fe/handlers/permissions_revoke.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.counter import Counter
@@ -6,10 +10,15 @@ from grouper.user_group import user_is_owner_of_group
 from grouper.user_permissions import user_grantable_permissions
 from grouper.util import matches_glob
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.models.user import User
+    from typing import Any
+
 
 class PermissionsRevoke(GrouperHandler):
     @staticmethod
-    def check_access(session, mapping, user):
+    def check_access(session: Session, mapping: PermissionMap, user: User):
         user_is_owner = user_is_owner_of_group(session, mapping.group, user)
 
         if user_is_owner:
@@ -24,7 +33,8 @@ class PermissionsRevoke(GrouperHandler):
 
         return False
 
-    def get(self, name=None, mapping_id=None):
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        mapping_id = int(kwargs["mapping_id"])
         mapping = PermissionMap.get(self.session, id=mapping_id)
 
         if not mapping:
@@ -35,7 +45,8 @@ class PermissionsRevoke(GrouperHandler):
 
         self.render("permission-revoke.html", mapping=mapping)
 
-    def post(self, name=None, mapping_id=None):
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        mapping_id = int(kwargs["mapping_id"])
         mapping = PermissionMap.get(self.session, id=mapping_id)
 
         if not mapping:

--- a/grouper/fe/handlers/public_key_add.py
+++ b/grouper/fe/handlers/public_key_add.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper import public_key
 from grouper.email_util import send_email
@@ -12,25 +15,22 @@ from grouper.service_account import can_manage_service_account
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class PublicKeyAdd(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
-        # type: (Session, User, User) -> bool
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or (target.role_user and can_manage_role_user(session, actor, tuser=target))
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -39,12 +39,10 @@ class PublicKeyAdd(GrouperHandler):
 
         self.render("public-key-add.html", form=PublicKeyForm(), user=user)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/public_key_add.py
+++ b/grouper/fe/handlers/public_key_add.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper import public_key
 from grouper.email_util import send_email
@@ -28,7 +27,7 @@ class PublicKeyAdd(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:
@@ -40,7 +39,7 @@ class PublicKeyAdd(GrouperHandler):
         self.render("public-key-add.html", form=PublicKeyForm(), user=user)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/public_key_delete.py
+++ b/grouper/fe/handlers/public_key_delete.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.email_util import send_email
 from grouper.fe.settings import settings
@@ -12,13 +15,12 @@ from grouper.user_permissions import user_is_user_admin
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class PublicKeyDelete(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
-        # type: (Session, User, User) -> bool
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or user_is_user_admin(session, actor)
@@ -26,13 +28,11 @@ class PublicKeyDelete(GrouperHandler):
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
-        key_id = kwargs["key_id"]  # type: int
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        key_id = int(kwargs["key_id"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -46,13 +46,11 @@ class PublicKeyDelete(GrouperHandler):
 
         self.render("public-key-delete.html", user=user, key=key)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
-        key_id = kwargs["key_id"]  # type: int
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        key_id = int(kwargs["key_id"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/public_key_delete.py
+++ b/grouper/fe/handlers/public_key_delete.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.email_util import send_email
 from grouper.fe.settings import settings
@@ -29,8 +28,8 @@ class PublicKeyDelete(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        key_id = int(kwargs["key_id"])
+        name = self.get_path_argument("name")
+        key_id = int(self.get_path_argument("key_id"))
 
         user = User.get(self.session, name=name)
         if not user:
@@ -47,8 +46,8 @@ class PublicKeyDelete(GrouperHandler):
         self.render("public-key-delete.html", user=user, key=key)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        key_id = int(kwargs["key_id"])
+        name = self.get_path_argument("name")
+        key_id = int(self.get_path_argument("key_id"))
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/role_user_view.py
+++ b/grouper/fe/handlers/role_user_view.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.audit import get_group_audit_members_infos
 from grouper.fe.handlers.template_variables import get_role_user_view_template_vars
@@ -7,17 +10,15 @@ from grouper.models.group import Group
 from grouper.models.user import User
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class RoleUserView(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
         self.handle_refresh()
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
 
         if not user or not user.role_user:
             return self.notfound()

--- a/grouper/fe/handlers/role_user_view.py
+++ b/grouper/fe/handlers/role_user_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.audit import get_group_audit_members_infos
 from grouper.fe.handlers.template_variables import get_role_user_view_template_vars
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 class RoleUserView(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         self.handle_refresh()
         user = User.get(self.session, name=name)

--- a/grouper/fe/handlers/service_account_create.py
+++ b/grouper/fe/handlers/service_account_create.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.forms import ServiceAccountCreateForm
 from grouper.fe.util import GrouperHandler
@@ -51,7 +50,7 @@ class ServiceAccountCreate(GrouperHandler, CreateServiceAccountUI):
         self.redirect(url)
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        owner: str = unquote(kwargs["name"])
+        owner = self.get_path_argument("name")
 
         usecase = self.usecase_factory.create_create_service_account_usecase(
             self.current_user.username, self
@@ -64,7 +63,7 @@ class ServiceAccountCreate(GrouperHandler, CreateServiceAccountUI):
         self.render("service-account-create.html", form=form, owner=owner)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        owner: str = unquote(kwargs["name"])
+        owner = self.get_path_argument("name")
 
         form = ServiceAccountCreateForm(self.request.arguments)
         if not form.validate():

--- a/grouper/fe/handlers/service_account_create.py
+++ b/grouper/fe/handlers/service_account_create.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.forms import ServiceAccountCreateForm
 from grouper.fe.util import GrouperHandler
@@ -9,52 +12,46 @@ if TYPE_CHECKING:
 
 
 class ServiceAccountCreate(GrouperHandler, CreateServiceAccountUI):
-    def render_form_with_errors(self, form, owner):
-        # type: (ServiceAccountCreateForm, str) -> None
-        return self.render(
+    def render_form_with_errors(self, form: ServiceAccountCreateForm, owner: str) -> None:
+        self.render(
             "service-account-create.html",
             form=form,
             owner=owner,
             alerts=self.get_form_alerts(form.errors),
         )
 
-    def create_service_account_failed_already_exists(self, service, owner):
-        # type: (str, str) -> None
+    def create_service_account_failed_already_exists(self, service: str, owner: str) -> None:
         form = ServiceAccountCreateForm(self.request.arguments)
         msg = "A user or service account with name {} already exists".format(service)
         form.name.errors = [msg]
         self.render_form_with_errors(form, owner)
 
-    def create_service_account_failed_invalid_name(self, service, owner, message):
-        # type: (str, str, str) -> None
+    def create_service_account_failed_invalid_name(
+        self, service: str, owner: str, message: str
+    ) -> None:
         form = ServiceAccountCreateForm(self.request.arguments)
         form.name.errors = [message]
         self.render_form_with_errors(form, owner)
 
     def create_service_account_failed_invalid_machine_set(
-        self, service, owner, machine_set, message
-    ):
-        # type: (str, str, str, str) -> None
+        self, service: str, owner: str, machine_set: str, message: str
+    ) -> None:
         form = ServiceAccountCreateForm(self.request.arguments)
         form.machine_set.errors = [message]
         self.render_form_with_errors(form, owner)
 
-    def create_service_account_failed_invalid_owner(self, service, owner):
-        # type: (str, str) -> None
+    def create_service_account_failed_invalid_owner(self, service: str, owner: str) -> None:
         self.notfound()
 
-    def create_service_account_failed_permission_denied(self, service, owner):
-        # type: (str, str) -> None
+    def create_service_account_failed_permission_denied(self, service: str, owner: str) -> None:
         self.forbidden()
 
-    def created_service_account(self, service, owner):
-        # type: (str, str) -> None
+    def created_service_account(self, service: str, owner: str) -> None:
         url = "/groups/{}/service/{}?refresh=yes".format(owner, service)
         self.redirect(url)
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        owner = kwargs["name"]  # type: str
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        owner: str = unquote(kwargs["name"])
 
         usecase = self.usecase_factory.create_create_service_account_usecase(
             self.current_user.username, self
@@ -66,9 +63,8 @@ class ServiceAccountCreate(GrouperHandler, CreateServiceAccountUI):
         form = ServiceAccountCreateForm()
         self.render("service-account-create.html", form=form, owner=owner)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        owner = kwargs["name"]  # type: str
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        owner: str = unquote(kwargs["name"])
 
         form = ServiceAccountCreateForm(self.request.arguments)
         if not form.validate():

--- a/grouper/fe/handlers/service_account_disable.py
+++ b/grouper/fe/handlers/service_account_disable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN
 from grouper.fe.util import GrouperHandler
@@ -24,8 +23,8 @@ class ServiceAccountDisable(GrouperHandler):
         return can_manage_service_account(session, target, actor)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        accountname: str = unquote(kwargs["accountname"])
+        name = self.get_path_argument("name")
+        accountname = self.get_path_argument("accountname")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/service_account_edit.py
+++ b/grouper/fe/handlers/service_account_edit.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.forms import ServiceAccountEditForm
 from grouper.fe.util import GrouperHandler
@@ -15,8 +14,8 @@ if TYPE_CHECKING:
 
 class ServiceAccountEdit(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        accountname: str = unquote(kwargs["accountname"])
+        name = self.get_path_argument("name")
+        accountname = self.get_path_argument("accountname")
 
         group = Group.get(self.session, name=name)
         if not group:
@@ -35,8 +34,8 @@ class ServiceAccountEdit(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        accountname: str = unquote(kwargs["accountname"])
+        name = self.get_path_argument("name")
+        accountname = self.get_path_argument("accountname")
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/service_account_edit.py
+++ b/grouper/fe/handlers/service_account_edit.py
@@ -1,16 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.fe.forms import ServiceAccountEditForm
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
 from grouper.service_account import BadMachineSet, can_manage_service_account, edit_service_account
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class ServiceAccountEdit(GrouperHandler):
-    def get(self, group_id=None, name=None, account_id=None, accountname=None):
-        group = Group.get(self.session, group_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        accountname: str = unquote(kwargs["accountname"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
-        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        service_account = ServiceAccount.get(self.session, name=accountname)
         if not service_account:
             return self.notfound()
 
@@ -23,11 +34,14 @@ class ServiceAccountEdit(GrouperHandler):
             "service-account-edit.html", service_account=service_account, group=group, form=form
         )
 
-    def post(self, group_id=None, name=None, account_id=None, accountname=None):
-        group = Group.get(self.session, group_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        accountname: str = unquote(kwargs["accountname"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
-        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        service_account = ServiceAccount.get(self.session, name=accountname)
         if not service_account:
             return self.notfound()
 

--- a/grouper/fe/handlers/service_account_enable.py
+++ b/grouper/fe/handlers/service_account_enable.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import operator
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN
 from grouper.fe.forms import ServiceAccountEnableForm
@@ -42,7 +41,7 @@ class ServiceAccountEnable(GrouperHandler):
         return form
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         service_account = ServiceAccount.get(self.session, name=name)
         if not service_account:
@@ -55,7 +54,7 @@ class ServiceAccountEnable(GrouperHandler):
         return self.render("service-account-enable.html", form=form, user=service_account.user)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         service_account = ServiceAccount.get(self.session, name=name)
         if not service_account:

--- a/grouper/fe/handlers/service_account_enable.py
+++ b/grouper/fe/handlers/service_account_enable.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import operator
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN
 from grouper.fe.forms import ServiceAccountEnableForm
@@ -9,20 +13,22 @@ from grouper.models.service_account import ServiceAccount
 from grouper.service_account import enable_service_account
 from grouper.user_permissions import user_has_permission
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.models.user import User
+    from typing import Any
+
 
 class ServiceAccountEnable(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
+    def check_access(session: Session, actor: User, target: ServiceAccount) -> bool:
         return user_has_permission(session, actor, USER_ADMIN)
 
-    def get_form(self):
+    def get_form(self) -> ServiceAccountEnableForm:
         """Helper to create a ServiceAccountEnableForm populated with all groups.
 
         Note that the first choice is blank so the first user alphabetically
         isn't always selected.
-
-        Returns:
-            ServiceAccountEnableForm object.
         """
         form = ServiceAccountEnableForm(self.request.arguments)
 
@@ -35,8 +41,10 @@ class ServiceAccountEnable(GrouperHandler):
 
         return form
 
-    def get(self, user_id=None, name=None):
-        service_account = ServiceAccount.get(self.session, user_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        service_account = ServiceAccount.get(self.session, name=name)
         if not service_account:
             return self.notfound()
 
@@ -46,8 +54,10 @@ class ServiceAccountEnable(GrouperHandler):
         form = self.get_form()
         return self.render("service-account-enable.html", form=form, user=service_account.user)
 
-    def post(self, user_id=None, name=None):
-        service_account = ServiceAccount.get(self.session, user_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        service_account = ServiceAccount.get(self.session, name=name)
         if not service_account:
             return self.notfound()
 

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.forms import ServiceAccountPermissionGrantForm
 from grouper.fe.util import Alert, GrouperHandler
@@ -14,8 +13,8 @@ if TYPE_CHECKING:
 
 class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAccountUI):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        owner: str = unquote(kwargs["name"])
-        service: str = unquote(kwargs["accountname"])
+        owner = self.get_path_argument("name")
+        service = self.get_path_argument("accountname")
 
         usecase = self.usecase_factory.create_grant_permission_to_service_account_usecase(
             self.current_user.username, self
@@ -70,8 +69,8 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
         self.redirect(url)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        self._owner: str = unquote(kwargs["name"])
-        service: str = unquote(kwargs["accountname"])
+        self._owner = self.get_path_argument("name")
+        service = self.get_path_argument("accountname")
 
         usecase = self.usecase_factory.create_grant_permission_to_service_account_usecase(
             self.current_user.username, self

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.forms import ServiceAccountPermissionGrantForm
 from grouper.fe.util import Alert, GrouperHandler
@@ -10,10 +13,9 @@ if TYPE_CHECKING:
 
 
 class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAccountUI):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        owner = kwargs["name"]  # type: str
-        service = kwargs["accountname"]  # type: str
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        owner: str = unquote(kwargs["name"])
+        service: str = unquote(kwargs["accountname"])
 
         usecase = self.usecase_factory.create_grant_permission_to_service_account_usecase(
             self.current_user.username, self
@@ -30,17 +32,15 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
         )
 
     def grant_permission_to_service_account_failed_invalid_argument(
-        self, permission, argument, service, message
-    ):
-        # type: (str, str, str, str) -> None
+        self, permission: str, argument: str, service: str, message: str
+    ) -> None:
         form = self._get_form(self._grantable)
         form.argument.errors = [message]
         self._render_form_with_errors(form, service, self._owner)
 
     def grant_permission_to_service_account_failed_permission_denied(
-        self, permission, argument, service, message
-    ):
-        # type: (str, str, str, str) -> None
+        self, permission: str, argument: str, service: str, message: str
+    ) -> None:
         form = self._get_form(self._grantable)
         self.render(
             "service-account-permission-grant.html",
@@ -50,26 +50,28 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
             alerts=[Alert("error", message)],
         )
 
-    def grant_permission_to_service_account_failed_permission_not_found(self, permission, service):
-        # type: (str, str) -> None
+    def grant_permission_to_service_account_failed_permission_not_found(
+        self, permission: str, service: str
+    ) -> None:
         message = "Unknown permission {}".format(permission)
         form = self._get_form(self._grantable)
         form.permission.errors = [message]
         self._render_form_with_errors(form, service, self._owner)
 
-    def grant_permission_to_service_account_failed_service_account_not_found(self, service):
-        # type: (str) -> None
+    def grant_permission_to_service_account_failed_service_account_not_found(
+        self, service: str
+    ) -> None:
         self.notfound()
 
-    def granted_permission_to_service_account(self, permission, argument, service):
-        # type: (str, str, str) -> None
+    def granted_permission_to_service_account(
+        self, permission: str, argument: str, service: str
+    ) -> None:
         url = "/groups/{}/service/{}?refresh=yes".format(self._owner, service)
         self.redirect(url)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        self._owner = kwargs["name"]  # type: str
-        service = kwargs["accountname"]  # type: str
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        self._owner: str = unquote(kwargs["name"])
+        service: str = unquote(kwargs["accountname"])
 
         usecase = self.usecase_factory.create_grant_permission_to_service_account_usecase(
             self.current_user.username, self
@@ -85,8 +87,9 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
             form.data["permission"], form.data["argument"], service
         )
 
-    def _get_form(self, grantable):
-        # type: (Iterable[GroupPermissionGrant]) -> ServiceAccountPermissionGrantForm
+    def _get_form(
+        self, grantable: Iterable[GroupPermissionGrant]
+    ) -> ServiceAccountPermissionGrantForm:
         """Helper to create a ServiceAccountPermissionGrantForm.
 
         Populate it with all the grantable permissions.  Note that the first choice is blank so the
@@ -102,8 +105,9 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
             form.permission.choices.append([grant.permission, entry])
         return form
 
-    def _render_form_with_errors(self, form, service, owner):
-        # type: (ServiceAccountPermissionGrantForm, str, str) -> None
+    def _render_form_with_errors(
+        self, form: ServiceAccountPermissionGrantForm, service: str, owner: str
+    ) -> None:
         self.render(
             "service-account-permission-grant.html",
             form=form,

--- a/grouper/fe/handlers/service_account_permission_revoke.py
+++ b/grouper/fe/handlers/service_account_permission_revoke.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN
 from grouper.fe.util import GrouperHandler
@@ -27,9 +26,9 @@ class ServiceAccountPermissionRevoke(GrouperHandler):
         return can_manage_service_account(session, target, actor)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        accountname: str = unquote(kwargs["accountname"])
-        mapping_id = int(kwargs["mapping_id"])
+        name = self.get_path_argument("name")
+        accountname = self.get_path_argument("accountname")
+        mapping_id = int(self.get_path_argument("mapping_id"))
 
         group = Group.get(self.session, name=name)
         if not group:

--- a/grouper/fe/handlers/service_account_permission_revoke.py
+++ b/grouper/fe/handlers/service_account_permission_revoke.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.constants import USER_ADMIN
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -8,19 +13,28 @@ from grouper.models.service_account_permission_map import ServiceAccountPermissi
 from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_has_permission
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from grouper.models.user import User
+    from typing import Any
+
 
 class ServiceAccountPermissionRevoke(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
+    def check_access(session: Session, actor: User, target: ServiceAccount) -> bool:
         if user_has_permission(session, actor, USER_ADMIN):
             return True
         return can_manage_service_account(session, target, actor)
 
-    def post(self, group_id=None, name=None, account_id=None, accountname=None, mapping_id=None):
-        group = Group.get(self.session, group_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        accountname: str = unquote(kwargs["accountname"])
+        mapping_id = int(kwargs["mapping_id"])
+
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
-        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        service_account = ServiceAccount.get(self.session, name=accountname)
         if not service_account:
             return self.notfound()
 

--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.handlers.template_variables import get_user_view_template_vars
 from grouper.fe.util import GrouperHandler
@@ -6,22 +9,19 @@ from grouper.models.group import Group
 from grouper.models.service_account import ServiceAccount
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class ServiceAccountView(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        group_id = kwargs.get("group_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
-        account_id = kwargs.get("account_id")  # type: Optional[int]
-        accountname = kwargs.get("accountname")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        accountname: str = unquote(kwargs["accountname"])
 
         self.handle_refresh()
-        group = Group.get(self.session, group_id, name)
+        group = Group.get(self.session, name=name)
         if not group:
             return self.notfound()
-        service_account = ServiceAccount.get(self.session, account_id, accountname)
+        service_account = ServiceAccount.get(self.session, name=accountname)
         if not service_account:
             return self.notfound()
 

--- a/grouper/fe/handlers/service_account_view.py
+++ b/grouper/fe/handlers/service_account_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.handlers.template_variables import get_user_view_template_vars
 from grouper.fe.util import GrouperHandler
@@ -14,8 +13,8 @@ if TYPE_CHECKING:
 
 class ServiceAccountView(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        accountname: str = unquote(kwargs["accountname"])
+        name = self.get_path_argument("name")
+        accountname = self.get_path_argument("accountname")
 
         self.handle_refresh()
         group = Group.get(self.session, name=name)

--- a/grouper/fe/handlers/user_disable.py
+++ b/grouper/fe/handlers/user_disable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN, USER_DISABLE
 from grouper.email_util import cancel_async_emails
@@ -29,7 +28,7 @@ class UserDisable(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_disable.py
+++ b/grouper/fe/handlers/user_disable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN, USER_DISABLE
 from grouper.email_util import cancel_async_emails
@@ -15,7 +16,7 @@ from grouper.user_permissions import user_has_permission
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class UserDisable(GrouperHandler):
@@ -28,10 +29,9 @@ class UserDisable(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        user_id: Optional[int] = kwargs.get("user_id")
-        name: Optional[str] = kwargs.get("name")
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_enable.py
+++ b/grouper/fe/handlers/user_enable.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.constants import USER_ADMIN, USER_ENABLE
 from grouper.fe.forms import UserEnableForm
 from grouper.fe.util import GrouperHandler
@@ -7,24 +12,30 @@ from grouper.role_user import enable_role_user, is_owner_of_role_user
 from grouper.user import enable_user
 from grouper.user_permissions import user_has_permission
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Any
+
 
 class UserEnable(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return user_has_permission(session, actor, USER_ADMIN) or (
             target.role_user and is_owner_of_role_user(session, actor, tuser=target)
         )
 
     @staticmethod
-    def check_access_without_membership(session, actor, target):
+    def check_access_without_membership(session: Session, actor: User, target: User) -> bool:
         return (
             user_has_permission(session, actor, USER_ADMIN)
             or (target.role_user and is_owner_of_role_user(session, actor, tuser=target))
             or user_has_permission(session, actor, USER_ENABLE, argument=target.name)
         )
 
-    def post(self, user_id=None, name=None):
-        user = User.get(self.session, user_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_enable.py
+++ b/grouper/fe/handlers/user_enable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_ADMIN, USER_ENABLE
 from grouper.fe.forms import UserEnableForm
@@ -33,7 +32,7 @@ class UserEnable(GrouperHandler):
         )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.email_util import send_email
 from grouper.fe.forms import UserPasswordForm
@@ -28,7 +27,7 @@ class UserPasswordAdd(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:
@@ -40,7 +39,7 @@ class UserPasswordAdd(GrouperHandler):
         self.render("user-password-add.html", form=UserPasswordForm(), user=user)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_password_add.py
+++ b/grouper/fe/handlers/user_password_add.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.email_util import send_email
 from grouper.fe.forms import UserPasswordForm
@@ -12,25 +15,22 @@ from grouper.user_password import add_new_user_password, PasswordAlreadyExists
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class UserPasswordAdd(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
-        # type: (Session, User, User) -> bool
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or (target.role_user and can_manage_role_user(session, actor, tuser=target))
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -39,12 +39,10 @@ class UserPasswordAdd(GrouperHandler):
 
         self.render("user-password-add.html", form=UserPasswordForm(), user=user)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_password_delete.py
+++ b/grouper/fe/handlers/user_password_delete.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
@@ -7,10 +12,14 @@ from grouper.service_account import can_manage_service_account
 from grouper.user_password import delete_user_password, PasswordDoesNotExist
 from grouper.user_permissions import user_is_user_admin
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Any
+
 
 class UserPasswordDelete(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or user_is_user_admin(session, actor)
@@ -18,31 +27,37 @@ class UserPasswordDelete(GrouperHandler):
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, user_id=None, name=None, pass_id=None):
-        user = User.get(self.session, user_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        password_id = int(kwargs["password_id"])
+
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
         if not self.check_access(self.session, self.current_user, user):
             return self.forbidden()
-        password = UserPassword.get(self.session, user=user, id=pass_id)
+        password = UserPassword.get(self.session, user=user, id=password_id)
         return self.render("user-password-delete.html", user=user, password=password)
 
-    def post(self, user_id=None, name=None, pass_id=None):
-        user = User.get(self.session, user_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        password_id = int(kwargs["password_id"])
+
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
         if not self.check_access(self.session, self.current_user, user):
             return self.forbidden()
 
-        password = UserPassword.get(self.session, user=user, id=pass_id)
+        password = UserPassword.get(self.session, user=user, id=password_id)
 
         try:
             delete_user_password(self.session, password.name, user.id)
         except PasswordDoesNotExist:
             # if the password doesn't exist, we can pretend like it did and that we deleted it
-            return self.redirect("/users/{}?refresh=yes".format(user.id))
+            return self.redirect("/users/{}?refresh=yes".format(user.username))
         AuditLog.log(
             self.session,
             self.current_user.id,
@@ -51,4 +66,4 @@ class UserPasswordDelete(GrouperHandler):
             on_user_id=user.id,
         )
         self.session.commit()
-        return self.redirect("/users/{}?refresh=yes".format(user.id))
+        return self.redirect("/users/{}?refresh=yes".format(user.username))

--- a/grouper/fe/handlers/user_password_delete.py
+++ b/grouper/fe/handlers/user_password_delete.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -28,8 +27,8 @@ class UserPasswordDelete(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        password_id = int(kwargs["password_id"])
+        name = self.get_path_argument("name")
+        password_id = int(self.get_path_argument("password_id"))
 
         user = User.get(self.session, name=name)
         if not user:
@@ -41,8 +40,8 @@ class UserPasswordDelete(GrouperHandler):
         return self.render("user-password-delete.html", user=user, password=password)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        password_id = int(kwargs["password_id"])
+        name = self.get_path_argument("name")
+        password_id = int(self.get_path_argument("password_id"))
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_shell.py
+++ b/grouper/fe/handlers/user_shell.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.fe.forms import UserShellForm
@@ -28,7 +27,7 @@ class UserShell(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:
@@ -43,7 +42,7 @@ class UserShell(GrouperHandler):
         self.render("user-shell.html", form=form, user=user)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_shell.py
+++ b/grouper/fe/handlers/user_shell.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.constants import USER_METADATA_SHELL_KEY
 from grouper.fe.forms import UserShellForm
@@ -12,25 +15,22 @@ from grouper.user_metadata import set_user_metadata
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class UserShell(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
-        # type: (Session, User, User) -> bool
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or (target.role_user and can_manage_role_user(session, actor, tuser=target))
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -42,12 +42,10 @@ class UserShell(GrouperHandler):
 
         self.render("user-shell.html", form=form, user=user)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from sqlalchemy.exc import IntegrityError
 
@@ -31,7 +30,7 @@ class UserTokenAdd(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:
@@ -43,7 +42,7 @@ class UserTokenAdd(GrouperHandler):
         self.render("user-token-add.html", form=UserTokenForm(), user=user)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_token_add.py
+++ b/grouper/fe/handlers/user_token_add.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from sqlalchemy.exc import IntegrityError
 
@@ -15,25 +18,22 @@ from grouper.user_token import add_new_user_token
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
-    from typing import Any, Optional
+    from typing import Any
 
 
 class UserTokenAdd(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
-        # type: (Session, User, User) -> bool
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or (target.role_user and can_manage_role_user(session, actor, tuser=target))
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -42,12 +42,10 @@ class UserTokenAdd(GrouperHandler):
 
         self.render("user-token-add.html", form=UserTokenForm(), user=user)
 
-    def post(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name = unquote(kwargs["name"])
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_token_disable.py
+++ b/grouper/fe/handlers/user_token_disable.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import unquote
+
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.user import User
@@ -7,10 +12,14 @@ from grouper.service_account import can_manage_service_account
 from grouper.user_permissions import user_is_user_admin
 from grouper.user_token import disable_user_token
 
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Any
+
 
 class UserTokenDisable(GrouperHandler):
     @staticmethod
-    def check_access(session, actor, target):
+    def check_access(session: Session, actor: User, target: User) -> bool:
         return (
             actor.name == target.name
             or user_is_user_admin(session, actor)
@@ -18,8 +27,11 @@ class UserTokenDisable(GrouperHandler):
             or (target.is_service_account and can_manage_service_account(session, target, actor))
         )
 
-    def get(self, user_id=None, name=None, token_id=None):
-        user = User.get(self.session, user_id, name)
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        token_id = int(kwargs["token_id"])
+
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 
@@ -29,8 +41,11 @@ class UserTokenDisable(GrouperHandler):
         token = UserToken.get(self.session, user=user, id=token_id)
         return self.render("user-token-disable.html", user=user, token=token)
 
-    def post(self, user_id=None, name=None, token_id=None):
-        user = User.get(self.session, user_id, name)
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+        token_id = int(kwargs["token_id"])
+
+        user = User.get(self.session, name=name)
         if not user:
             return self.notfound()
 

--- a/grouper/fe/handlers/user_token_disable.py
+++ b/grouper/fe/handlers/user_token_disable.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
@@ -28,8 +27,8 @@ class UserTokenDisable(GrouperHandler):
         )
 
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        token_id = int(kwargs["token_id"])
+        name = self.get_path_argument("name")
+        token_id = int(self.get_path_argument("token_id"))
 
         user = User.get(self.session, name=name)
         if not user:
@@ -42,8 +41,8 @@ class UserTokenDisable(GrouperHandler):
         return self.render("user-token-disable.html", user=user, token=token)
 
     def post(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
-        token_id = int(kwargs["token_id"])
+        name = self.get_path_argument("name")
+        token_id = int(self.get_path_argument("token_id"))
 
         user = User.get(self.session, name=name)
         if not user:

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import unquote
 
 from grouper.fe.handlers.template_variables import get_user_view_template_vars
 from grouper.fe.util import GrouperHandler
@@ -13,7 +12,7 @@ if TYPE_CHECKING:
 
 class UserView(GrouperHandler):
     def get(self, *args: Any, **kwargs: Any) -> None:
-        name: str = unquote(kwargs["name"])
+        name = self.get_path_argument("name")
 
         self.handle_refresh()
 

--- a/grouper/fe/handlers/user_view.py
+++ b/grouper/fe/handlers/user_view.py
@@ -1,27 +1,29 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from grouper.fe.handlers.template_variables import get_user_view_template_vars
 from grouper.fe.util import GrouperHandler
 from grouper.models.user import User
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 
 class UserView(GrouperHandler):
-    def get(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
-        user_id = kwargs.get("user_id")  # type: Optional[int]
-        name = kwargs.get("name")  # type: Optional[str]
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name: str = unquote(kwargs["name"])
+
         self.handle_refresh()
 
-        user = User.get(self.session, user_id, name)
+        user = User.get(self.session, name=name)
 
         if not user:
             return self.notfound()
 
         if user.role_user:
-            return self.redirect("/service/{}".format(user_id or name))
+            return self.redirect("/service/{}".format(name))
 
         if user.is_service_account:
             service_account = user.service_account

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -76,7 +76,7 @@ $(function () {
     // text and set its form actions to correspond to the selected user.
 
     $("#removeUserModal").on("show.bs.modal", function(e) {
-        var groupId = $('#removeUserModal').data('group-id');
+        var groupName = $('#removeUserModal').data('group-name');
         var button = $(e.relatedTarget);
         var memberName = button.data("member-name");
         var memberType = button.data("member-type");
@@ -85,7 +85,7 @@ $(function () {
         modal.find(".member-name").html(memberName);
 
         var form = modal.find(".remove-member-form");
-        form.attr("action", "/groups/" + groupId + "/remove");
+        form.attr("action", "/groups/" + groupName + "/remove");
         form.find("input[name=member]").val(memberName);
         form.find("input[name=member_type]").val(memberType);
     });

--- a/grouper/fe/templates/group.html
+++ b/grouper/fe/templates/group.html
@@ -132,7 +132,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default"
                         data-dismiss="modal">Close</button>
-                <form action="/groups/{{group.id}}/enable" method="post"
+                <form action="/groups/{{group.groupname}}/enable" method="post"
                       class="inline">
                     {{ xsrf_form()|safe }}
                     <button type="submit" class="btn btn-primary">Enable</button>
@@ -162,7 +162,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default"
                         data-dismiss="modal">Close</button>
-                <form action="/groups/{{group.id}}/disable" method="post"
+                <form action="/groups/{{group.groupname}}/disable" method="post"
                       class="inline">
                     {{ xsrf_form()|safe }}
                     <button type="submit" class="btn btn-primary">Disable</button>
@@ -172,8 +172,8 @@
     </div>
 </div>
 
-<div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog" data-group-id="{{ group.id }}"
-      aria-labelledby="removeUserModal" aria-hidden="true">
+<div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog"
+     data-group-name="{{ group.groupname }}" aria-labelledby="removeUserModal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/grouper/fe/templates/role-user.html
+++ b/grouper/fe/templates/role-user.html
@@ -144,7 +144,7 @@
                 </button>
                 <h4 class="modal-title">Enable User</h4>
            </div>
-            <form action="/users/{{user.id}}/enable" method="post">
+            <form action="/users/{{user.username}}/enable" method="post">
                 <div class="modal-body">
                     <p>Are you sure you want to enable this user?</p>
                     <label class="checkbox normal-weight">
@@ -180,7 +180,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default"
                         data-dismiss="modal">Close</button>
-                <form action="/users/{{user.id}}/disable" method="post"
+                <form action="/users/{{user.username}}/disable" method="post"
                       class="inline">
                     {{ xsrf_form()|safe }}
                     <button type="submit" class="btn btn-primary">Disable</button>
@@ -191,7 +191,7 @@
 </div>
 
 <div class="modal fade" id="removeUserModal" tabindex="-1" role="dialog"
-      data-group-id="{{group.id}}" aria-labelledby="removeUserModal" aria-hidden="true">
+      data-group-name="{{group.groupname}}" aria-labelledby="removeUserModal" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/grouper/fe/templates/user.html
+++ b/grouper/fe/templates/user.html
@@ -140,7 +140,7 @@
                 </button>
                 <h4 class="modal-title">Enable User</h4>
            </div>
-            <form action="/users/{{user.id}}/enable" method="post">
+            <form action="/users/{{user.username}}/enable" method="post">
                 <div class="modal-body">
                     <p>Are you sure you want to enable this user?</p>
 		    {% if can_enable_preserving_membership %}
@@ -178,7 +178,7 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-default"
                         data-dismiss="modal">Close</button>
-                <form action="/users/{{user.id}}/disable" method="post"
+                <form action="/users/{{user.username}}/disable" method="post"
                       class="inline">
                     {{ xsrf_form()|safe }}
                     <button type="submit" class="btn btn-primary">Disable</button>

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -161,6 +161,16 @@ class GrouperHandler(RequestHandler):
 
         return user
 
+    def get_path_argument(self, name: str) -> str:
+        """Get a URL path argument.
+
+        Parallel to get_request_argument() and get_body_argument(), this uses path_kwargs to find
+        an argument to the handler, undo any URL quoting, and return it.  Use this uniformly
+        instead of kwargs for all handler get() and post() methods to handle escaping properly.
+        """
+        value: str = self.path_kwargs[name]
+        return unquote(value)
+
     def prepare(self) -> None:
         username = self.request.headers.get(settings().user_auth_header)
 

--- a/grouper/models/base/constants.py
+++ b/grouper/models/base/constants.py
@@ -1,4 +1,12 @@
-REQUEST_STATUS_CHOICES = {
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Set
+
+
+REQUEST_STATUS_CHOICES: Dict[str, Set[str]] = {
     # Request has been made and awaiting action.
     "pending": set(["actioned", "cancelled"]),
     "actioned": set([]),

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -96,6 +96,17 @@ def test_wrong_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> No
         assert page.has_text("whatever you were looking for wasn't found")
 
 
+def test_escaped_at_sign(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.create_service_account("service@svc.localhost", "some-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/service/service%40svc.localhost"))
+        page = ServiceAccountViewPage(browser)
+        assert page.subheading == "Service Account: service@svc.localhost"
+        assert page.owner == "some-group"
+
+
 def test_create_duplicate(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
     with setup.transaction():
         setup.add_user_to_group("cbguder@a.co", "some-group")

--- a/itests/fe/users_test.py
+++ b/itests/fe/users_test.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
     from tests.setup import SetupTest
 
 
+def test_escaped_at_sign(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/users/gary%40a.co"))
+        page = UserViewPage(browser)
+        assert page.subheading == "gary@a.co"
+
+
 def test_disable_last_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
     with setup.transaction():
         setup.add_user_to_group("gary@a.co", "some-group", role="owner")


### PR DESCRIPTION
Stop supporting both numeric IDs and group, user, service account,
or permission names.  This adds complexity and several ways to do
things for no good reason.  Require the name be used everywhere.

Add support for escaped @ signs in the URL.  Tornado doesn't
unescape them, so we have to support them in the regex and then
manually unescape them.

Remove some gunk from grouper.constants that was only there to
support the frontend routes and instead only keep the bits that are
used for validation.  Move the other regexes for route parsing to
grouper.fe.routes.  Use shorter variable names and f-strings to
make the route list more compact.

Update all the files touched to use modern mypy typing.