### PR TITLE
Make permission requests expand to permission aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get install -y chromium-driver
 RUN apt-get install -y procps unzip wget
 RUN apt-get install -y libcurl4-openssl-dev libssl-dev
 
+ENV DB mysql
 WORKDIR /app
 COPY ci/setup.sh /app/ci/setup.sh
 COPY requirements*.txt /app/

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -314,6 +314,16 @@ def get_owners_by_grantable_permission(
         ):
             owners_by_arg_by_perm[perm.name][arg].append(group)
 
+        for gp in group_permissions:
+            aliases = get_plugin_proxy().get_aliases_for_mapped_permission(
+                    session, gp.name, group.name
+            )
+            for alias in aliases:
+                if alias[0] == PERMISSION_GRANT:
+                    perm, arg = alias[1].split('/', 1)
+                    owners_by_arg_by_perm[perm][arg].append(group)
+
+
     # merge in plugin results
     for res in get_plugin_proxy().get_owner_by_arg_by_perm(session):
         for permission_name, owners_by_arg in res.items():

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -320,8 +320,8 @@ def get_owners_by_grantable_permission(
             )
             for alias in aliases:
                 if alias[0] == PERMISSION_GRANT:
-                    perm, arg = alias[1].split('/', 1)
-                    owners_by_arg_by_perm[perm][arg].append(group)
+                    alias_perm, arg = alias[1].split('/', 1)
+                    owners_by_arg_by_perm[alias_perm][arg].append(group)
 
 
     # merge in plugin results

--- a/grouper/permissions.py
+++ b/grouper/permissions.py
@@ -316,13 +316,12 @@ def get_owners_by_grantable_permission(
 
         for gp in group_permissions:
             aliases = get_plugin_proxy().get_aliases_for_mapped_permission(
-                    session, gp.name, group.name
+                session, gp.name, group.name
             )
             for alias in aliases:
                 if alias[0] == PERMISSION_GRANT:
-                    alias_perm, arg = alias[1].split('/', 1)
+                    alias_perm, arg = alias[1].split("/", 1)
                     owners_by_arg_by_perm[alias_perm][arg].append(group)
-
 
     # merge in plugin results
     for res in get_plugin_proxy().get_owner_by_arg_by_perm(session):

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -305,7 +305,7 @@ def test_permission_grant_to_owners(
             # type: (Session, str, str) -> List[Tuple[str, str]]
             if permission != "alias_perm" or argument != "team-sre":
                 return []
-            return [(perm_grant, "foo-perm/bar-arg")]
+            return [(PERMISSION_GRANT, "foo-perm/bar-arg")]
 
     owner_perm = create_permission(session, "alias_perm")
     session.commit()

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -1,11 +1,11 @@
 import unittest
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
-from grouper.plugin.base import BasePlugin
+
 import pytest
 from tornado.httpclient import HTTPError
 from wtforms.validators import ValidationError
-from grouper.plugin import get_plugin_proxy
+
 import grouper.fe.util
 from grouper.constants import (
     ARGUMENT_VALIDATION,
@@ -32,6 +32,8 @@ from grouper.permissions import (
     get_requests,
     grant_permission_to_service_account,
 )
+from grouper.plugin import get_plugin_proxy
+from grouper.plugin.base import BasePlugin
 from grouper.user_permissions import user_grantable_permissions, user_has_permission
 from tests.fixtures import (  # noqa: F401
     fe_app as app,
@@ -48,6 +50,8 @@ from tests.util import get_group_permissions, get_user_permissions, grant_permis
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
+    from typing import List, Tuple
+    from sqlalchemy.orm import Session
 
 
 @pytest.fixture

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -305,7 +305,7 @@ def test_permission_grant_to_owners(
             # type: (Session, str, str) -> List[Tuple[str, str]]
             if permission != "alias_perm" or argument != "team-sre":
                 return []
-            return [("grouper.permission.grant", "foo-perm/bar-arg")]
+            return [(perm_grant, "foo-perm/bar-arg")]
 
     owner_perm = create_permission(session, "alias_perm")
     session.commit()


### PR DESCRIPTION
Currently, grantable permissions don't take any permission alias into account. So when looking to see who can grant a permission where the `grouper.permission.grant` is given as an alias, that request goes to grouper admin instead of the appropriate owner of the group. This will fix that bug.