### PR TITLE
Introduce a new method of template handling

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -280,6 +280,27 @@ provides a pre-constructed use case factory to its handlers, created as
 part of initialization of the UI.  For tests, repository, service, and use
 case factories are provided as attributes on the `SetupTest` object.
 
+Templates
+---------
+
+There is a new mechanism for wrapping templates for the frontend (the `fe`
+directory) in `grouper.fe.templates`.  Each template has a corresponding
+dataclass class in that module that defines the variables required by that
+template.  The call mechanism inside frontends then looks like:
+
+.. code:: python
+
+    template = SomeTemplate(variable=value, other=value)
+    self.render_template_class(template)
+
+This provides type checking for templates, ensuring that all the required
+variables are passed in and are of the correct type.
+
+Using this mechanism for all new templates is strongly encouraged, and
+existing templates should be converted to this mechanism as they are
+modified.  The code inside the frontend handlers is much cleaner and type
+checking will catch bugs.
+
 Testing
 -------
 
@@ -399,8 +420,9 @@ New View Use Case
 #. Implement each UI and its corresponding test case.  Many use cases will
    only make sense in one or two of these UIs.
 
-   #. Frontend UI invovles a handler in `grouper.fe.handlers` and possibly
-      a route and new templates, and an integration test in `itests.fe`
+   #. Frontend UI invovles a handler in `grouper.fe.handlers`, possibly a
+      route, possibly a new template and wrapper dataclass in
+      `grouper.fe.templates`, and an integration test in `itests.fe`
       (which may require defining new pages in `itests.pages`).
    #. API UI involves a handler in `grouper.api.handlers` and an
       integration test in `itests.api`.
@@ -455,8 +477,9 @@ New Modify Use Case
    frontend.  It's often faster to test and is convenient later for
    automation or operations.
 
-   #. Frontend UI invovles a handler in `grouper.fe.handlers` and possibly
-      a route and new templates, and an integration test in `itests.fe`
+   #. Frontend UI invovles a handler in `grouper.fe.handlers`, possibly a
+      route, possibly a new template and wrapper dataclass in
+      `grouper.fe.templates`, and an integration test in `itests.fe`
       (which may require defining new pages in `itests.pages`).
    #. `grouper-ctl` UI involves a new class in `grouper.ctl` and a test in
       `tests.ctl`.

--- a/grouper/fe/alerts.py
+++ b/grouper/fe/alerts.py
@@ -1,0 +1,8 @@
+class Alert:
+    def __init__(self, severity: str, message: str, heading: str = None) -> None:
+        self.severity = severity
+        self.message = message
+        if heading is None:
+            self.heading = severity.title() + "!"
+        else:
+            self.heading = heading

--- a/grouper/fe/handlers/audits_complete.py
+++ b/grouper/fe/handlers/audits_complete.py
@@ -5,7 +5,8 @@ from grouper.audit import (
 )
 from grouper.constants import PERMISSION_AUDITOR
 from grouper.email_util import cancel_async_emails
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.alerts import Alert
+from grouper.fe.util import GrouperHandler
 from grouper.models.audit import Audit
 from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.models.audit_member import AUDIT_STATUS_CHOICES

--- a/grouper/fe/handlers/group_add.py
+++ b/grouper/fe/handlers/group_add.py
@@ -6,9 +6,10 @@ from typing import TYPE_CHECKING
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import GroupAddForm
 from grouper.fe.settings import settings
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.group import get_all_groups
 from grouper.group_member import InvalidRoleForMember
 from grouper.models.audit_log import AuditLog

--- a/grouper/fe/handlers/group_edit_member.py
+++ b/grouper/fe/handlers/group_edit_member.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from grouper.audit import assert_can_join, UserNotAuditor
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import GroupEditMemberForm
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.group_member import InvalidRoleForMember
 from grouper.models.comment import OBJ_TYPES
 from grouper.models.group import Group

