### PR TITLE
Allow for unargumented permission requests

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -211,10 +211,7 @@ class PermissionRequestForm(Form):
     permission = SelectField("Permission", [validators.DataRequired()])
     argument = StringField(
         "Argument",
-        [
-            validators.Length(min=0, max=64),
-            ValidateRegex(constants.ARGUMENT_VALIDATION),
-        ],
+        [validators.Length(min=0, max=64), ValidateRegex(constants.ARGUMENT_VALIDATION)],
     )
     reason = TextAreaField("Reason", [validators.DataRequired()])
 

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -212,7 +212,6 @@ class PermissionRequestForm(Form):
     argument = StringField(
         "Argument",
         [
-            validators.DataRequired(),
             validators.Length(min=0, max=64),
             ValidateRegex(constants.ARGUMENT_VALIDATION),
         ],

--- a/grouper/fe/static/js/grouper.js
+++ b/grouper/fe/static/js/grouper.js
@@ -157,7 +157,7 @@ $(function () {
             if (args.length == 1 && args[0] == "*") {
                 $argument_input.show();
                 $argument_input.prop('name', 'argument');
-                $argument_input.prop('required', true);
+                $argument_input.prop('required', false);
 
                 $argument_select.hide();
                 $argument_select.prop('name', 'ignore');

--- a/grouper/fe/templates/permission-request-update.html
+++ b/grouper/fe/templates/permission-request-update.html
@@ -49,7 +49,7 @@
                                     {{ request.permission.name }}
                                 </a>
                             </dd>
-                            <dt>Argument:</dt><dd>{{ request.argument }}</dd>
+                            <dt>Argument:</dt><dd>{{ request.argument|default("(unargumented)", True) }}</dd>
                             <dt>Reason:</dt><dd>{{ comment.comment }}</dd>
                         </span>
                     </td>

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -56,6 +56,30 @@ def test_requesting_permission(tmpdir, setup, browser):
         )
 
 
+def test_unargumented_request(tmpdir, setup, browser):
+    # type: (LocalPath, SetupTest, Chrome) -> None
+    with setup.transaction():
+        setup.create_permission("sample.permission")
+        setup.create_group("grouper-administrators")
+        setup.add_user_to_group("gary@a.co", "grouper-administrators")
+        setup.add_user_to_group("rra@a.co", "test-group")
+
+        setup.grant_permission_to_group(
+            PERMISSION_GRANT, "sample.permission", "grouper-administators"
+        )
+
+    with frontend_server(tmpdir, "rra@a.co") as frontend_url:
+        browser.get(url(frontend_url, "/permissions/request?permission=sample.permission"))
+        page = PermissionRequestPage(browser)
+
+        page.set_group("test-group")
+        page.set_argument_freeform("")
+        page.set_reason("Some testing reason")
+        page.submit()
+
+        assert browser.current_url.endswith("/permissions/requests/1")
+
+
 def test_limited_arguments(tmpdir, setup, browser):
     # type: (LocalPath, SetupTest, Chrome) -> None
     with setup.transaction():


### PR DESCRIPTION
Technically two bugfixes:
(1) The argument field was marked required (twice!), even though empty arguments are allowed.
(2) Displaying of unargumented permission requests on the request update page was sad.

They say if you like something, you should put a test on it.
Good thing I don't like this.