### PR TITLE
Add ability to search for permission by it's argument

### DIFF
--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -39,8 +39,8 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
 
     def get(self, *args: Any, **kwargs: Any) -> None:
         name = self.get_path_argument("name")
-        permission_arg = self.get_argument("permission_arg", None)
+        argument = self.get_argument("argument", None)
         usecase = self.usecase_factory.create_view_permission_usecase(self)
         usecase.view_permission(
-            name, self.current_user.username, audit_log_limit=20, permission_arg=permission_arg
+            name, self.current_user.username, audit_log_limit=20, argument=argument
         )

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -41,5 +41,6 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
         name = self.get_path_argument("name")
         permission_arg = self.get_argument("permission_arg", None)
         usecase = self.usecase_factory.create_view_permission_usecase(self)
-        usecase.view_permission(name, self.current_user.username, audit_log_limit=20,
-                                permission_arg=permission_arg)
+        usecase.view_permission(
+            name, self.current_user.username, audit_log_limit=20, permission_arg=permission_arg
+        )

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -39,5 +39,7 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
 
     def get(self, *args: Any, **kwargs: Any) -> None:
         name = self.get_path_argument("name")
+        permission_arg = self.get_argument("permission_arg", None)
         usecase = self.usecase_factory.create_view_permission_usecase(self)
-        usecase.view_permission(name, self.current_user.username, audit_log_limit=20)
+        usecase.view_permission(name, self.current_user.username, audit_log_limit=20,
+                                permission_arg=permission_arg)

--- a/grouper/fe/handlers/search.py
+++ b/grouper/fe/handlers/search.py
@@ -17,8 +17,6 @@ class Search(GrouperHandler):
         if limit > 9000:
             limit = 9000
 
