### PR TITLE
Avoid infinite loop when checking auditor status

### DIFF
--- a/grouper/audit.py
+++ b/grouper/audit.py
@@ -73,6 +73,7 @@ def assert_controllers_are_auditors(group: Group) -> None:
         cur_group = queue.pop()
         if cur_group in checked:
             continue
+        checked.add(cur_group)
         details = graph.get_group_details(cur_group)
         for chk_user, info in details["users"].items():
             if chk_user in checked:


### PR DESCRIPTION
Not adding an explicit test case for this, as it triggers when there's a cyclic group membership and cyclic group membership aren't something we're generally robust/testing against. Felt bad to leave this known infinite loop case though.