### PR TITLE
extend create_service_account to support initial user metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN /etc/init.d/mysql start && mysql -e "\
  "
 
 RUN /etc/init.d/mysql start && \
- TRAVIS_PYTHON_VERSION=3.7 DB=mysql ci/setup.sh
+ TRAVIS_PYTHON_VERSION=3.7 ci/setup.sh
 
 COPY . /app
 ENV PYTHONPATH /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # but its "MariaDB" replacement for MySQL dies with "Specified key was
 # too long; max key length is 767 bytes" when our tests try creating
 # their tables.
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 RUN apt-get update
 
@@ -22,6 +22,7 @@ RUN apt-get install -y libmysqlclient-dev mysql-client mysql-server
 RUN apt-get install -y python3-dev python3-pip gcc
 RUN apt-get install -y chromium-driver
 RUN apt-get install -y procps unzip wget
+RUN apt-get install -y libcurl4-openssl-dev libssl-dev
 
 WORKDIR /app
 COPY ci/setup.sh /app/ci/setup.sh
@@ -33,14 +34,13 @@ RUN /etc/init.d/mysql start && mysql -e "\
  "
 
 RUN /etc/init.d/mysql start && \
- TRAVIS_PYTHON_VERSION=3.5 ci/setup.sh && \
- pip3 install isort mypy
+ TRAVIS_PYTHON_VERSION=3.7 DB=mysql ci/setup.sh
 
 COPY . /app
 ENV PYTHONPATH /app
 ENV GROUPER_SETTINGS /app/config/dev.yaml
 
-RUN bin/grouper-ctl sync_db && \
+RUN bin/grouper-ctl -vv sync_db && \
  bin/grouper-ctl -vv user create user@example.com && \
  bin/grouper-ctl -vv group add_member --owner grouper-administrators user@example.com
 
@@ -53,5 +53,5 @@ RUN ( \
 EXPOSE 8888
 
 ENV PYTHONDONTWRITEBYTECODE=PLEASE
-ENV TRAVIS_PYTHON_VERSION 3.5
+ENV TRAVIS_PYTHON_VERSION 3.7
 CMD ["/bin/bash", "-c", "/etc/init.d/mysql start && exec /bin/bash"]

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -9,5 +9,5 @@ if [ "$DB" = 'mysql' ]; then
     mysql -e 'CREATE DATABASE merou CHARACTER SET utf8mb4;'
 fi
 
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
+pip3 install -r requirements.txt
+pip3 install -r requirements-dev.txt

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -60,6 +60,7 @@ class ServiceAccountRepository:
         # Set initial user metadata fields if present.
         if initial_metadata is not None:
             for key, value in initial_metadata.items():
+                # TODO: move this to use the hexagonal architecture model.
                 set_user_metadata(self.session, user.id, key, value)
 
         # Create the linkage to the owner.

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -7,9 +7,11 @@ from grouper.models.group import Group
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.service_account import ServiceAccount as SQLServiceAccount
 from grouper.models.user import User as SQLUser
+from grouper.user_metadata import set_user_metadata
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
+    from typing import Dict, Optional
 
 
 class ServiceAccountRepository:
@@ -40,8 +42,8 @@ class ServiceAccountRepository:
             )
             group_service_account.add(self.session)
 
-    def create_service_account(self, name, owner, machine_set, description):
-        # type: (str, str, str, str) -> None
+    def create_service_account(self, name, owner, machine_set, description, initial_metadata=None):
+        # type: (str, str, str, str, Optional[Dict[str,str]]) -> None
         group = Group.get(self.session, name=owner)
         if not group:
             raise GroupNotFoundException(owner)
@@ -52,8 +54,15 @@ class ServiceAccountRepository:
         user.add(self.session)
         service.add(self.session)
 
-        # Flush the account to allocate an ID, and then create the linkage to the owner.
+        # Flush the account to allocate an ID.
         self.session.flush()