-        print("In search, got {}".format(query))
-
         groups = (
             self.session.query(
                 label("type", literal("Group")),
@@ -30,7 +28,6 @@ class Search(GrouperHandler):
         )
 
         permission_query = query.split("=")[0] if "=" in query else query
-        print("In search, looking for {}".format(permission_query))
         permissions = (
             self.session.query(
                 label("type", literal("Permission")),

--- a/grouper/fe/handlers/search.py
+++ b/grouper/fe/handlers/search.py
@@ -57,12 +57,12 @@ class Search(GrouperHandler):
         if len(results) == 1:
             result = results[0]
 
-            params = {}
-            base_url = "/{}s/{}".format(result.type.lower(), result.name)
+            encoded_params = ""
             if result.type.lower() == "permission" and "=" in query:
-                params = {"permission_arg": query.split("=", 1)[1]}
+                encoded_params = "?" + urlencode({"permission_arg": query.split("=", 1)[1]})
 
-            return self.redirect(base_url + "?" + urlencode(params))
+            base_url = "/{}s/{}".format(result.type.lower(), result.name)
+            return self.redirect(base_url + encoded_params)
 
         self.render(
             "search.html",

--- a/grouper/fe/handlers/search.py
+++ b/grouper/fe/handlers/search.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from sqlalchemy import union_all
 from sqlalchemy.sql import label, literal
 
@@ -5,7 +7,6 @@ from grouper.fe.util import GrouperHandler
 from grouper.models.group import Group
 from grouper.models.permission import Permission
 from grouper.models.user import User
-from urllib.parse import urlencode
 
 
 class Search(GrouperHandler):
@@ -36,7 +37,9 @@ class Search(GrouperHandler):
                 label("id", Permission.id),
                 label("name", Permission.name),
             )
-            .filter(Permission.enabled == True, Permission.name.like("%{}%".format(permission_query)))
+            .filter(
+                Permission.enabled == True, Permission.name.like("%{}%".format(permission_query))
+            )
             .subquery()
         )
 
@@ -62,7 +65,7 @@ class Search(GrouperHandler):
             if result.type.lower() == "permission" and "=" in query:
                 params = {"permission_arg": query.split("=", 1)[1]}
 
-            return self.redirect(base_url + '?' + urlencode(params))
+            return self.redirect(base_url + "?" + urlencode(params))
 
         self.render(
             "search.html",

--- a/grouper/fe/handlers/search.py
+++ b/grouper/fe/handlers/search.py
@@ -59,7 +59,7 @@ class Search(GrouperHandler):
 
             encoded_params = ""
             if result.type.lower() == "permission" and "=" in query:
-                encoded_params = "?" + urlencode({"permission_arg": query.split("=", 1)[1]})
+                encoded_params = "?" + urlencode({"argument": query.split("=", 1)[1]})
 
             base_url = "/{}s/{}".format(result.type.lower(), result.name)
             return self.redirect(base_url + encoded_params)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from functools import wraps
 from typing import TYPE_CHECKING
-from urllib.parse import quote, unquote, urlencode, urljoin
+from urllib.parse import quote, unquote, urlencode, urljoin, urlparse
 from uuid import uuid4
 
 from plop.collector import Collector
@@ -117,7 +117,8 @@ class GrouperHandler(RequestHandler):
 
     def redirect(self, url: str, *args: Any, **kwargs: Any) -> None:
         if self.is_refresh():
-            url = urljoin(url, "?refresh=yes")
+            url += ('&' if urlparse(url).query else '?') + urlencode({'refresh': 'yes'})
+
         alerts = kwargs.pop("alerts", [])  # type: List[Alert]
         self.set_alerts(alerts)
         super().redirect(url, *args, **kwargs)

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -7,7 +7,7 @@ import sys
 from datetime import datetime
 from functools import wraps
 from typing import TYPE_CHECKING
-from urllib.parse import quote, unquote, urlencode, urljoin, urlparse
+from urllib.parse import quote, unquote, urlencode, urlparse
 from uuid import uuid4
 
 from plop.collector import Collector
@@ -117,7 +117,7 @@ class GrouperHandler(RequestHandler):
 
     def redirect(self, url: str, *args: Any, **kwargs: Any) -> None:
         if self.is_refresh():
-            url += ('&' if urlparse(url).query else '?') + urlencode({'refresh': 'yes'})
+            url += ("&" if urlparse(url).query else "?") + urlencode({"refresh": "yes"})
 
         alerts = kwargs.pop("alerts", [])  # type: List[Alert]
         self.set_alerts(alerts)

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -665,8 +665,8 @@ class GroupGraph:
 
     def get_group_details(self, groupname, show_permission=None, expose_aliases=True):
         # type: (str, Optional[str], bool) -> Dict[str, Any]
-        """ Get users and permissions that belong to a group. Raise NoSuchGroup
-        for missing groups. """
+        """Get users and permissions that belong to a group. Raise NoSuchGroup
+        for missing groups."""
 
         with self.lock:
             data = {

--- a/grouper/group_member.py
+++ b/grouper/group_member.py
@@ -26,7 +26,7 @@ class InvalidRoleForMember(Exception):
 
 class MemberNotFound(Exception):
     """This exception is raised when trying to perform a group operation on an account that is
-       not a member of the group."""
+    not a member of the group."""
 
     pass
 

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -80,8 +80,8 @@ class PermissionGrantRepository(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def group_grants_for_permission(self, name, include_disabled_groups=False):
-        # type: (str, bool) -> List[GroupPermissionGrant]
+    def group_grants_for_permission(self, name, include_disabled_groups=False, argument=None):
+        # type: (str, bool, Optional[str]) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod
@@ -110,8 +110,8 @@ class PermissionGrantRepository(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
+    def service_account_grants_for_permission(self, name, argument=None):
+        # type: (str, Optional[str]) -> List[ServiceAccountPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -71,13 +71,13 @@ class PermissionService(PermissionInterface):
         self.permission_repository.disable_permission(name)
         self.audit_log.log_disable_permission(name, authorization)
 
-    def group_grants_for_permission(self, name):
-        # type: (str) -> List[GroupPermissionGrant]
-        return self.permission_grant_repository.group_grants_for_permission(name)
+    def group_grants_for_permission(self, name, argument=None):
+        # type: (str, Optional[str]) -> List[GroupPermissionGrant]
+        return self.permission_grant_repository.group_grants_for_permission(name, argument=argument)
 
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
-        return self.permission_grant_repository.service_account_grants_for_permission(name)
+    def service_account_grants_for_permission(self, name, argument=None):
+        # type: (str, Optional[str]) -> List[ServiceAccountPermissionGrant]
+        return self.permission_grant_repository.service_account_grants_for_permission(name, argument=argument)
 
     def is_system_permission(self, name):
         # type: (str) -> bool

--- a/grouper/services/permission.py
+++ b/grouper/services/permission.py
@@ -73,11 +73,15 @@ class PermissionService(PermissionInterface):
 
     def group_grants_for_permission(self, name, argument=None):
         # type: (str, Optional[str]) -> List[GroupPermissionGrant]
-        return self.permission_grant_repository.group_grants_for_permission(name, argument=argument)
+        return self.permission_grant_repository.group_grants_for_permission(
+            name, argument=argument
+        )
 
     def service_account_grants_for_permission(self, name, argument=None):
         # type: (str, Optional[str]) -> List[ServiceAccountPermissionGrant]
-        return self.permission_grant_repository.service_account_grants_for_permission(name, argument=argument)
+        return self.permission_grant_repository.service_account_grants_for_permission(
+            name, argument=argument
+        )
 
     def is_system_permission(self, name):
         # type: (str) -> bool

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -198,13 +198,13 @@ class PermissionInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def group_grants_for_permission(self, name):
-        # type: (str) -> List[GroupPermissionGrant]
+    def group_grants_for_permission(self, name, argument=None):
+        # type: (str, Optional[str]) -> List[GroupPermissionGrant]
         pass
 
     @abstractmethod
-    def service_account_grants_for_permission(self, name):
-        # type: (str) -> List[ServiceAccountPermissionGrant]
+    def service_account_grants_for_permission(self, name, argument=None):
+        # type: (str, Optional[str]) -> List[ServiceAccountPermissionGrant]
         pass
 
     @abstractmethod

--- a/grouper/usecases/view_permission.py
+++ b/grouper/usecases/view_permission.py
@@ -43,18 +43,16 @@ class ViewPermission:
         self.user_service = user_service
         self.audit_log_service = audit_log_service
 
-    def view_permission(self, name, actor, audit_log_limit, permission_arg=None):
+    def view_permission(self, name, actor, audit_log_limit, argument=None):
         # type: (str, str, int, Optional[str]) -> None
 
         permission = self.permission_service.permission(name)
         if not permission:
             self.ui.view_permission_failed_not_found(name)
             return
-        group_grants = self.permission_service.group_grants_for_permission(
-            name, argument=permission_arg
-        )
+        group_grants = self.permission_service.group_grants_for_permission(name, argument=argument)
         service_grants = self.permission_service.service_account_grants_for_permission(
-            name, argument=permission_arg
+            name, argument=argument
         )
         audit_log = self.audit_log_service.entries_affecting_permission(name, audit_log_limit)
         access = self.user_service.permission_access_for_user(actor, name)

--- a/grouper/usecases/view_permission.py
+++ b/grouper/usecases/view_permission.py
@@ -50,8 +50,12 @@ class ViewPermission:
         if not permission:
             self.ui.view_permission_failed_not_found(name)
             return
-        group_grants = self.permission_service.group_grants_for_permission(name, argument=permission_arg)
-        service_grants = self.permission_service.service_account_grants_for_permission(name, argument=permission_arg)
+        group_grants = self.permission_service.group_grants_for_permission(
+            name, argument=permission_arg
+        )
+        service_grants = self.permission_service.service_account_grants_for_permission(
+            name, argument=permission_arg
+        )
         audit_log = self.audit_log_service.entries_affecting_permission(name, audit_log_limit)
         access = self.user_service.permission_access_for_user(actor, name)
         self.ui.viewed_permission(permission, group_grants, service_grants, access, audit_log)

--- a/grouper/usecases/view_permission.py
+++ b/grouper/usecases/view_permission.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
         ServiceAccountPermissionGrant,
     )
     from grouper.usecases.interfaces import AuditLogInterface, PermissionInterface, UserInterface
-    from typing import List
+    from typing import List, Optional
 
 
 class ViewPermissionUI(metaclass=ABCMeta):
@@ -43,14 +43,15 @@ class ViewPermission:
         self.user_service = user_service
         self.audit_log_service = audit_log_service
 
-    def view_permission(self, name, actor, audit_log_limit):
-        # type: (str, str, int) -> None
+    def view_permission(self, name, actor, audit_log_limit, permission_arg=None):
+        # type: (str, str, int, Optional[str]) -> None
+
         permission = self.permission_service.permission(name)
         if not permission:
             self.ui.view_permission_failed_not_found(name)
             return
-        group_grants = self.permission_service.group_grants_for_permission(name)
-        service_grants = self.permission_service.service_account_grants_for_permission(name)
+        group_grants = self.permission_service.group_grants_for_permission(name, argument=permission_arg)
+        service_grants = self.permission_service.service_account_grants_for_permission(name, argument=permission_arg)
         audit_log = self.audit_log_service.entries_affecting_permission(name, audit_log_limit)
         access = self.user_service.permission_access_for_user(actor, name)
         self.ui.viewed_permission(permission, group_grants, service_grants, access, audit_log)

--- a/tests/audit_test.py
+++ b/tests/audit_test.py
@@ -47,8 +47,8 @@ if TYPE_CHECKING:
 
 
 def test_group_audited(standard_graph, graph, session, groups, permissions):  # noqa: F811
-    """ Ensure that the audited flag gets set appropriate only groups and inherited down the
-        graph. """
+    """Ensure that the audited flag gets set appropriate only groups and inherited down the
+    graph."""
     assert not graph.get_group_details("security-team")["audited"]
     assert graph.get_group_details("serving-team")["audited"]
     assert graph.get_group_details("team-sre")["audited"]

--- a/tests/groups_test.py
+++ b/tests/groups_test.py
@@ -205,14 +205,14 @@ def test_graph_cycle_direct(session, graph, users, groups):  # noqa: F811
 
 
 def test_graph_cycle_indirect(session, graph, users, groups):  # noqa: F811
-    """ Test adding a member that will create a cycle.
+    """Test adding a member that will create a cycle.
 
-        gary         zay            testuser
-         |            |                |
-        sre <----- tech-ops <----- team-infra <--
-         |                                       |
-         |                                       |
-          --------> all-teams --------------------
+    gary         zay            testuser
+     |            |                |
+    sre <----- tech-ops <----- team-infra <--
+     |                                       |
+     |                                       |
+      --------> all-teams --------------------
 
     """
 

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -80,8 +80,8 @@ def _get_unsent_and_mark_as_sent_emails(session):  # noqa: F811
 def test_basic_permission(
     standard_graph, graph, session, users, groups, permissions  # noqa: F811
 ):
-    """ Test adding some permissions to various groups and ensuring that the permissions are all
-        implemented as expected. This also tests permissions inheritance in the graph. """
+    """Test adding some permissions to various groups and ensuring that the permissions are all
+    implemented as expected. This also tests permissions inheritance in the graph."""
 
     assert sorted(get_group_permissions(graph, "team-sre")) == [
         "audited:",

--- a/tests/usecases/view_permission_test.py
+++ b/tests/usecases/view_permission_test.py
@@ -48,6 +48,7 @@ def test_view_permissions(setup):
         setup.create_permission("argumented-permission", "Some argumented permission")
         setup.grant_permission_to_group("some-permission", "", "another-group")
         setup.grant_permission_to_group("some-permission", "foo", "some-group")
+        setup.grant_permission_to_group("argumented-permission", "foo-arg", "some-group")
         setup.create_service_account("service@svc.localhost", "owner-group")
         setup.create_service_account(
             "service_for_argumented_permission@svc.localhost", "foo-group"
@@ -113,13 +114,16 @@ def test_view_permissions(setup):
     audit_log_entries = [(e.actor, e.action, e.on_permission) for e in mock_ui.audit_log_entries]
     assert audit_log_entries == [("gary@a.co", "disable_permission", "disabled-permission")]
 
-    # Search for permission based on argument without group grants but some service account grants.
+    # Search for permission based on argument with group grants and service account grants.
     usecase.view_permission("argumented-permission", "gary@a.co", 20, "foo-arg")
     assert mock_ui.permission.name == "argumented-permission"
     assert mock_ui.permission.description == "Some argumented permission"
     assert not mock_ui.permission.audited
     assert mock_ui.permission.enabled
-    assert mock_ui.group_grants == []
+    group_grants = [(g.group, g.permission, g.argument) for g in mock_ui.group_grants]
+    assert group_grants == [
+        ("some-group", "argumented-permission", "foo-arg"),
+    ]
     service_account_grants = [
         (g.service_account, g.permission, g.argument) for g in mock_ui.service_account_grants
     ]


### PR DESCRIPTION
This diff allows searching for `perm=arg` in the search bar; this will result in showing only the results which are granted the `perm`  permission with the argument `arg`