### PR TITLE
expose arbitrary user metadata for get/set opts in fe

### DIFF
--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -245,6 +245,23 @@ fe:
     shell:
         - [/bin/false, Your administrator has not configured Grouper for shell management]
 
+    # A dict of lists of lists representing the options that users are allowed
+    # to select for a given user metadata key.  The key is the user_metadata
+    # data_key. The dict values are lists of two item lists. The first argument
+    # is the value to be set in the database, and the second is a user readable
+    # representation for display.
+    #
+    # NOTE: The metadata key "shell" is special cased in the above "shell"
+    # configuration block. Ideally, "shell" will be folded in to the newly
+    # supported "metadata_options".
+    #
+    # Type: Dict[List[Tuple[str, str]]]
+    metadata_options:
+        test_key:
+            - [first, the first value]
+            - [second, the second value]
+            - [third, the third value]
+
     # Site-specific docs.  Each list entry should provide url, name, and
     # description keys.
     #

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -278,6 +278,11 @@ class UserShellForm(Form):
     shell = SelectField("Shell", [validators.DataRequired()])
 
 
+class UserMetadataForm(Form):
+    # Caller of form will add choices based on settings.
+    value = SelectField("Value", [validators.DataRequired()])
+
+
 class UserPasswordForm(Form):
     name = StringField(
         "Password name",

--- a/grouper/fe/handlers/user_metadata.py
+++ b/grouper/fe/handlers/user_metadata.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from grouper.constants import USER_METADATA_GITHUB_USERNAME_KEY, USER_METADATA_SHELL_KEY
+from grouper.fe.forms import UserMetadataForm
+from grouper.fe.settings import settings
+from grouper.fe.util import GrouperHandler
+from grouper.models.audit_log import AuditLog
+from grouper.models.user import User
+from grouper.role_user import can_manage_role_user
+from grouper.service_account import can_manage_service_account
+from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
+
+if TYPE_CHECKING:
+    from grouper.models.base.session import Session
+    from typing import Any
+
+
+DEFAULT_METADATA_OPTIIONS = [
+    ["n/a", "No values have been setup by the administrator for this metadata item"],
+]
+
+
+class UserMetadata(GrouperHandler):
+    @staticmethod
+    def check_access(session: Session, actor: User, target: User) -> bool:
+        return (
+            actor.name == target.name
+            or (target.role_user and can_manage_role_user(session, actor, tuser=target))
+            or (target.is_service_account and can_manage_service_account(session, target, actor))
+        )
+
+    def get(self, *args: Any, **kwargs: Any) -> None:
+        name = self.get_path_argument("name")
+
+        user = User.get(self.session, name=name)
+        if not user:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, user):
+            return self.forbidden()
+
+        metadata_key = self.get_path_argument("key")
+
+        if metadata_key == USER_METADATA_SHELL_KEY:
+            return self.redirect("/users/{}/shell".format(user.name))
+        elif metadata_key == USER_METADATA_GITHUB_USERNAME_KEY:
+            return self.redirect("/github/link_begin/{}".format(user.id))
+
+        known_field = metadata_key in settings().metadata_options
+        metadata_item = get_user_metadata_by_key(self.session, user.id, metadata_key)
+        if not metadata_item and not known_field:
+            return self.notfound()
+
+        form = UserMetadataForm()
+        form.value.choices = settings().metadata_options.get(
+            metadata_key, DEFAULT_METADATA_OPTIIONS
+        )
+
+        self.render("user-metadata.html", form=form, user=user, metadata_key=metadata_key)
+
+    def post(self, *args: Any, **kwargs: Any) -> None:
+        name = self.get_path_argument("name")
+
+        user = User.get(self.session, name=name)
+        if not user:
+            return self.notfound()
+
+        if not self.check_access(self.session, self.current_user, user):
+            return self.forbidden()
+
+        metadata_key = self.get_path_argument("key")
+
+        if metadata_key == USER_METADATA_SHELL_KEY:
+            return self.redirect("/users/{}/shell".format(user.name))
+        elif metadata_key == USER_METADATA_GITHUB_USERNAME_KEY:
+            return self.redirect("/github/link_begin/{}".format(user.id))
+
+        known_field = metadata_key in settings().metadata_options
+        metadata_item = get_user_metadata_by_key(self.session, user.id, metadata_key)
+        if not metadata_item and not known_field:
+            return self.notfound()
+
+        form = UserMetadataForm(self.request.arguments)
+        form.value.choices = settings().metadata_options.get(
+            metadata_key, DEFAULT_METADATA_OPTIIONS
+        )
+        if not form.validate():
+            return self.render(
+                "user-metadata.html",
+                form=form,
+                user=user,
+                metadata_key=metadata_key,
+                alerts=self.get_form_alerts(form.errors),
+            )
+
+        set_user_metadata(self.session, user.id, metadata_key, form.data["value"])
+
+        AuditLog.log(
+            self.session,
+            self.current_user.id,
+            "changed_user_metadata",
+            "Changed {}: {}".format(metadata_key, form.data["value"]),
+            on_user_id=user.id,
+        )
+
+        return self.redirect("/users/{}?refresh=yes".format(user.name))

