### PR TITLE
Test that template dataclasses match template needs

### DIFF
--- a/grouper/fe/templates.py
+++ b/grouper/fe/templates.py
@@ -5,6 +5,8 @@ Jinja2 templates.  The goal is for every template page to have a corresponding w
 defined here, and for all handlers to interact with the template only through the wrapper class.
 This ensures that the template receives all of the parameters that it expects and that they are
 typed correctly, since mypy cannot analyze Jinja2 code.
+
+Keep all wrapper classes in this file so that they will be seen properly by the test suite.
 """
 
 from __future__ import annotations

--- a/grouper/fe/templates/forms/service-account-create.html
+++ b/grouper/fe/templates/forms/service-account-create.html
@@ -1,7 +1,0 @@
-{% from 'macros/ui.html' import form_field -%}
-
-{{ form_field(form.name, 3, 8, class_="form-control") }}
-{{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
-{{ form_field(form.machine_set, 3, 8, class_="form-control", rows=1) }}
-
-{{ xsrf_form()|safe }}

--- a/grouper/fe/templates/forms/service-account-permission-grant.html
+++ b/grouper/fe/templates/forms/service-account-permission-grant.html
@@ -1,6 +1,0 @@
-{% from 'macros/ui.html' import form_field -%}
-
-{{ form_field(form.permission, 3, 8, class_="form-control") }}
-{{ form_field(form.argument, 3, 8, class_="form-control") }}
-
-{{ xsrf_form()|safe }}

--- a/grouper/fe/templates/help.html
+++ b/grouper/fe/templates/help.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import permission with context %}
+{% from 'macros/ui.html' import permission_link %}
 
 {% block subtitle %} help{% endblock %}
 
@@ -44,7 +44,7 @@ pairs from the groups of which they are members.</p>
 <h3>How do I request a permission?</h3>
 <p>First, make sure you're a member of an appropriate group.  We don't grant permissions
 directly to users because that approach is not scalable.  Once you're a member of a group
-that should have a particular permission but doesn't, check the {{permission(grant_perm)}}
+that should have a particular permission but doesn't, check the {{permission_link(grant_perm)}}
 page for a list of which groups can grant which permissions and reach out to the group(s)
 that control(s) the permission you need.</p>
 
@@ -58,19 +58,19 @@ which begins with no permissions.</p>
 on a manual way to pre-populate users.</p>
 
 <h3>Who can create permissions?</h3>
-<p>A user with the permission ({{permission(create_perm)}}, prefix.*) can create any
+<p>A user with the permission ({{permission_link(create_perm)}}, prefix.*) can create any
 permission starting with "prefix." We strongly encourage namespacing using the character
 '.' as a separator.</p>
 
 <h3>Who can grant permissions?</h3>
-<p>Generally, a user with the permission ({{permission(grant_perm)}}, prefix.*) can grant
+<p>Generally, a user with the permission ({{permission_link(grant_perm)}}, prefix.*) can grant
 any permission starting with "prefix." with any argument.  As a special case, the
 permission ({{grant_perm.name}}, {{grant_perm.name}}/prefix.*) allows a user to
 grant the permission to grant ({{grant_perm.name}}, prefix.*).</p>
 
 <h3>How does auditing work?</h3>
 <p>Certain grouper permissions are designated as audited permissions. Groups with at least
-one audited permission become audited groups.  Users with the {{permission(audit_perm)}}
+one audited permission become audited groups.  Users with the {{permission_link(audit_perm)}}
 permission (any argument) are considered auditors.  Only auditors can be the manager,
 owner, or np-owner of an audited group.</p>
 

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -337,7 +337,7 @@ enabled. Membership in this group is regularly reviewed.
     {% endif %}
 {% endmacro %}
 
-{% macro permission(perm) -%}
+{% macro permission_link(perm) -%}
 <a class="permission-link" href="/permissions/{{perm.name or perm.permission}}">
     <i class="fa fa-key hidden-xs"></i>
     {{perm.name or perm.permission}}
@@ -435,7 +435,7 @@ enabled. Membership in this group is regularly reviewed.
                                 Group: {{ account(entry.on_group) }}<br />
                             {% endif %}
                             {% if entry.on_permission %}
-                                Permission: {{ permission(entry.on_permission) }}<br />
+                                Permission: {{ permission_link(entry.on_permission) }}<br />
                             {% endif %}
                             {% if entry.on_user %}
                                 User: {{ account(entry.on_user) }}<br />
@@ -487,7 +487,7 @@ enabled. Membership in this group is regularly reviewed.
                                 Group: {{ account(entry.on_group, type="group") }}<br />
                             {% endif %}
                             {% if entry.on_permission %}
-                                Permission: {{ permission(entry.on_permission) }}<br />
+                                Permission: {{ permission_link(entry.on_permission) }}<br />
                             {% endif %}
                             {% if entry.on_user %}
                                 User: {{ account(entry.on_user, type="user") }}<br />
@@ -529,7 +529,7 @@ enabled. Membership in this group is regularly reviewed.
                 <tbody>
                 {% for map in mappings if not map.alias %}
                     <tr class="permission-row">
-                        <td class="permission-name">{{ permission(map) }}</td>
+                        <td class="permission-name">{{ permission_link(map) }}</td>
                         <td class="permission-argument col-sm-2">{{ map.argument|default("(unargumented)", True) }}</td>
                         <td class="permission-source col-sm-2">
                         {% if map.distance == 0 %}

--- a/grouper/fe/templates/permission.html
+++ b/grouper/fe/templates/permission.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import audit_log_panel, paginator, dropdown with context %}
+{% from 'macros/ui.html' import audit_log_panel %}
 
 {% block subtitle %} permission {{ permission.name }}{% endblock %}
 

--- a/grouper/fe/templates/permissions.html
+++ b/grouper/fe/templates/permissions.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'macros/ui.html' import permission, paginator, dropdown with context %}
+{% from 'macros/ui.html' import permission_link, paginator, dropdown with context %}
 
 {% block subtitle %}
     {% if audited_permissions %}
@@ -51,7 +51,7 @@
             <tbody>
             {% for perm in permissions %}
                 <tr class="permission-row">
-                    <td class="permission-name">{{ permission(perm) }}</td>
+                    <td class="permission-name">{{ permission_link(perm) }}</td>
                     <td class="permission-description">{{ perm.description|default("", True) }}</td>
                     <td class="permission-created-on">{{ perm.created_on | print_date}}</td>
                 </tr>

--- a/grouper/fe/templates/service-account-create.html
+++ b/grouper/fe/templates/service-account-create.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/ui.html" import form_field -%}
 
 {% block subtitle %} create service account for {{owner}}{% endblock %}
 
@@ -20,7 +21,10 @@
             <div class="panel-body" id="dropdown_form">
                 <form class="form-horizontal" id="new-service-account-form" role="form"
                     method="post" action="/groups/{{ owner }}/service/create">
-                    {% include "forms/service-account-create.html" %}
+                    {{ form_field(form.name, 3, 8, class_="form-control") }}
+                    {{ form_field(form.description, 3, 8, class_="form-control", rows=5) }}
+                    {{ form_field(form.machine_set, 3, 8, class_="form-control", rows=1) }}
+                    {{ xsrf_form()|safe }}
                     <div class="form-shell">
                         <div class="col-sm-offset-3 col-sm-4">
                             <button type="submit" class="btn btn-primary">Submit</button>

--- a/grouper/fe/templates/service-account-permission-grant.html
+++ b/grouper/fe/templates/service-account-permission-grant.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'macros/ui.html' import form_field -%}
 
 {% block subtitle %} grant permission to {{service}}{% endblock %}
 
@@ -19,13 +20,14 @@
         <div class="panel-body">
             <form id="grant-permission-form" class="form-horizontal" role="form" method="post"
                   action="/groups/{{owner}}/service/{{service}}/grant">
-                {% include "forms/service-account-permission-grant.html" %}
+                {{ form_field(form.permission, 3, 8, class_="form-control") }}
+                {{ form_field(form.argument, 3, 8, class_="form-control") }}
+                {{ xsrf_form()|safe }}
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-4">
                         <button type="submit" class="btn btn-primary">Submit</button>
                     </div>
                 </div>
-
             </form>
         </div>
     </div>

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import log_entry_panel, tokens_panel, shell_panel, passwords_panel,
-                                permission, public_key_panel %}
+                                permission_link, public_key_panel %}
 
 {% macro permission_panel(mappings, group, user, can_manage) -%}
     <div class="panel panel-default">
@@ -22,7 +22,7 @@
                 <tbody>
                 {% for map in mappings %}
                     <tr class="permission-row">
-                        <td class="permission-name">{{ permission(map) }}</td>
+                        <td class="permission-name">{{ permission_link(map) }}</td>
                         <td class="col-sm-2 permission-argument">
                             {{ map.argument|default("(unargumented)", True) }}
                         </td>

--- a/grouper/templating.py
+++ b/grouper/templating.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -33,8 +35,7 @@ class BaseTemplateEngine:
     from which templates should be loaded.
     """
 
