### PR TITLE
Catch db engine creation failures

### DIFF
--- a/grouper/models/base/session.py
+++ b/grouper/models/base/session.py
@@ -3,7 +3,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from sqlalchemy import create_engine
+from sqlalchemy.exc import ArgumentError, OperationalError
 from sqlalchemy.orm import Session as _Session, sessionmaker
+
+from grouper.settings import InvalidSettingsError
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -31,7 +34,12 @@ def flush_transaction(method):
 
 def get_db_engine(url):
     # type: (str) -> Engine
-    return create_engine(url, pool_recycle=300)
+    try:
+        engine = create_engine(url, pool_recycle=300)
+    except (ArgumentError, OperationalError):
+        logging.exception("Can't create database engine.")
+        raise InvalidSettingsError("Invalid arguments. Can't create database engine")
+    return engine
 
 
 class SessionWithoutAdd(_Session):

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -6,6 +6,7 @@ import pytest
 import pytz
 from mock import call, patch
 
+from grouper.models.base.session import get_db_engine
 from grouper.settings import DatabaseSourceException, InvalidSettingsError, Settings
 
 if TYPE_CHECKING:
@@ -144,3 +145,11 @@ def test_mask_passsword_in_logs(caplog):
 
     assert test_url not in caplog.text
     assert expected_url in caplog.text
+
+
+def test_bad_db_url():
+    # type: () -> None
+    bad_url = "This is not even a valid URL"
+    with pytest.raises(InvalidSettingsError):
+        engine = get_db_engine(bad_url)
+        assert engine


### PR DESCRIPTION
Failures during db engine creation end up leaking the url parameter in the exception logs.
The url parameter is sensitive and can contain credentials to connect to the database.

Catch and throw a Grouper specific exception which masks any sensitive information. 