--- a/grouper/fe/routes.py
+++ b/grouper/fe/routes.py
@@ -60,6 +60,7 @@ from grouper.fe.handlers.service_account_permission_revoke import ServiceAccount
 from grouper.fe.handlers.service_account_view import ServiceAccountView
 from grouper.fe.handlers.user_disable import UserDisable
 from grouper.fe.handlers.user_enable import UserEnable
+from grouper.fe.handlers.user_metadata import UserMetadata
 from grouper.fe.handlers.user_password_add import UserPasswordAdd
 from grouper.fe.handlers.user_password_delete import UserPasswordDelete
 from grouper.fe.handlers.user_requests import UserRequests
@@ -98,6 +99,7 @@ _MEMBER_NAME = _NAME.replace("<name>", "<member_name>")
 
 # Verbatim from grouper.constants, but create an alias for consistency.
 _PERMISSION = PERMISSION_VALIDATION
+_METADATA_KEY = PERMISSION_VALIDATION.replace("<name>", "<key>")
 
 HANDLERS: List[Tuple[str, Type[RequestHandler]]] = [
     ("/", Index),
@@ -148,6 +150,7 @@ HANDLERS: List[Tuple[str, Type[RequestHandler]]] = [
     (f"/users/{_USERNAME}/enable", UserEnable),
     (f"/users/{_USERNAME}/github/clear", UserClearGitHub),
     (f"/users/{_USERNAME}/shell", UserShell),
+    (f"/users/{_USERNAME}/metadata/{_METADATA_KEY}", UserMetadata),
     (f"/users/{_USERNAME}/public-key/add", PublicKeyAdd),
     (f"/users/{_USERNAME}/public-key/{_KEY_ID}/delete", PublicKeyDelete),
     (f"/users/{_USERNAME}/tokens/add", UserTokenAdd),

--- a/grouper/fe/settings.py
+++ b/grouper/fe/settings.py
@@ -35,6 +35,7 @@ class FrontendSettings(Settings):
         self.shell = (
             [["/bin/false", "Shell support in Grouper has not been setup by the administrator"]],
         )
+        self.metadata_options = {}  # type: Dict[List[str, str]]
         self.site_docs = []  # type: List[Dict[str, str]]
 
     def update_from_config(self, filename=None, section="fe"):

--- a/grouper/fe/templates/forms/user-metadata.html
+++ b/grouper/fe/templates/forms/user-metadata.html
@@ -1,0 +1,5 @@
+{% from 'macros/ui.html' import form_field -%}
+
+{{ form_field(form.value, 3, 8, class_="form-control") }}
+
+{{ xsrf_form()|safe }}

--- a/grouper/fe/templates/macros/ui.html
+++ b/grouper/fe/templates/macros/ui.html
@@ -728,3 +728,61 @@ enabled. Membership in this group is regularly reviewed.
         </div>
     </div>
 {%- endmacro %}
+
+{% macro addl_metadata_panel(user, metadata, can_control=False) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{ metadata.data_key }}</h3>
+        </div>
+        <div class="table-responsive standard-panel">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-md-2">{{ metadata.data_key }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>{{ metadata.data_value }}</td>
+                    </tr>
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/metadata/{{ metadata.data_key }}">
+                <span class="glyphicon glyphicon-pencil"></span> Change {{ metadata.data_key }}
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endmacro %}
+
+{% macro unset_metadata_panel(user, key, can_control=False) -%}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{ key }}</h3>
+        </div>
+        <div class="table-responsive standard-panel">
+            <table class="table table-striped table-condensed">
+                <thead>
+                    <tr>
+                        <th class="col-md-2">{{ key }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>(Unset)</td>
+                    </tr>
+                </tbody>
+            </table>
+            {% if can_control %}
+            <div class='panel-footer'>
+                <a class="btn btn-default btn-sm" href="/users/{{ user.name }}/metadata/{{ key }}">
+                <span class="glyphicon glyphicon-pencil"></span> Change {{ key }}
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endmacro %}

--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from 'macros/ui.html' import log_entry_panel, tokens_panel, shell_panel, passwords_panel,
-                                permission_link, public_key_panel %}
+                                permission_link, public_key_panel, addl_metadata_panel,
+                                unset_metadata_panel %}
 
 {% macro permission_panel(mappings, group, user, can_manage) -%}
     <div class="panel panel-default">
@@ -143,6 +144,26 @@
         <div class="col-md-4">
             {{ passwords_panel(user, passwords, can_control) }}
         </div>
