### PR TITLE
Exit with status 1 if a user cannot be disabled

### DIFF
--- a/grouper/ctl/user.py
+++ b/grouper/ctl/user.py
@@ -60,6 +60,7 @@ def user_command(args, settings, session_factory):
                     session.commit()
                 except PluginRejectedDisablingUser as e:
                     logging.error("%s", e)
+                    sys.exit(1)
 
         return
 

--- a/tests/ctl/user_test.py
+++ b/tests/ctl/user_test.py
@@ -1,4 +1,5 @@
 from mock import patch
+from pytest import raises
 
 from grouper.models.group import Group
 from grouper.plugin.proxy import PluginProxy
@@ -19,5 +20,6 @@ def test_group_disable_group_owner(get_plugin_proxy, session, tmpdir, users, gro
     assert ("User", username) in Group.get(session, name=groupname).my_members()
 
     # disable (fails)
-    call_main(session, tmpdir, "user", "disable", username)
+    with raises(SystemExit):
+        call_main(session, tmpdir, "user", "disable", username)
     assert ("User", username) in Group.get(session, name=groupname).my_members()


### PR DESCRIPTION
This allows other tools that programmatically call grouper-ctl to rely
on the status code to determine if a user was in fact successfully
disabled. We still return 0 in the "already disabled" and "does not
exist" cases, because these are in fact not a problem for the disable
case.