### PR TITLE
Allow non-admin non-owners to grant permissions to service accounts

### DIFF
--- a/grouper/entities/pagination.py
+++ b/grouper/entities/pagination.py
@@ -12,6 +12,7 @@ list of some other entity along with the total entity count and information abou
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Generic, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
@@ -52,3 +53,12 @@ class PaginatedList(Generic[T]):
     total: int
     offset: int
     limit: Optional[int]
+
+
+# Define specific types used for pagination here, as they must be available throughout the layers.
+
+
+class ListPermissionsSortKey(Enum):
+    NONE = "none"
+    NAME = "name"
+    DATE = "date"

--- a/grouper/fe/handlers/permissions_view.py
+++ b/grouper/fe/handlers/permissions_view.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from grouper.entities.pagination import PaginatedList, Pagination
+from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList, Pagination
 from grouper.entities.permission import Permission
 from grouper.fe.templates import PermissionsTemplate
 from grouper.fe.util import GrouperHandler
-from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
+from grouper.usecases.list_permissions import ListPermissionsUI
 
 if TYPE_CHECKING:
     from typing import Any

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from grouper.entities.pagination import PaginatedList, Pagination
+    from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
         GroupPermissionGrant,
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from grouper.repositories.schema import SchemaRepository
     from grouper.repositories.service_account import ServiceAccountRepository
     from grouper.repositories.transaction import TransactionRepository
-    from grouper.usecases.list_permissions import ListPermissionsSortKey
     from typing import Dict, List, Optional
 
 

--- a/grouper/repositories/permission.py
+++ b/grouper/repositories/permission.py
@@ -1,10 +1,9 @@
 from typing import TYPE_CHECKING
 
-from grouper.entities.pagination import PaginatedList
+from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList
 from grouper.entities.permission import Permission, PermissionNotFoundException
 from grouper.models.permission import Permission as SQLPermission
 from grouper.repositories.interfaces import PermissionRepository
-from grouper.usecases.list_permissions import ListPermissionsSortKey
 
 if TYPE_CHECKING:
     from datetime import datetime

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -94,8 +94,13 @@ class ServiceFactory:
         # type: () -> UserInterface
         audit_log_service = self.create_audit_log_service()
         user_repository = self.repository_factory.create_user_repository()
+        permission_repository = self.repository_factory.create_permission_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
         group_edge_repository = self.repository_factory.create_group_edge_repository()
         return UserService(
-            user_repository, permission_grant_repository, group_edge_repository, audit_log_service
+            user_repository,
+            permission_repository,
+            permission_grant_repository,
+            group_edge_repository,
+            audit_log_service,
         )

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -71,6 +71,7 @@ class ServiceFactory:
         user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