--- a/grouper/fe/handlers/group_join.py
+++ b/grouper/fe/handlers/group_join.py
@@ -6,9 +6,10 @@ from typing import TYPE_CHECKING
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
 from grouper.entities.group_edge import APPROVER_ROLE_INDICES, GROUP_EDGE_ROLES
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import GroupJoinForm
 from grouper.fe.settings import settings
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.group_member import InvalidRoleForMember
 from grouper.group_requests import count_requests_by_group
 from grouper.models.audit_log import AuditLog

--- a/grouper/fe/handlers/group_remove.py
+++ b/grouper/fe/handlers/group_remove.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import GroupRemoveForm
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 from grouper.plugin.exceptions import PluginRejectedGroupMembershipUpdate

--- a/grouper/fe/handlers/group_request_update.py
+++ b/grouper/fe/handlers/group_request_update.py
@@ -4,9 +4,10 @@ from typing import TYPE_CHECKING
 
 from grouper.audit import assert_can_join, UserNotAuditor
 from grouper.email_util import send_email
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import GroupRequestModifyForm
 from grouper.fe.settings import settings
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.group import Group

--- a/grouper/fe/handlers/permission_disable.py
+++ b/grouper/fe/handlers/permission_disable.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.alerts import Alert
+from grouper.fe.util import GrouperHandler
 from grouper.usecases.disable_permission import DisablePermissionUI
 
 if TYPE_CHECKING:

--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -5,9 +5,10 @@ from tornado.web import HTTPError
 
 from grouper import permissions
 from grouper.audit import UserNotAuditor
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import PermissionRequestForm
 from grouper.fe.settings import settings
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
 from grouper.permissions import get_grantable_permissions, get_permission
 from grouper.user_group import get_groups_by_user

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from grouper.fe.templates import PermissionTemplate
 from grouper.fe.util import GrouperHandler
 from grouper.usecases.view_permission import ViewPermissionUI
 
@@ -27,14 +28,14 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
         access: PermissionAccess,
         audit_log_entries: List[AuditLogEntry],
     ) -> None:
