### PR TITLE
Pipe database_source exec stderr.

### DIFF
--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -173,7 +173,7 @@ class Settings:
         while True:
             try:
                 self._logger.debug("Getting database URL by running %s", self.database_source)
-                raw_url = subprocess.check_output([self.database_source], stderr=subprocess.STDOUT)
+                raw_url = subprocess.check_output([self.database_source], stderr=subprocess.PIPE)
                 url = raw_url.decode().strip()
                 if not url:
                     raise DatabaseSourceException("Returned URL is empty")
@@ -189,6 +189,8 @@ class Settings:
                     msg = "Unable to get a database URL from {} after {} tries: {}".format(
                         self.database_source, self.DB_URL_RETRIES, str(e)
                     )
+                    if isinstance(e, CalledProcessError):
+                        msg += f"\nstderr: {e.stderr!r}"
                     raise DatabaseSourceException(msg)
 
     def _url_without_password(self, url):

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -97,7 +97,7 @@ def test_database():
         mock_subprocess.return_value = b"sqlite:///other.sqlite\n"
         assert settings.database == "sqlite:///other.sqlite"
         assert mock_subprocess.call_args_list == [
-            call(["/path/to/program"], stderr=subprocess.STDOUT)
+            call(["/path/to/program"], stderr=subprocess.PIPE)
         ]
 
     # If the command fails, it should be retried.  Disable the delay to not make the test slow.


### PR DESCRIPTION
This allows extraneous logging to be ignored while preserving stderr for analysis in an exception message.