### PR TITLE
Fix POST URL for editing service accounts

### DIFF
--- a/grouper/fe/templates/service-account-edit.html
+++ b/grouper/fe/templates/service-account-edit.html
@@ -17,8 +17,8 @@
             <h3 class="panel-title">Edit Service Account {{service_account.user.username}}</h3>
         </div>
         <div class="panel-body">
-            <form class="form-horizontal" role="form"
-                  method="post" action="/groups/{{group.name}}/service/{{service_account.id}}/edit">
+            <form class="form-horizontal" role="form" id="edit-service-account-form"
+                  method="post" action="/groups/{{group.name}}/service/{{service_account.user.username}}/edit">
                 {% include "forms/service-account-edit.html" %}
                 <div class="form-group">
                     <div class="col-sm-offset-3 col-sm-4">

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -89,7 +89,7 @@
     {% endif %}
     {% if can_control %}
         <a href="/groups/{{ group.name }}/service/{{ user.username }}/edit"
-           class="btn btn-primary"><i class="fa fa-edit"></i> Edit
+           class="btn btn-primary edit-service-account"><i class="fa fa-edit"></i> Edit
         </a>
     {% endif %}
 {% endblock %}

--- a/itests/pages/service_accounts.py
+++ b/itests/pages/service_accounts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from selenium.webdriver.common.keys import Keys
@@ -40,6 +42,10 @@ class ServiceAccountViewPage(BasePage):
     def click_disable_button(self):
         # type: () -> None
         button = self.find_element_by_class_name("disable-service-account")
+        button.click()
+
+    def click_edit_button(self) -> None:
+        button = self.find_element_by_class_name("edit-service-account")
         button.click()
 
     def click_enable_button(self):
@@ -90,6 +96,25 @@ class ServiceAccountCreatePage(BasePage):
         # type: () -> None
         form = self._get_new_service_account_form()
         form.submit()
+
+
+class ServiceAccountEditPage(BasePage):
+    @property
+    def form(self) -> WebElement:
+        return self.find_element_by_id("edit-service-account-form")
+
+    def set_description(self, name: str) -> None:
+        field = self.form.find_element_by_name("description")
+        field.clear()
+        field.send_keys(name)
+
+    def set_machine_set(self, name: str) -> None:
+        field = self.form.find_element_by_name("machine_set")
+        field.clear()
+        field.send_keys(name)
+
+    def submit(self) -> None:
+        self.form.submit()
 
 
 class ServiceAccountEnablePage(BasePage):


### PR DESCRIPTION
The POST URL was still using the old by-id route, which no longer
exists, making it impossible to edit service accounts.  Fix this and
add a proper test for service account editing.