### PR TITLE
Allow downgrading your own role

### DIFF
--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -347,7 +347,7 @@ enabled. Membership in this group is regularly reviewed.
 {% macro member_row(group, member, members, current_user, current_user_role) -%}
     <tr class="member-row">
         <td>
-            {% if member.name != current_user.name and member.name != group.name and
+            {% if member.name != group.name and
                 (current_user_role['is_approver'] or
                  (current_user_role['is_manager'] and ROLES[member.role] == "member"))
             %}

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -683,7 +683,7 @@ def get_changes_by_request_id(
 
 
 def update_request(
-    session: Session, request: PermissionRequest, user: User, new_status: str, comment: str,
+    session: Session, request: PermissionRequest, user: User, new_status: str, comment: str
 ) -> None:
     """Update a request.
 

--- a/itests/fe/group_edit_member.py
+++ b/itests/fe/group_edit_member.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from selenium.common.exceptions import NoSuchElementException
+
+from itests.pages.groups import GroupEditMemberPage, GroupViewPage
+from itests.setup import frontend_server
+from plugins import group_ownership_policy
+from tests.url_util import url
+
+if TYPE_CHECKING:
+    from py.path import LocalPath
+    from selenium.webdriver import Chrome
+    from tests.setup import SetupTest
+
+
+def test_edit_self_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group"))
+
+        view_page = GroupViewPage(browser)
+        row = view_page.find_member_row("gary@a.co")
+        assert row.role == "owner"
+        row.click_edit_button()
+
+        edit_page = GroupEditMemberPage(browser)
+        edit_page.set_role("No-Permissions Owner")
+        edit_page.set_reason("Testing")
+        edit_page.submit()
+
+        row = view_page.find_member_row("gary@a.co")
+        assert row.role == "np-owner"
+
+
+def test_self_np_owner_downgrade(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="np-owner")
+        setup.add_user_to_group("zorkian@a.co", "some-group", role="owner")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/edit/user/gary@a.co"))
+
+        page = GroupEditMemberPage(browser)
+        assert sorted(page.get_role_options()) == ["member", "np-owner"]
+        page.set_role("Member")
+        page.set_reason("Testing")
+        page.submit()
+
+        view_page = GroupViewPage(browser)
+        row = view_page.find_member_row("gary@a.co")
+        assert row.role == "member"
+
+
+def test_self_manager_downgrade(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="manager")
+        setup.add_user_to_group("zorkian@a.co", "some-group", role="owner")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/edit/user/gary@a.co"))
+
+        page = GroupEditMemberPage(browser)
+        assert sorted(page.get_role_options()) == ["member", "manager"]
+        page.set_role("Member")
+        page.set_reason("Testing")
+        page.submit()
+
+        view_page = GroupViewPage(browser)
+        row = view_page.find_member_row("gary@a.co")
+        assert row.role == "member"
+
+
+def test_remove_last_owner(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group/edit/user/gary@a.co"))
+
+        page = GroupEditMemberPage(browser)
+        assert sorted(page.get_role_options()) == ["manager", "member", "np-owner", "owner"]
+        page.set_role("Manager")
+        page.set_reason("Testing")
+        page.submit()
+        assert page.subheading == "Edit Member gary@a.co in some-group"
+        assert page.has_alert(group_ownership_policy.EXCEPTION_MESSAGE)
+
+
+def test_edit_member_group_role(tmpdir: LocalPath, setup: SetupTest, browser: Chrome) -> None:
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group", role="owner")
+        setup.add_group_to_group("other-group", "some-group")
+
+    with frontend_server(tmpdir, "gary@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/groups/some-group"))
+
+        view_page = GroupViewPage(browser)
+        row = view_page.find_member_row("other-group")
+        assert row.role == "member"
+        row.click_edit_button()
+
+        edit_page = GroupEditMemberPage(browser)
+        with pytest.raises(NoSuchElementException):
+            edit_page.set_role("Owner")

--- a/itests/pages/groups.py
+++ b/itests/pages/groups.py
@@ -48,6 +48,11 @@ class GroupEditMemberPage(BasePage):
     def form(self) -> WebElement:
         return self.find_element_by_class_name("edit-member-form")
 
+    def get_role_options(self) -> List[str]:
+        element = self.form.find_element_by_name("role")
+        options = element.find_elements_by_tag_name("option")
+        return [o.get_attribute("value") for o in options]
+
     def set_role(self, role: str) -> None:
         field = Select(self.form.find_element_by_name("role"))
         field.select_by_visible_text(role)


### PR DESCRIPTION
Permit an owner to downgrade their role in a group, but not upgrade
(so np-owner cannot become owner).  Ensure that this doesn't allow
someone to remove the last owner by editing their role.

This redoes the exception handling in Group.add_member() slightly
since otherwise it was spewing errors into the logs when someone
tried to downgrade the role as the last owner.  This isn't an
exceptional case, just a known error, so don't use the noisy
flush_transaction decorator (which is also a little silly here since
AuditLog.log() commits the transaction anyway), and instead manually
wrap the call and roll back if needed.