### PR TITLE
Show service account Add Permission button for all users

### DIFF
--- a/grouper/fe/templates/service-account.html
+++ b/grouper/fe/templates/service-account.html
@@ -54,14 +54,12 @@
                 </tbody>
             </table>
         </div>
-        {% if can_manage %}
         <div class='panel-footer'>
             <a id="add-permission" class="btn btn-default btn-sm"
                href="/groups/{{group.name}}/service/{{user.username}}/grant">
                 <span class="glyphicon glyphicon-plus"></span> Add Permission
             </a>
         </div>
-        {% endif %}
     </div>
 {%- endmacro %}
 

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -294,9 +294,9 @@ def test_permission_grant_denied(tmpdir: LocalPath, setup: SetupTest, browser: C
     with frontend_server(tmpdir, "rra@a.co") as frontend_url:
         browser.get(url(frontend_url, "/groups/some-group/service/service@svc.localhost"))
 
-        page = ServiceAccountViewPage(browser)
-        assert len(page.permission_rows) == 0
-        page.click_add_permission_button()
+        view_page = ServiceAccountViewPage(browser)
+        assert len(view_page.permission_rows) == 0
+        view_page.click_add_permission_button()
 
         forbidden_page = ErrorPage(browser)
         assert forbidden_page.heading == "Error"

--- a/itests/fe/service_accounts_test.py
+++ b/itests/fe/service_accounts_test.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 from selenium.common.exceptions import NoSuchElementException
 
-from grouper.constants import USER_ADMIN, PERMISSION_ADMIN
+from grouper.constants import PERMISSION_ADMIN, USER_ADMIN
 from itests.pages.base import BasePage
 from itests.pages.error import ErrorPage
 from itests.pages.groups import GroupViewPage


### PR DESCRIPTION
Status quo: only members of a service account's owning group (as well as user admins) can see the Add Permission button on a service account page.
Problem: users who aren't members of the owning group but who have `grouper.permission.grant` perms, as well as permission admins, ought to be able to grant perms to a service account. Right now, they can't see (and thus can't click) the button.

Choosing the simplicity of just having the button be visible to everyone, since the grant-to-service-account page will already 403 for any user that cannot grant any perms to the given service account.