### PR TITLE
Flush before calling user_created plugins

### DIFF
--- a/grouper/models/base/model_base.py
+++ b/grouper/models/base/model_base.py
@@ -27,12 +27,12 @@ class _Model:
 
         return instance, True
 
-    def just_created(self):
+    def just_created(self, session):
         pass
 
     def add(self, session):
         session._add(self)
-        self.just_created()
+        self.just_created(session)
         return self
 
     def delete(self, session):

--- a/grouper/models/user.py
+++ b/grouper/models/user.py
@@ -47,13 +47,13 @@ class User(Model, CommentObjectMixin):
             return session.query(User).filter_by(username=name).scalar()
         return None
 
-    def just_created(self):
-        # type: () -> None
+    def just_created(self, session):
+        # type: (Session) -> None
         """Call the user_created plugin on new User creation."""
-        # This is a little weird because the default value of the column may not be applied in
-        # the object at the time this is called, so the flag may be None instead of False.
-        is_service_account = self.is_service_account is not None and self.is_service_account
-        get_plugin_proxy().user_created(self, is_service_account)
+        # Flush the session to apply defaults, allocate an id, and so forth
+        # in case any plugins rely on that data.
+        session.flush()
+        get_plugin_proxy().user_created(self, self.is_service_account)
 
     def add(self, session):
         # type: (Session) -> User

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -254,7 +254,7 @@ def test_name_rejected_by_plugin(setup):
 
 
 class ServiceAccountCreatedPlugin(BasePlugin):
-    def user_created(self, user, is_service_account):
+    def user_created(self, user, is_service_account=False):
         # type: (User, bool) -> None
         assert is_service_account and user.is_service_account
         assert user.id

--- a/tests/usecases/view_permission_test.py
+++ b/tests/usecases/view_permission_test.py
@@ -95,7 +95,7 @@ def test_view_permissions(setup):
     assert not mock_ui.permission.enabled
     assert mock_ui.group_grants == []
     assert mock_ui.service_account_grants == []
-    audit_log_entries = [(l.actor, l.action, l.on_permission) for l in mock_ui.audit_log_entries]
+    audit_log_entries = [(e.actor, e.action, e.on_permission) for e in mock_ui.audit_log_entries]
     assert audit_log_entries == [
         ("gary@a.co", "disable_permission", "disabled-permission"),
         ("gary@a.co", "create_permission", "disabled-permission"),
@@ -103,7 +103,7 @@ def test_view_permissions(setup):
 
     # Limit the number of audit log entries.
     usecase.view_permission("disabled-permission", "gary@a.co", 1)
-    audit_log_entries = [(l.actor, l.action, l.on_permission) for l in mock_ui.audit_log_entries]
+    audit_log_entries = [(e.actor, e.action, e.on_permission) for e in mock_ui.audit_log_entries]
     assert audit_log_entries == [("gary@a.co", "disable_permission", "disabled-permission")]
 
 

--- a/tests/users_test.py
+++ b/tests/users_test.py
@@ -25,6 +25,7 @@ from tests.fixtures import (  # noqa: F401
 from tests.setup import SetupTest
 from tests.url_util import url
 from tests.util import get_groups, grant_permission
+from tests.setup import SetupTest
 
 
 def test_basic_metadata(standard_graph, session, users, groups, permissions):  # noqa: F811

--- a/tests/users_test.py
+++ b/tests/users_test.py
@@ -25,7 +25,6 @@ from tests.fixtures import (  # noqa: F401
 from tests.setup import SetupTest
 from tests.url_util import url
 from tests.util import get_groups, grant_permission
-from tests.setup import SetupTest
 
 
 def test_basic_metadata(standard_graph, session, users, groups, permissions):  # noqa: F811


### PR DESCRIPTION
Plugins may depend on attributes of the user, and prefer having those attributes flushed to passing additional information via parameters.

To note, it shouldn't even be necessary to pass the existing `is_service_account` parameter; plugins can check `user.is_service_account` instead. Actually removing that parameter is left to a later time.