+        permission_repository = self.repository_factory.create_permission_repository()
         group_edge_repository = self.repository_factory.create_group_edge_repository()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return ServiceAccountService(
@@ -79,6 +80,7 @@ class ServiceFactory:
             user_repository,
             service_account_repository,
             permission_grant_repository,
+            permission_repository,
             group_edge_repository,
             group_request_repository,
             audit_log_service,

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -5,7 +5,7 @@ from grouper.constants import ARGUMENT_VALIDATION, SYSTEM_PERMISSIONS
 from grouper.usecases.interfaces import PermissionInterface
 
 if TYPE_CHECKING:
-    from grouper.entities.pagination import PaginatedList, Pagination
+    from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList, Pagination
     from grouper.entities.permission import Permission
     from grouper.entities.permission_grant import (
         GroupPermissionGrant,
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from grouper.repositories.permission import PermissionRepository
     from grouper.repositories.permission_grant import PermissionGrantRepository
     from grouper.usecases.authorization import Authorization
-    from grouper.usecases.list_permissions import ListPermissionsSortKey
     from grouper.usecases.interfaces import AuditLogInterface
     from typing import Dict, List, Optional, Tuple
 

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -7,6 +7,7 @@ from grouper.constants import (
     PERMISSION_GRANT,
     USER_ADMIN,
 )
+from grouper.entities.pagination import ListPermissionsSortKey, Pagination
 from grouper.entities.permission import PermissionAccess
 from grouper.usecases.interfaces import UserInterface
 from grouper.util import matches_glob
@@ -14,7 +15,6 @@ from grouper.util import matches_glob
 if TYPE_CHECKING:
     from grouper.entities.permission_grant import GroupPermissionGrant
     from grouper.entities.user import User
-    from grouper.entities.pagination import Pagination, ListPermissionsSortKey
     from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.interfaces import PermissionGrantRepository, PermissionRepository
     from grouper.repositories.user import UserRepository
@@ -85,7 +85,7 @@ class UserService(UserInterface):
         # type: (str) -> bool
         return self.permission_grant_repository.user_has_permission(user, PERMISSION_CREATE)
 
-    def user_grantable_permissions(self, user):
+    def permissions_grantable_by_user(self, user):
         # type: (str) -> List[Tuple[str, str]]
         """Returns a name-sorted list of all (permission, argument glob) pairs a user can grant.
 

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -1,18 +1,26 @@
 from typing import TYPE_CHECKING
 
-from grouper.constants import AUDIT_MANAGER, PERMISSION_ADMIN, PERMISSION_CREATE, USER_ADMIN
+from grouper.constants import (
+    AUDIT_MANAGER,
+    PERMISSION_ADMIN,
+    PERMISSION_CREATE,
+    PERMISSION_GRANT,
+    USER_ADMIN,
+)
 from grouper.entities.permission import PermissionAccess
 from grouper.usecases.interfaces import UserInterface
+from grouper.util import matches_glob
 
 if TYPE_CHECKING:
     from grouper.entities.permission_grant import GroupPermissionGrant
     from grouper.entities.user import User
+    from grouper.entities.pagination import Pagination, ListPermissionsSortKey
     from grouper.repositories.group_edge import GroupEdgeRepository
-    from grouper.repositories.interfaces import PermissionGrantRepository
+    from grouper.repositories.interfaces import PermissionGrantRepository, PermissionRepository
     from grouper.repositories.user import UserRepository
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.interfaces import AuditLogInterface
-    from typing import Dict, List
+    from typing import Dict, List, Tuple
 
 
 class UserService(UserInterface):
@@ -21,12 +29,14 @@ class UserService(UserInterface):
     def __init__(
         self,
         user_repository,  # type: UserRepository
+        permission_repository,  # type: PermissionRepository
         permission_grant_repository,  # type: PermissionGrantRepository
         group_edge_repository,  # type: GroupEdgeRepository
         audit_log_service,  # type: AuditLogInterface
     ):
         # type: (...) -> None
         self.user_repository = user_repository
+        self.permission_repository = permission_repository
         self.permission_grant_repository = permission_grant_repository
         self.group_edge_repository = group_edge_repository
         self.audit_log = audit_log_service
@@ -74,3 +84,34 @@ class UserService(UserInterface):
     def user_can_create_permissions(self, user):
         # type: (str) -> bool
         return self.permission_grant_repository.user_has_permission(user, PERMISSION_CREATE)
+
+    def user_grantable_permissions(self, user):
+        # type: (str) -> List[Tuple[str, str]]
+        """Returns a name-sorted list of all (permission, argument glob) pairs a user can grant.
+
+        NOTE: The list of grantable permissions is calculated based on _all_ grants of the
+        PERMISSION_GRANT permission that the user has. In particular this includes indirectly
+        inherited grants. As of writing, this behavior differs from the legacy non-hexagonal
+        logic, so anything relying on that old logic will act differently.
+        """
+        pagination = Pagination(
+            sort_key=ListPermissionsSortKey.NAME, reverse_sort=False, offset=0, limit=None
+        )
+        all_permissions = self.permission_repository.list_permissions(pagination, False).values
+
+        if self.user_is_permission_admin(user):
+            return [(p.name, "*") for p in all_permissions]
+
+        all_grants = self.permission_grant_repository.permission_grants_for_user(user)
+        grants_of_permission_grant = [g for g in all_grants if g.permission == PERMISSION_GRANT]
+
+        result = []
+        for grant in grants_of_permission_grant:
+            grantable = grant.argument.split("/", 1)
+            if not grantable:
+                continue
+            for permission in all_permissions:
+                if matches_glob(grantable[0], permission.name):
+                    result.append((permission.name, grantable[1] if len(grantable) > 1 else "*"))
+
+        return result

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -362,3 +362,8 @@ class UserInterface(metaclass=ABCMeta):
     def user_is_user_admin(self, user):
         # type: (str) -> bool
         pass
+
+    @abstractmethod
+    def user_grantable_permissions(self, user):
+        # type: (str) -> List[Tuple[str, str]]
+        pass

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from grouper.entities.audit_log_entry import AuditLogEntry
     from grouper.entities.group import GroupJoinPolicy
     from grouper.entities.group_request import GroupRequestStatus, UserGroupRequest
-    from grouper.entities.pagination import PaginatedList, Pagination
+    from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList, Pagination
     from grouper.entities.permission import Permission, PermissionAccess
     from grouper.entities.permission_grant import (
         GroupPermissionGrant,
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     )
     from grouper.entities.user import User
     from grouper.usecases.authorization import Authorization
-    from grouper.usecases.list_permissions import ListPermissionsSortKey
     from typing import ContextManager, Dict, List, Optional, Tuple
 
 
@@ -306,6 +305,11 @@ class ServiceAccountInterface(metaclass=ABCMeta):
         # type: (str) -> bool
         pass
 
+    @abstractmethod
+    def permissions_grantable_by_service_account(self, user):
+        # type: (str) -> List[Tuple[str, str]]
+        pass
+
 
 class TransactionInterface(metaclass=ABCMeta):
     """Abstract base class for starting and committing transactions."""
@@ -364,6 +368,6 @@ class UserInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def user_grantable_permissions(self, user):
+    def permissions_grantable_by_user(self, user):
         # type: (str) -> List[Tuple[str, str]]
         pass

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -1,19 +1,12 @@
 from abc import ABCMeta, abstractmethod
-from enum import Enum
 from typing import TYPE_CHECKING
 
 from grouper.entities.pagination import Pagination
 
 if TYPE_CHECKING:
-    from grouper.entities.pagination import PaginatedList
+    from grouper.entities.pagination import PaginatedList, ListPermissionsSortKey
     from grouper.entities.permission import Permission
     from grouper.usecases.interfaces import PermissionInterface, UserInterface
-
-
-class ListPermissionsSortKey(Enum):
-    NONE = "none"
-    NAME = "name"
-    DATE = "date"
 
 
 class ListPermissionsUI(metaclass=ABCMeta):

--- a/grouper/usecases/list_permissions.py
+++ b/grouper/usecases/list_permissions.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
-from grouper.entities.pagination import Pagination
+from grouper.entities.pagination import ListPermissionsSortKey, Pagination
 
 if TYPE_CHECKING:
-    from grouper.entities.pagination import PaginatedList, ListPermissionsSortKey
+    from grouper.entities.pagination import PaginatedList
     from grouper.entities.permission import Permission
     from grouper.usecases.interfaces import PermissionInterface, UserInterface
 

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -215,7 +215,7 @@ def test_permission_grant_denied(tmpdir: LocalPath, setup: SetupTest, browser: C
         page.set_argument("bar")
         page.submit()
 
-        assert page.has_alert("The group some-group does not have that permission")
+        assert page.has_alert("Permission denied")
 
 
 def test_permission_grant_invalid_argument(

--- a/tests/services/group_test.py
+++ b/tests/services/group_test.py
@@ -1,12 +1,64 @@
 from typing import TYPE_CHECKING
 
 import pytest
+from mock import ANY
 
 from grouper.constants import DEFAULT_ADMIN_GROUP, ILLEGAL_NAME_CHARACTER
 from grouper.entities.group import GroupJoinPolicy, InvalidGroupNameException
+from grouper.entities.permission_grant import GroupPermissionGrant
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest
+
+
+def test_permission_grants_for_group(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.grant_permission_to_group("some-permission", "one", "some-group")
+        setup.grant_permission_to_group("some-permission", "two", "some-group")
+        setup.grant_permission_to_group("other-permission", "*", "some-group")
+        setup.grant_permission_to_group("parent-permission", "foo", "parent-group")
+        setup.add_group_to_group("some-group", "parent-group")
+        setup.create_group("other-group")
+        setup.create_user("gary@a.co")
+
+    service = setup.service_factory.create_group_service()
+    expected = [
+        GroupPermissionGrant(
+            group="some-group",
+            permission="other-permission",
+            argument="*",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="parent-permission",
+            argument="foo",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="some-permission",
+            argument="one",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+        GroupPermissionGrant(
+            group="some-group",
+            permission="some-permission",
+            argument="two",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        ),
+    ]
+    assert sorted(service.permission_grants_for_group("some-group")) == expected
+    assert service.permission_grants_for_group("other-group") == []
 
 
 def test_invalid_group_name(setup):

--- a/tests/usecases/grant_permission_to_service_account_test.py
+++ b/tests/usecases/grant_permission_to_service_account_test.py
@@ -2,64 +2,81 @@ from typing import TYPE_CHECKING
 
 from mock import ANY, call, MagicMock
 
-from grouper.constants import ARGUMENT_VALIDATION, PERMISSION_ADMIN
-from grouper.entities.permission_grant import GroupPermissionGrant, ServiceAccountPermissionGrant
+from grouper.constants import ARGUMENT_VALIDATION, PERMISSION_ADMIN, PERMISSION_GRANT
+from grouper.entities.permission_grant import ServiceAccountPermissionGrant
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest
 
 
-def test_permission_grants_for_group(setup):
+def test_permissions_grantable_to_service_account(setup):
     # type: (SetupTest) -> None
     with setup.transaction():
-        setup.grant_permission_to_group("some-permission", "one", "some-group")
-        setup.grant_permission_to_group("some-permission", "two", "some-group")
+        # Serivce account in an owning group that has some perms, should all be grantable
+        setup.add_user_to_group("gary@a.co", "some-group")
+        setup.create_service_account("service@svc.localhost", "some-group")
+        setup.grant_permission_to_group("some-permission", "arg_one", "some-group")
+        setup.grant_permission_to_group("some-permission", "arg_two", "some-group")
         setup.grant_permission_to_group("other-permission", "*", "some-group")
-        setup.grant_permission_to_group("parent-permission", "foo", "parent-group")
-        setup.add_group_to_group("some-group", "parent-group")
-        setup.create_group("other-group")
-        setup.create_user("gary@a.co")
+        # Admin user and service account, should be able to grant _all_ permissions
+        setup.add_user_to_group("zorkian@a.co", "admin-group")
+        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admin-group")
+        setup.create_service_account("admin@svc.localhost", "admin-group")
+        setup.grant_permission_to_service_account(PERMISSION_ADMIN, "", "admin@svc.localhost")
+        # User and service account with PERMISSION_GRANT; should be able to grant relevant perms
+        setup.add_user_to_group("rra@a.co", "granter-group")
+        setup.grant_permission_to_group(PERMISSION_GRANT, "some-permission", "granter-group")
+        setup.create_service_account("granter@svc.localhost", "granter-group")
+        setup.grant_permission_to_service_account(
+            PERMISSION_GRANT, "some-permission/arg", "granter@svc.localhost"
+        )
+        # User with no special permissions should not be able to grant anything.
+        setup.create_user("permless@a.co")
 
     mock_ui = MagicMock()
+
+    # For members of the owning group, owner group perms are included
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "gary@a.co", mock_ui
     )
-    expected = [
-        GroupPermissionGrant(
-            group="some-group",
-            permission="other-permission",
-            argument="*",
-            granted_on=ANY,
-            is_alias=False,
-            grant_id=ANY,
-        ),
-        GroupPermissionGrant(
-            group="some-group",
-            permission="parent-permission",
-            argument="foo",
-            granted_on=ANY,
-            is_alias=False,
-            grant_id=ANY,
-        ),
-        GroupPermissionGrant(
-            group="some-group",
-            permission="some-permission",
-            argument="one",
-            granted_on=ANY,
-            is_alias=False,
-            grant_id=ANY,
-        ),
-        GroupPermissionGrant(
-            group="some-group",
-            permission="some-permission",
-            argument="two",
-            granted_on=ANY,
-            is_alias=False,
-            grant_id=ANY,
-        ),
+    expected = [  # alphabetically sorted
+        ("other-permission", "*"),
+        ("some-permission", "arg_one"),
+        ("some-permission", "arg_two"),
     ]
-    assert sorted(usecase.permission_grants_for_group("some-group")) == expected
-    assert usecase.permission_grants_for_group("other-group") == []
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == expected
+
+    # For admins, _all_ permissions are included with "*" as the argument
+    all_permissions = ["some-permission", "other-permission", PERMISSION_ADMIN, PERMISSION_GRANT]
+    expected = sorted([(perm, "*") for perm in all_permissions])
+
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "zorkian@a.co", mock_ui
+    )
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == expected
+
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "admin@svc.localhost", mock_ui
+    )
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == expected
+
+    # For all other users, only include permissions the user can independently grant
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "rra@a.co", mock_ui
+    )
+    expected = [("some-permission", "*")]
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == expected
+
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "granter@svc.localhost", mock_ui
+    )
+    expected = [("some-permission", "arg")]
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == expected
+
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "permless@a.co", mock_ui
+    )
+    assert usecase.permissions_grantable_to_service_account("service@svc.localhost") == []
 
 
 def test_service_account_exists_with_owner(setup):
@@ -93,6 +110,10 @@ def test_success(setup):
         setup.create_service_account("service@svc.localhost", "some-group")
         setup.create_service_account("admin@svc.localhost", "admins")
         setup.grant_permission_to_service_account(PERMISSION_ADMIN, "", "admin@svc.localhost")
+        setup.create_service_account("granter@svc.localhost", "other-group")
+        setup.grant_permission_to_service_account(
+            PERMISSION_GRANT, "some-permission/arg*", "granter@svc.localhost"
+        )
 
     service = setup.service_factory.create_service_account_service()
     assert service.permission_grants_for_service_account("service@svc.localhost") == []
@@ -102,7 +123,6 @@ def test_success(setup):
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "gary@a.co", mock_ui
     )
-    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase.grant_permission_to_service_account(
         "some-permission", "argument", "service@svc.localhost"
     )
@@ -129,7 +149,6 @@ def test_success(setup):
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "zorkian@a.co", mock_ui
     )
-    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase.grant_permission_to_service_account(
         "other-permission", "argument", "service@svc.localhost"
     )
@@ -153,7 +172,6 @@ def test_success(setup):
 
     # Delegation from a permission admin that happens to be a service account.
     mock_ui.reset_mock()
-    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "admin@svc.localhost", mock_ui
     )
@@ -168,6 +186,30 @@ def test_success(setup):
             service_account="service@svc.localhost",
             permission="other-permission",
             argument="*",
+            granted_on=ANY,
+            is_alias=False,
+            grant_id=ANY,
+        )
+    )
+    setup.graph.update_from_db(setup.session)
+    assert service.permission_grants_for_service_account("service@svc.localhost") == expected
+
+    # Delegation from an independent granter that happens to be a service account.
+    mock_ui.reset_mock()
+    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
+        "granter@svc.localhost", mock_ui
+    )
+    usecase.grant_permission_to_service_account("some-permission", "argA", "service@svc.localhost")
+    assert mock_ui.mock_calls == [
+        call.granted_permission_to_service_account(
+            "some-permission", "argA", "service@svc.localhost"
+        )
+    ]
+    expected.append(
+        ServiceAccountPermissionGrant(
+            service_account="service@svc.localhost",
+            permission="some-permission",
+            argument="argA",
             granted_on=ANY,
             is_alias=False,
             grant_id=ANY,
@@ -234,31 +276,38 @@ def test_invalid_argument(setup):
     ]
 
 
+def _assert_sane_permission_denied_message(mock_ui):
+    # type: (MagicMock) -> None
+    # Check the mock's first call ([0]) non-keyword args ([1]) last arg ([-1]),
+    # which in permission denied cases is the error message.
+    assert mock_ui.mock_calls[0][1][-1].startswith("Permission denied")
+
+
 def test_permission_denied(setup):
     # type: (SetupTest) -> None
     with setup.transaction():
         setup.create_user("gary@a.co")
         setup.create_service_account("service@svc.localhost", "some-group")
         setup.create_permission("some-permission")
+        setup.grant_permission_to_group("other-permission", "*", "some-group")
 
     # User with no special permissions.
     mock_ui = MagicMock()
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "gary@a.co", mock_ui
     )
-    assert not usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase.grant_permission_to_service_account(
         "some-permission", "argument", "service@svc.localhost"
     )
     assert mock_ui.mock_calls == [
         call.grant_permission_to_service_account_failed_permission_denied(
-            "some-permission", "argument", "service@svc.localhost", "Permission denied"
+            "some-permission", "argument", "service@svc.localhost", ANY
         )
     ]
+    _assert_sane_permission_denied_message(mock_ui)
 
     # Service account with no special permissions.
     mock_ui.reset_mock()
-    assert not usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "service@svc.localhost", mock_ui
     )
@@ -267,9 +316,10 @@ def test_permission_denied(setup):
     )
     assert mock_ui.mock_calls == [
         call.grant_permission_to_service_account_failed_permission_denied(
-            "some-permission", "argument", "service@svc.localhost", "Permission denied"
+            "some-permission", "argument", "service@svc.localhost", ANY
         )
     ]
+    _assert_sane_permission_denied_message(mock_ui)
 
     # Add the user to the group, but don't delegate the permission to the group.  The user should
     # now be able to grant permissions in general, but not this permission in particular.
@@ -280,39 +330,15 @@ def test_permission_denied(setup):
     usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
         "gary@a.co", mock_ui
     )
-    assert usecase.can_grant_permissions_for_service_account("service@svc.localhost")
     usecase.grant_permission_to_service_account(
         "some-permission", "argument", "service@svc.localhost"
     )
     assert mock_ui.mock_calls == [
         call.grant_permission_to_service_account_failed_permission_denied(
-            "some-permission",
-            "argument",
-            "service@svc.localhost",
-            "The group some-group does not have that permission",
+            "some-permission", "argument", "service@svc.localhost", ANY
         )
     ]
-
-
-def test_unknown_permission(setup):
-    # type: (SetupTest) -> None
-    with setup.transaction():
-        setup.add_user_to_group("gary@a.co", "admins")
-        setup.grant_permission_to_group(PERMISSION_ADMIN, "", "admins")
-        setup.create_service_account("service@svc.localhost", "some-group")
-
-    mock_ui = MagicMock()
-    usecase = setup.usecase_factory.create_grant_permission_to_service_account_usecase(
-        "gary@a.co", mock_ui
-    )
-    usecase.grant_permission_to_service_account(
-        "some-permission", "argument", "service@svc.localhost"
-    )
-    assert mock_ui.mock_calls == [
-        call.grant_permission_to_service_account_failed_permission_not_found(
-            "some-permission", "service@svc.localhost"
-        )
-    ]
+    _assert_sane_permission_denied_message(mock_ui)
 
 
 def test_unknown_service_account(setup):

--- a/tests/usecases/list_permissions_test.py
+++ b/tests/usecases/list_permissions_test.py
@@ -4,9 +4,9 @@ from time import time
 from typing import TYPE_CHECKING
 
 from grouper.constants import PERMISSION_CREATE
-from grouper.entities.pagination import PaginatedList, Pagination
+from grouper.entities.pagination import ListPermissionsSortKey, PaginatedList, Pagination
 from grouper.entities.permission import Permission
-from grouper.usecases.list_permissions import ListPermissionsSortKey, ListPermissionsUI
+from grouper.usecases.list_permissions import ListPermissionsUI
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest


### PR DESCRIPTION
Reworks the logic of granting a permission to a service account, so that it now allows for granting based on `grouper.permission.grant` permissions. As a result, users and service accounts that are neither permission admins nor owners of a target service account can now grant permissions to that target.

Note that there is now a (different) mismatch between the logic of granting permissions to service accounts vs. granting permissions to groups, in that the former allows for inheriting `grouper.permission.grant` through nested groups while the latter does not.

Note as well that there still is no way to request a permission directly to a service account; the flow is still to request the permission to the owning group and then grant it to the service account from there.