+    </div>
+{% endif %}
+
+{% if addl_metadata %}
+    <div class="row">
+        {% for metadata in addl_metadata %}
+        <div class="col-md-4">
+            {{ addl_metadata_panel(user, metadata, can_control) }}
+        </div>
+        {% endfor %}
+    </div>
+{% endif %}
+
+{% if unset_metadata %}
+    <div class="row">
+        {% for key in unset_metadata %}
+        <div class="col-md-4">
+            {{ unset_metadata_panel(user, key, can_control) }}
+        </div>
+        {% endfor %}
     </div>
 {% endif %}
 

--- a/grouper/fe/templates/user-metadata.html
+++ b/grouper/fe/templates/user-metadata.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block subtitle %} change {{ metadata_key }} for {{user.name}}{% endblock %}
+
+{% block heading %}
+    <a href="/users">Users</a>
+{% endblock %}
+
+{% block subheading %}
+    Change {{ metadata_key }} for User {{ user.name }}
+{% endblock %}
+
+{% block content %}
+<div class="col-md-6 col-md-offset-3">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Change {{ metadata_key }} for User {{ user.name }}</h3>
+       </div>
+
+        <div class="panel-body" id="dropdown_form">
+            <form class="form-horizontal" role="form"
+                method="post" action="/users/{{ user.name }}/metadata/{{ metadata_key }}">
+                {% include "forms/user-metadata.html" %}
+                <div class="form-shell">
+                    <div class="col-sm-offset-3 col-sm-4">
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/grouper/user_metadata.py
+++ b/grouper/user_metadata.py
@@ -6,7 +6,7 @@ from grouper.models.counter import Counter
 from grouper.models.user_metadata import UserMetadata
 
 if TYPE_CHECKING:
-    from typing import Optional, Sequence
+    from typing import List, Optional, Sequence
     from grouper.models.base.session import Session
 
 
@@ -18,17 +18,26 @@ class InvalidUserMetadataKeyException(Exception):
         super().__init__(f"Metadata key '{key}' is invalid.")
 
 
-def get_user_metadata(session, user_id):
-    # type: (Session, int) -> Sequence[UserMetadata]
+def get_user_metadata(session, user_id, exclude=None):
+    # type: (Session, int, Optional[List[str]]) -> Sequence[UserMetadata]
     """Return all of a user's metadata.
 
     Args:
         session(models.base.session.Session): database session
         user_id(int): id of user in question
+        exclude(Optional[list[str]]): metadata keys to exclude
 
     Returns:
         List of UserMetadata objects
     """
+    if exclude is not None:
+        return (
+            session.query(UserMetadata)
+            .filter(UserMetadata.user_id == user_id)
+            .filter(~UserMetadata.data_key.in_(exclude))
+            .all()
+        )
+
     return session.query(UserMetadata).filter(UserMetadata.user_id == user_id).all()
 
 

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,0 +1,59 @@
+from urllib.parse import urlencode
+
+import pytest
+
+from grouper.models.user import User
+from grouper.settings import settings
+from grouper.user_metadata import get_user_metadata_by_key, set_user_metadata
+from tests.fixtures import (  # noqa: F401
+    fe_app as app,
+    graph,
+    groups,
+    permissions,
+    service_accounts,
+    session,
+    standard_graph,
+    users,
+)
+from tests.url_util import url
+
+
+@pytest.mark.gen_test
+def test_metadata(session, users, http_client, base_url):  # noqa: F811
+    settings().metadata_options = {"favorite_food": [["pizza", "pizza"], ["kale", "kale"]]}
+
+    user = users["zorkian@a.co"]
+    assert not get_user_metadata_by_key(session, user.id, "favorite_food")
+
+    user = User.get(session, name=user.username)
+    set_user_metadata(session, user.id, "favorite_food", "default")
+    fe_url = url(base_url, "/users/{}/metadata/favorite_food".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"value": "pizza"}),
+        headers={"X-Grouper-User": user.username},
+    )
+    assert resp.code == 200
+
+    assert get_user_metadata_by_key(session, user.id, "favorite_food").data_value == "pizza"
+
+    fe_url = url(base_url, "/users/{}/metadata/favorite_food".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"value": "kale"}),
+        headers={"X-Grouper-User": user.username},
+    )
+
+    assert get_user_metadata_by_key(session, user.id, "favorite_food").data_value == "kale"
+
+    fe_url = url(base_url, "/users/{}/metadata/favorite_food".format(user.username))
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode({"value": "donuts"}),
+        headers={"X-Grouper-User": user.username},
+    )
+
+    assert get_user_metadata_by_key(session, user.id, "favorite_food").data_value == "kale"


### PR DESCRIPTION
- This allows non-special cased (shell and github) metadata to be visible for service accounts.
- Provides a way to set values through the UI (currently assumes the metadata key is already set)
- Adds a mechanism for specifying a set of valid values for metadata items