-        self.render(
-            "permission.html",
+        template = PermissionTemplate(
             permission=permission,
             access=access,
             group_grants=group_grants,
             service_account_grants=service_account_grants,
             audit_log_entries=audit_log_entries,
         )
+        self.render_template_class(template)
 
     def get(self, *args: Any, **kwargs: Any) -> None:
         name = self.get_path_argument("name")

--- a/grouper/fe/handlers/permissions_request_update.py
+++ b/grouper/fe/handlers/permissions_request_update.py
@@ -1,7 +1,8 @@
 from grouper import permissions
 from grouper.audit import UserNotAuditor
+from grouper.fe.alerts import Alert
 from grouper.fe.forms import PermissionRequestUpdateForm
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.util import GrouperHandler
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 
 

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -1,37 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from grouper.entities.pagination import PaginatedList, Pagination
 from grouper.entities.permission import Permission
+from grouper.fe.templates import PermissionsTemplate
 from grouper.fe.util import GrouperHandler
 from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
 
+if TYPE_CHECKING:
+    from typing import Any
+
 
 class PermissionsView(GrouperHandler, ListPermissionsUI):
-    """Controller for viewing the major permissions list.
-
-    There is no privacy here; the existence of a permission is public.
-    """
-
-    def listed_permissions(self, permissions, can_create):
-        # type: (PaginatedList[Permission], bool) -> None
-        audited_only = bool(int(self.get_argument("audited", 0)))
+    def listed_permissions(self, permissions: PaginatedList[Permission], can_create: bool) -> None:
+        audited_only = bool(int(self.get_argument("audited", "0")))
         sort_key = self.get_argument("sort_by", "name")
         sort_dir = self.get_argument("order", "asc")
-        self.render(
-            "permissions.html",
+
+        template = PermissionsTemplate(
             permissions=permissions.values,
             offset=permissions.offset,
-            limit=permissions.limit,
+            limit=permissions.limit or 100,
             total=permissions.total,
             can_create=can_create,
             audited_permissions=audited_only,
             sort_key=sort_key,
             sort_dir=sort_dir,
         )
+        self.render_template_class(template)
 
-    def get(self, audited_only=False):
+    def get(self, *args: Any, **kwargs: Any) -> None:
         self.handle_refresh()
-        offset = int(self.get_argument("offset", 0))
-        limit = int(self.get_argument("limit", 100))
-        audited_only = bool(int(self.get_argument("audited", 0)))
+        offset = int(self.get_argument("offset", "0"))
+        limit = int(self.get_argument("limit", "100"))
+        audited_only = bool(int(self.get_argument("audited", "0")))
         sort_key = ListPermissionsSortKey(self.get_argument("sort_by", "name"))
         sort_dir = self.get_argument("order", "asc")
 

--- a/grouper/fe/handlers/template_variables.py
+++ b/grouper/fe/handlers/template_variables.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from grouper.constants import USER_METADATA_GITHUB_USERNAME_KEY, USER_METADATA_SHELL_KEY
 from grouper.entities.group_edge import APPROVER_ROLE_INDICES, OWNER_ROLE_INDICES
-from grouper.fe.util import Alert
+from grouper.fe.alerts import Alert
 from grouper.graph import NoSuchGroup, NoSuchUser
 from grouper.group_requests import count_requests_by_group
 from grouper.group_service_account import get_service_accounts

--- a/grouper/fe/handlers/user_disable.py
+++ b/grouper/fe/handlers/user_disable.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING
 
 from grouper.constants import USER_ADMIN, USER_DISABLE
 from grouper.email_util import cancel_async_emails
-from grouper.fe.util import Alert, GrouperHandler
+from grouper.fe.alerts import Alert
+from grouper.fe.util import GrouperHandler
 from grouper.models.audit_log import AuditLog
 from grouper.models.group import Group
 from grouper.models.user import User

--- a/grouper/fe/templates.py
+++ b/grouper/fe/templates.py
@@ -1,0 +1,123 @@
+"""Wrappers around Jinja2 templates in the templates subdirectory.
+
+This is a not-yet-fully-complete experiment in improving typing and code safety for rendering
+Jinja2 templates.  The goal is for every template page to have a corresponding wrapper class
+defined here, and for all handlers to interact with the template only through the wrapper class.
+This ensures that the template receives all of the parameters that it expects and that they are
+typed correctly, since mypy cannot analyze Jinja2 code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import TYPE_CHECKING
+
+from grouper.fe.alerts import Alert
+
+if TYPE_CHECKING:
+    from dataclasses import InitVar
+    from grouper.entities.audit_log_entry import AuditLogEntry
+    from grouper.entities.permission import Permission, PermissionAccess
+    from grouper.entities.permission_grant import (
+        GroupPermissionGrant,
+        ServiceAccountPermissionGrant,
+    )
+    from grouper.fe.forms import ServiceAccountCreateForm, ServiceAccountPermissionGrantForm
+    from grouper.fe.util import GrouperHandler
+    from typing import Dict, List, Optional
+    from wtforms_tornado import Form
+
+
+@dataclass(repr=False, eq=False)
+class BaseTemplate:
+    """Base class for all template wrapper objects.
+
+    All child classes must define an InitVar named template with a default value matching the file
+    name of the Jinja2 template for that template object.
+    """
+
+    def render(self, handler: GrouperHandler, alerts: Optional[List[Alert]] = None) -> str:
+        # The machinations here are to work around dataclass limitations on inheritance and default
+        # values.  A child class cannot define a default value for a parent class attribute and
+        # then add new attributes with no default value, so the attribute has to exist only in the
+        # children, which means getattr is needed since mypy knows BaseTemplate has no template
+        # attribute.
+        template = handler.template_engine.get_template(getattr(self, "template"))
+
+        # Merge alerts from cookies and passed into the render call.  If there is a form, also
+        # merge any errors from the form as well.
+        all_alerts = handler.get_alerts()
+        if hasattr(self, "form"):
+            form: Form = getattr(self, "form")
+            all_alerts.extend(self._get_form_alerts(form.errors))
+        if alerts:
+            all_alerts.extend(alerts)
+
+        # Set some default variables used by all templates.
+        namespace = {
+            "alerts": all_alerts,
+            "is_active": handler.is_active,
+            "static_url": handler.static_url,
+            "perf_trace_uuid": handler.perf_trace_uuid,
+            "update_qs": handler.update_qs,
+            "xsrf_form": handler.xsrf_form_html,
+        }
+
+        # It would be nice to be able to use asdict here, but alas, it tries to deep copies of
+        # things that cannot be copied, like WTForms form objects.  Instead, iterate through the
+        # fields and update the namespace with the shallow value.
+        for field in fields(self):
+            namespace[field.name] = getattr(self, field.name)
+
+        # Render the template and return the results.
+        return template.render(namespace)
+
+    def _get_form_alerts(self, errors: Dict[str, List[str]]) -> List[Alert]:
+        """Create alerts from all errors in a WTForms form."""
+        alerts = []
+        for field, field_errors in errors.items():
+            for error in field_errors:
+                alerts.append(Alert("danger", error, field))
+        return alerts
+
+
+@dataclass(repr=False, eq=False)
+class PermissionTemplate(BaseTemplate):
+    permission: Permission
+    group_grants: List[GroupPermissionGrant]
+    service_account_grants: List[ServiceAccountPermissionGrant]
+    access: PermissionAccess
+    audit_log_entries: List[AuditLogEntry]
+
+    template: InitVar[str] = "permission.html"
+
+
+@dataclass(repr=False, eq=False)
+class PermissionsTemplate(BaseTemplate):
+    permissions: List[Permission]
+    offset: int
+    limit: int
+    total: int
+    can_create: bool
+    audited_permissions: bool
+    sort_key: str
+    sort_dir: str
+
+    template: InitVar[str] = "permissions.html"
+
+
+@dataclass(repr=False, eq=False)
+class ServiceAccountCreateTemplate(BaseTemplate):
+    owner: str
+    form: ServiceAccountCreateForm
+
+    template: InitVar[str] = "service-account-create.html"
+
+
+@dataclass(repr=False, eq=False)
+class ServiceAccountPermissionGrantTemplate(BaseTemplate):
+    service: str
+    owner: str
+    form: ServiceAccountPermissionGrantForm
+
+    template: InitVar[str] = "service-account-permission-grant.html"

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -204,7 +204,6 @@ def test_permission_grant_invalid_argument(
         page.set_argument("@@@@")
         page.submit()
 
-        print(page.root.page_source)
         assert page.has_alert("argument")
 
 


### PR DESCRIPTION
Template handling in the frontend has caused problems because there
is no systematic validation that the correct variables are passed into
the template when rendering it, or that those variables have the
correct type.  Handling of alerts is also somewhat tedious.

Introduce a new wrapper dataclass around each template and use it in
all handlers that have been rewritten to use usecases.  This provides
type and argument validation and hides more of the machinery of
generating the template namespace.

Take advantage of this opportunity to add automatic handling of form
errors, turning them into alerts.

Move the definition of Alert to a separate file to reduce circular
dependencies between grouper.fe.templates and grouper.fe.util.  (There
is still a circular dependency for type checking since GrouperHandler
has a method that takes a BaseTemplate, and BaseTemplate has to get
data from the handler, but it's not a true source circular dependency.)

Stash the constructed form in the handler object in more cases, which
allows reuse in error callbacks without reconstructing the form.  As a
bonus, this means validate() has always been called, so it's safe to
append to field errors.

Remove a stray debugging print in the service account integration test.