-    def __init__(self, settings, package):
-        # type: (Settings, str) -> None
+    def __init__(self, settings: Settings, package: str) -> None:
         self.settings = settings
         loader = PackageLoader(package, "templates")
         self.environment = Environment(loader=loader, autoescape=select_autoescape(["html"]))
@@ -49,12 +50,10 @@ class BaseTemplateEngine:
         template_globals = {"ROLES": GROUP_EDGE_ROLES, "TYPES": OBJ_TYPES_IDX}
         self.environment.globals.update(template_globals)
 
-    def get_template(self, name):
-        # type: (str) -> Template
+    def get_template(self, name: str) -> Template:
         return self.environment.get_template(name)
 
-    def print_date(self, date):
-        # type: (Optional[datetime]) -> str
+    def print_date(self, date: Optional[datetime]) -> str:
         """Format a human readable datetime string, respecting configuration settings."""
         if date is None:
             return ""
@@ -64,8 +63,9 @@ class BaseTemplateEngine:
         return date.strftime(self.settings.date_format)
 
     @classmethod
-    def expires_when_str(cls, date, utcnow_fn=_utcnow):
-        # type: (Optional[datetime], Callable[[], datetime]) -> str
+    def expires_when_str(
+        cls, date: Optional[datetime], utcnow_fn: Callable[[], datetime] = _utcnow
+    ) -> str:
         """Format an expiration datetime.
 
         The utcnow_fn parameter is only used for testing and allows overriding the definition of
@@ -88,8 +88,7 @@ class BaseTemplateEngine:
             return delta_str
 
     @classmethod
-    def long_ago_str(cls, date, utcnow_fn=_utcnow):
-        # type: (datetime, Callable[[], datetime]) -> str
+    def long_ago_str(cls, date: datetime, utcnow_fn: Callable[[], datetime] = _utcnow) -> str:
         """Format a datetime as an interval in the past.
 
         The utcnow_fn parameter is only used for testing and allows overriding the definition of
