### PR TITLE
disallow setting user metadata fields that do not have options

### DIFF
--- a/grouper/fe/handlers/user_metadata.py
+++ b/grouper/fe/handlers/user_metadata.py
@@ -58,7 +58,13 @@ class UserMetadata(GrouperHandler):
             metadata_key, DEFAULT_METADATA_OPTIIONS
         )
 
-        self.render("user-metadata.html", form=form, user=user, metadata_key=metadata_key)
+        self.render(
+            "user-metadata.html",
+            form=form,
+            user=user,
+            is_enabled=known_field,
+            metadata_key=metadata_key,
+        )
 
     def post(self, *args: Any, **kwargs: Any) -> None:
         name = self.get_path_argument("name")
@@ -92,6 +98,7 @@ class UserMetadata(GrouperHandler):
                 form=form,
                 user=user,
                 metadata_key=metadata_key,
+                is_enabled=known_field,
                 alerts=self.get_form_alerts(form.errors),
             )
 

--- a/grouper/fe/templates/user-metadata.html
+++ b/grouper/fe/templates/user-metadata.html
@@ -23,7 +23,12 @@
                 {% include "forms/user-metadata.html" %}
                 <div class="form-shell">
                     <div class="col-sm-offset-3 col-sm-4">
-                        <button type="submit" class="btn btn-primary">Submit</button>
+                        {% if is_enabled %}
+                        <button type="submit" class="btn btn-primary">
+                        {% else %}
+                        <button type="submit" class="btn btn-secondary" disabled>
+                        {% endif %}
+                        Submit</button>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
Options are derived from the metadata_options field in the settings.
This prevents user_metadata set by integrations/admins from being
changed. At some point we may want to add more configuration options
around user metadata fields, but this seems reasonable for now.