### PR TITLE
Plugin support for validating permission arguments

### DIFF
--- a/grouper/fe/handlers/permission_request.py
+++ b/grouper/fe/handlers/permission_request.py
@@ -11,6 +11,7 @@ from grouper.fe.settings import settings
 from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
 from grouper.permissions import get_grantable_permissions, get_permission
+from grouper.plugin.exceptions import PluginRejectedPermissionArgument
 from grouper.user_group import get_groups_by_user
 
 if TYPE_CHECKING:
@@ -55,6 +56,7 @@ class PermissionRequest(GrouperHandler):
 
         # save off request
         try:
+            self.plugins.check_permission_argument(permission.name, argument)
             request = permissions.create_request(
                 self.session, self.current_user, group, permission, argument, form.reason.data
             )
@@ -83,6 +85,8 @@ class PermissionRequest(GrouperHandler):
             ]
         except UserNotAuditor as e:
             alerts = [Alert("danger", str(e))]
+        except PluginRejectedPermissionArgument as e:
+            alerts = [Alert("danger", f"Rejected by plugin: {e}")]
         else:
             alerts = []
 

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -49,6 +49,19 @@ class BasePlugin:
         """
         pass
 
+    def check_permission_argument(self, permission: str, argument: str) -> None:
+        """Check permission argument for validity
+
+        Args:
+            permission: A Grouper permission name
+            argument: The argument for that permission
+
+        Raises:
+            PluginRejectedPermissionArgument to reject the argument. The exception message will be
+            shown to the user.
+        """
+        pass
+
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> Optional[Iterable[Tuple[str, str]]]
         """Called when building the graph to get aliases of a mapped permission.

--- a/grouper/plugin/exceptions.py
+++ b/grouper/plugin/exceptions.py
@@ -5,6 +5,8 @@ class PluginException(Exception):
 class PluginsDirectoryDoesNotExist(PluginException):
     """The specified plugin directory does not exist."""
 
+    pass
+
 
 class PluginRejectedGroupMembershipUpdate(PluginException):
     pass
@@ -22,6 +24,12 @@ class PluginRejectedMachineSet(PluginException):
 
 class PluginRejectedServiceAccountName(PluginException):
     """A plugin rejected a name for a service account."""
+
+    pass
+
+
+class PluginRejectedPermissionArgument(PluginException):
+    """A plugin rejected a permission argument pairing."""
 
     pass
 

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -50,6 +50,10 @@ class PluginProxy:
         for plugin in self._plugins:
             plugin.check_service_account_name(name)
 
+    def check_permission_argument(self, permission: str, argument: str) -> None:
+        for plugin in self._plugins:
+            plugin.check_permission_argument(permission, argument)
+
     def get_aliases_for_mapped_permission(self, session, permission, argument):
         # type: (Session, str, str) -> Iterable[Tuple[str, str]]
         for plugin in self._plugins:

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -496,13 +496,9 @@ class PermissionValidationPlugin(BasePlugin):
 
 @pytest.mark.gen_test
 def test_permission_plugin(
-    grantable_permissions, groups, http_client, base_url, setup  # noqa: F811
+    session, grantable_permissions, http_client, base_url  # noqa: F811
 ):
-
-    perm_grant, _, perm1, perm2 = grantable_permissions
-    grant_permission(groups["all-teams"], perm_grant, argument="grantable.*")
-
-    setup.plugins.add_plugin(PermissionValidationPlugin())
+    get_plugin_proxy().add_plugin(PermissionValidationPlugin())
     groupname = "serving-team"
     username = "zorkian@a.co"
     permission_name = "grantable.one"

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -495,9 +495,7 @@ class PermissionValidationPlugin(BasePlugin):
 
 
 @pytest.mark.gen_test
-def test_permission_plugin(
-    session, grantable_permissions, http_client, base_url  # noqa: F811
-):
+def test_permission_plugin(session, grantable_permissions, http_client, base_url):  # noqa: F811
     get_plugin_proxy().add_plugin(PermissionValidationPlugin())
     groupname = "serving-team"
     username = "zorkian@a.co"


### PR DESCRIPTION
This allows for developers to write arbitrary code to determine
permission/argument pair validity. Examples include applying a regex or
querying some internal system.