@@ -110,8 +109,7 @@ class BaseTemplateEngine:
             return "{} ago".format(delta_str)
 
     @staticmethod
-    def _highest_period_delta_str(delta):
-        # type: (relativedelta) -> Optional[str]
+    def _highest_period_delta_str(delta: relativedelta) -> Optional[str]:
         """Return a string version of the longest non-microsecond interval in a relativedelta.
 
         Helper function for expires_when_str and long_ago_str.  If relativedelta is negative or

--- a/tests/fe/templates_test.py
+++ b/tests/fe/templates_test.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from dataclasses import fields, is_dataclass
+from typing import TYPE_CHECKING
+
+from jinja2.meta import find_undeclared_variables
+
+import grouper.fe
+from grouper.fe.settings import FrontendSettings
+from grouper.fe.templates import BaseTemplate
+from grouper.fe.templating import FrontendTemplateEngine
+
+if TYPE_CHECKING:
+    from typing import Set
+
+# These fields are automatically added to the template namespace for all render invocations in
+# BaseTemplate or BaseTemplateEngine and thus don't need to be provided by the template dataclass.
+DEFAULT_FIELDS = {"ROLES", "TYPES", "alerts", "is_active", "static_url", "update_qs", "xsrf_form"}
+
+# Unfortunately, the trick that we're using doesn't expand macros, and macros show up as undefined
+# variables.  We therefore have to exclude them as well, and we can't look inside the macros to see
+# the additional variables they need.  Thankfully, macros cannot access the template context unless
+# that is explicitly requested, so they mostly do not add new variables.
+MACROS = {"audit_log_panel", "dropdown", "form_field", "paginator", "permission_link"}
+
+
+def get_template_variables(engine: FrontendTemplateEngine, name: str) -> Set[str]:
+    """Return all variables used by the given template, primarily for tests."""
+    source = engine.environment.loader.get_source(engine.environment, name)[0]
+    ast = engine.environment.parse(source)
+    return find_undeclared_variables(ast)
+
+
+def test_template_consistency() -> None:
+    """Check that template dataclasses define all variables needed by their templates.
+
+    For each frontend template that has been wrapped in a dataclass, ask Jinja2 what variables need
+    to be defined for that template and then check that the dataclass defines all of those
+    variables and no others.  This unfortunately can't check types, but at least it ensures that
+    the dataclass is complete.
+    """
+    static_path = os.path.join(os.path.dirname(grouper.fe.__file__), "static")
+    engine = FrontendTemplateEngine(FrontendSettings(), "tests", static_path)
+
+    for template_class in BaseTemplate.__subclasses__():
+        assert is_dataclass(template_class)
+
+        template_fields = fields(template_class)
+        expected: Set[str] = set()
+        for template_field in template_fields:
+            if template_field.name == "template":
+                template = template_field.default
+            else:
+                expected.add(template_field.name)
+        assert template
+
+        wanted = (get_template_variables(engine, template) - DEFAULT_FIELDS) - MACROS
+        assert expected == wanted, f"fields for {template}"


### PR DESCRIPTION
For each template wrapped in a dataclass, test that the dataclass
defines all of the variables that the form needs.

This unfortunately doesn't expand macros, so we have to whitelist
all the macros.  It also doesn't handle inclusion of other files,
so in-line the forms into the templates (which is probably a good
idea anyway).

Rename the permission macro to permission_link, since permission is
used elsewhere as a variable.

Modernize mypy typing of grouper.templating (no modifications were
needed here in the end, but it seemed pointless to throw out the
work).