### PR TITLE
allow user admins to manage all service accounts

### DIFF
--- a/grouper/service_account.py
+++ b/grouper/service_account.py
@@ -24,6 +24,7 @@ from grouper.models.user import User
 from grouper.plugin import get_plugin_proxy
 from grouper.plugin.exceptions import PluginRejectedMachineSet
 from grouper.user import disable_user, enable_user
+from grouper.user_permissions import user_is_user_admin
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
@@ -78,6 +79,8 @@ def edit_service_account(session, actor, service_account, description, machine_s
 def can_manage_service_account(session, target, user):
     # type: (Session, Union[ServiceAccount, User], User) -> bool
     """Returns whether a User has permission to manage a ServiceAccount."""
+    if user_is_user_admin(session, user):
+        return True
     if type(target) == User:
         if not target.is_service_account:
             return False

--- a/tests/service_accounts_test.py
+++ b/tests/service_accounts_test.py
@@ -170,6 +170,7 @@ def test_service_account_fe_edit(
 ):
     owner = "gary@a.co"
     plebe = "oliver@a.co"
+    admin = "tyleromeara@a.co"
 
     # Unrelated people cannot edit the service account.
     fe_url = url(base_url, "/groups/team-sre/service/service@a.co/edit")
@@ -192,7 +193,7 @@ def test_service_account_fe_edit(
     # A user admin also can.
     update["description"] = "done by admin"
     resp = yield http_client.fetch(
-        fe_url, method="POST", headers={"X-Grouper-User": owner}, body=urlencode(update)
+        fe_url, method="POST", headers={"X-Grouper-User": admin}, body=urlencode(update)
     )
     assert resp.code == 200
     graph.update_from_db(session)


### PR DESCRIPTION
in `tests/service_accounts_test.py` the intention is clear that user admins should have the ability to edit all service accounts, yet it is tested using a member of the service account owner group. this commit fixes both the test (using the user admin "tyleromeara@a.co" defined in `tests/fixtures.py:standard_graph`) and the implementation of `grouper/service_account.py:can_manage_service_account` such that user admins can manage any arbitrary service account.