+
+        # Set initial user metadata fields if present.
+        if initial_metadata is not None:
+            for key, value in initial_metadata.items():
+                set_user_metadata(self.session, user.id, key, value)
+
+        # Create the linkage to the owner.
         GroupServiceAccount(group_id=group.id, service_account=service).add(self.session)
 
     def enable_service_account(self, name):

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from grouper.settings import Settings
     from grouper.usecases.authorization import Authorization
     from grouper.usecases.interfaces import AuditLogInterface
-    from typing import List, Optional, Tuple
+    from typing import Dict, List, Optional, Tuple
 
 
 class ServiceAccountService(ServiceAccountInterface):
@@ -58,10 +58,12 @@ class ServiceAccountService(ServiceAccountInterface):
         self.group_request_repository = group_request_repository
         self.audit_log = audit_log_service
 
-    def create_service_account(self, service, owner, machine_set, description, authorization):
-        # type: (str, str, str, str, Authorization) -> None
+    def create_service_account(
+        self, service, owner, machine_set, description, initial_metadata, authorization
+    ):
+        # type: (str, str, str, str, Optional[Dict[str,str]], Authorization) -> None
         self.service_account_repository.create_service_account(
-            service, owner, machine_set, description
+            service, owner, machine_set, description, initial_metadata
         )
         self.audit_log.log_create_service_account(service, owner, authorization)
 

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from grouper.entities.group import GroupNotFoundException
 from grouper.plugin.exceptions import PluginRejectedMachineSet
 from grouper.usecases.authorization import Authorization
-from grouper.user_metadata import set_user_metadata
 
 if TYPE_CHECKING:
     from grouper.plugin.proxy import PluginProxy

--- a/grouper/usecases/create_service_account.py
+++ b/grouper/usecases/create_service_account.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from grouper.entities.group import GroupNotFoundException
 from grouper.plugin.exceptions import PluginRejectedMachineSet
 from grouper.usecases.authorization import Authorization
+from grouper.user_metadata import set_user_metadata
 
 if TYPE_CHECKING:
     from grouper.plugin.proxy import PluginProxy
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
         TransactionInterface,
         UserInterface,
     )
+    from typing import Dict, Optional
 
 
 class CreateServiceAccountUI(metaclass=ABCMeta):
@@ -87,8 +89,10 @@ class CreateServiceAccount:
         else:
             return self.user_service.user_is_user_admin(self.actor)
 
-    def create_service_account(self, service, owner, machine_set, description):
-        # type: (str, str, str, str) -> None
+    def create_service_account(
+        self, service, owner, machine_set, description, initial_metadata=None
+    ):
+        # type: (str, str, str, str, Optional[Dict[str,str]]) -> None
         if "@" not in service:
             service += "@" + self.settings.service_account_email_domain
 
@@ -122,7 +126,7 @@ class CreateServiceAccount:
         with self.transaction_service.transaction():
             try:
                 self.service_account_service.create_service_account(
-                    service, owner, machine_set, description, authorization
+                    service, owner, machine_set, description, initial_metadata, authorization
                 )
             except GroupNotFoundException:
                 self.ui.create_service_account_failed_invalid_owner(service, owner)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -251,8 +251,10 @@ class ServiceAccountInterface(metaclass=ABCMeta):
     """Abstract base class for service account operations and queries."""
 
     @abstractmethod
-    def create_service_account(self, service, owner, machine_set, description, authorization):
-        # type: (str, str, str, str, Authorization) -> None
+    def create_service_account(
+        self, service, owner, machine_set, description, initial_metadata, authorization
+    ):
+        # type: (str, str, str, str, Optional[Dict[str,str]], Authorization) -> None
         pass
 
     @abstractmethod

--- a/grouper/user_metadata.py
+++ b/grouper/user_metadata.py
@@ -10,6 +10,14 @@ if TYPE_CHECKING:
     from grouper.models.base.session import Session
 
 
+class InvalidUserMetadataKeyException(Exception):
+    """Setting metadata failed due to an invalid key string."""
+
+    def __init__(self, key):
+        # type: (str) -> None
+        super().__init__(f"Metadata key '{key}' is invalid.")
+
+
 def get_user_metadata(session, user_id):
     # type: (Session, int) -> Sequence[UserMetadata]
     """Return all of a user's metadata.
@@ -52,7 +60,8 @@ def set_user_metadata(session, user_id, data_key, data_value):
     Returns:
         the UserMetadata object or None if entry was deleted
     """
-    assert re.match(PERMISSION_VALIDATION, data_key), "proposed metadata key is valid"
+    if not re.match(PERMISSION_VALIDATION, data_key):
+        raise InvalidUserMetadataKeyException(data_key)
 
     user_md = get_user_metadata_by_key(session, user_id, data_key)  # type: Optional[UserMetadata]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ black==19.10b0
 flake8-import-order==0.18.1
 flake8==3.7.9
 groupy>=0.5.1
+isort==5.5.2
 mock==2.0.0
 py==1.8.0
 mypy==0.740

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -7,8 +7,10 @@ from grouper.models.group import Group
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
+from grouper.models.user_metadata import UserMetadata
 from grouper.plugin.base import BasePlugin
 from grouper.plugin.exceptions import PluginRejectedMachineSet, PluginRejectedServiceAccountName
+from grouper.user_metadata import get_user_metadata
 
 if TYPE_CHECKING:
     from tests.setup import SetupTest
@@ -88,6 +90,42 @@ def test_success(setup):
     assert metadata["service_account"]["owner"] == "some-group"
     group_details = setup.graph.get_group_details("some-group")
     assert group_details["service_accounts"] == ["service@svc.localhost"]
+
+
+def test_success_set_initial_metadata(setup):
+    # type: (SetupTest) -> None
+    with setup.transaction():
+        setup.add_user_to_group("gary@a.co", "some-group")
+
+    initial_metadata = {"test-item-1": "foo", "test-item-2": "bar"}
+
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account(
+        "service@svc.localhost", "some-group", "machine-set", "description", initial_metadata
+    )
+
+    user = User.get(setup.session, name="service@svc.localhost")
+    assert user is not None
+    metadata_items = get_user_metadata(setup.session, user.id)
+    actual_items = {mi.data_key: mi.data_value for mi in metadata_items}
+    assert len(initial_metadata) == len(actual_items)
+    for key, value in initial_metadata.items():
+        assert key in actual_items
+        assert initial_metadata[key] == actual_items[key]
+
+    usecase = setup.usecase_factory.create_create_service_account_usecase("gary@a.co", mock_ui)
+    usecase.create_service_account(
+        "another_service@svc.localhost", "some-group", "machine-set", "description"
+    )
+    assert mock_ui.mock_calls[-1] == call.created_service_account(
+        "another_service@svc.localhost", "some-group"
+    )
+
+    user = User.get(setup.session, name="another_service@svc.localhost")
+    assert user is not None
+    metadata_items = get_user_metadata(setup.session, user.id)
+    assert metadata_items == []
 
 
 def test_add_domain(setup):

--- a/tests/usecases/create_service_account_test.py
+++ b/tests/usecases/create_service_account_test.py
@@ -7,7 +7,6 @@ from grouper.models.group import Group
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
-from grouper.models.user_metadata import UserMetadata
 from grouper.plugin.base import BasePlugin
 from grouper.plugin.exceptions import PluginRejectedMachineSet, PluginRejectedServiceAccountName
 from grouper.user_metadata import get_user_metadata
@@ -118,10 +117,6 @@ def test_success_set_initial_metadata(setup):
     usecase.create_service_account(
         "another_service@svc.localhost", "some-group", "machine-set", "description"
     )
-    assert mock_ui.mock_calls[-1] == call.created_service_account(
-        "another_service@svc.localhost", "some-group"
-    )
-
     user = User.get(setup.session, name="another_service@svc.localhost")
     assert user is not None
     metadata_items = get_user_metadata(setup.session, user.id)


### PR DESCRIPTION
Implemented at the usecase layer, but not exposed in the UI service account creation dialog.