### PR TITLE
Pass full Tornado request to request logging plugin

### DIFF
--- a/grouper/api/handlers.py
+++ b/grouper/api/handlers.py
@@ -81,7 +81,7 @@ class GraphHandler(RequestHandler):
         handler = self.__class__.__name__
         response_status = self.get_status()
         duration_ms = int((datetime.utcnow() - self._request_start_time).total_seconds() * 1000)
-        self.plugins.log_request(handler, response_status, duration_ms)
+        self.plugins.log_request(handler, response_status, duration_ms, self.request)
 
     def log_exception(
         self,

--- a/grouper/fe/handlers/permission_grants_group_view.py
+++ b/grouper/fe/handlers/permission_grants_group_view.py
@@ -25,7 +25,7 @@ class PermissionGrantsGroupView(GrouperHandler, ViewPermissionGroupGrantsUI):
             return PermissionGroupGrantSortKey.GROUP
 
     def viewed_permission(
-        self, permission: Permission, grants: PaginatedList[GroupPermissionGrant],
+        self, permission: Permission, grants: PaginatedList[GroupPermissionGrant]
     ) -> None:
 
         sort_key = self.get_sort_key().name.lower()
@@ -57,5 +57,5 @@ class PermissionGrantsGroupView(GrouperHandler, ViewPermissionGroupGrantsUI):
 
         usecase = self.usecase_factory.create_view_permission_group_grants_usecase(self)
         usecase.view_granted_permission(
-            name, self.current_user.username, argument=argument, pagination=pagination,
+            name, self.current_user.username, argument=argument, pagination=pagination
         )

--- a/grouper/fe/handlers/permission_grants_service_account_view.py
+++ b/grouper/fe/handlers/permission_grants_service_account_view.py
@@ -31,7 +31,7 @@ class PermissionGrantsServiceAccountView(GrouperHandler, ViewPermissionServiceAc
             return PermissionServiceAccountGrantSortKey.SERVICE_ACCOUNT
 
     def viewed_permission(
-        self, permission: Permission, grants: PaginatedList[ServiceAccountPermissionGrant],
+        self, permission: Permission, grants: PaginatedList[ServiceAccountPermissionGrant]
     ) -> None:
 
         sort_key = self.get_sort_key().name.lower()
@@ -63,5 +63,5 @@ class PermissionGrantsServiceAccountView(GrouperHandler, ViewPermissionServiceAc
 
         usecase = self.usecase_factory.create_view_permission_service_account_grants_usecase(self)
         usecase.view_granted_permission(
-            name, self.current_user.username, argument=argument, pagination=pagination,
+            name, self.current_user.username, argument=argument, pagination=pagination
         )

--- a/grouper/fe/handlers/permission_view.py
+++ b/grouper/fe/handlers/permission_view.py
@@ -23,7 +23,7 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
         audit_log_entries: List[AuditLogEntry],
     ) -> None:
         template = PermissionTemplate(
-            permission=permission, access=access, audit_log_entries=audit_log_entries,
+            permission=permission, access=access, audit_log_entries=audit_log_entries
         )
         self.render_template_class(template)
 
@@ -33,5 +33,5 @@ class PermissionView(GrouperHandler, ViewPermissionUI):
 
         usecase = self.usecase_factory.create_view_permission_usecase(self)
         usecase.view_permission(
-            name, self.current_user.username, audit_log_limit=20, argument=argument,
+            name, self.current_user.username, audit_log_limit=20, argument=argument
         )

--- a/grouper/fe/handlers/user_metadata.py
+++ b/grouper/fe/handlers/user_metadata.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 DEFAULT_METADATA_OPTIIONS = [
-    ["n/a", "No values have been setup by the administrator for this metadata item"],
+    ["n/a", "No values have been setup by the administrator for this metadata item"]
 ]
 
 

--- a/grouper/fe/util.py
+++ b/grouper/fe/util.py
@@ -190,7 +190,7 @@ class GrouperHandler(RequestHandler):
         handler = self.__class__.__name__
         duration_ms = int((datetime.utcnow() - self._request_start_time).total_seconds() * 1000)
         response_status = self.get_status()
-        self.plugins.log_request(handler, response_status, duration_ms)
+        self.plugins.log_request(handler, response_status, duration_ms, self.request)
 
     def update_qs(self, **kwargs: Any) -> str:
         qs = self.request.arguments.copy()

--- a/grouper/graph.py
+++ b/grouper/graph.py
@@ -566,10 +566,7 @@ class GroupGraph:
         # type: (str, bool) -> Dict[str, Union[bool, Dict[str, Any]]]
         """ Get a permission and what groups and service accounts it's assigned to. """
         with self.lock:
-            data = {
-                "groups": {},
-                "service_accounts": {},
-            }  # type: Dict[str, Dict[str, Any]]
+            data = {"groups": {}, "service_accounts": {}}  # type: Dict[str, Dict[str, Any]]
 
             # Get all mapped versions of the permission. This is only direct relationships.
             direct_groups = set()

--- a/grouper/plugin/base.py
+++ b/grouper/plugin/base.py
@@ -156,14 +156,15 @@ class BasePlugin:
         """
         pass
 
-    def log_request(self, handler, status, duration_ms):
-        # type: (str, int, int) -> None
+    def log_request(self, handler, status, duration_ms, request):
+        # type: (str, int, int, Optional[HTTPRequest]) -> None
         """Log information about a handled request
 
         Arg(s):
             handler: name of the handler class that handled the request
             status: the response status of the request (e.g., 200, 404, etc.)
             duration_ms: the request processing latency
+            request: the Tornado request that was handled
         """
         pass
 

--- a/grouper/plugin/proxy.py
+++ b/grouper/plugin/proxy.py
@@ -118,10 +118,10 @@ class PluginProxy:
         for plugin in self._plugins:
             plugin.log_periodic_graph_update(success)
 
-    def log_request(self, handler, status, duration_ms):
-        # type: (str, int, int) -> None
+    def log_request(self, handler, status, duration_ms, request):
+        # type: (str, int, int, Optional[HTTPRequest]) -> None
         for plugin in self._plugins:
-            plugin.log_request(handler, status, duration_ms)
+            plugin.log_request(handler, status, duration_ms, request)
 
     def user_created(self, user, is_service_account=False):
         # type: (User, bool) -> None

--- a/grouper/usecases/grant_permission_to_group.py
+++ b/grouper/usecases/grant_permission_to_group.py
@@ -113,7 +113,7 @@ class GrantPermissionToGroup:
             message = (
                 "Permission denied. Actor {actor} does not have the ability to"
                 "grant the permission {permission} with argument {argument}."
-            ).format(actor=self.actor, permission=permission, argument=argument,)
+            ).format(actor=self.actor, permission=permission, argument=argument)
             self.ui.grant_permission_to_group_failed_permission_denied(
                 permission, argument, group, message
             )

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import pytest
-import time
 from selenium.common.exceptions import NoSuchElementException
 
 from grouper.entities.group import GroupJoinPolicy

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -101,8 +101,7 @@ def test_require_clickthru(tmpdir: LocalPath, setup: SetupTest, browser: Chrome)
         create_group_modal.set_join_policy(GroupJoinPolicy.CAN_JOIN)
         create_group_modal.click_require_clickthru_checkbox()
         create_group_modal.confirm()
-
-    time.sleep(0.5)  # Help prevent flakiness of unclear cause
+        time.sleep(0.5)  # Ensure confirm() goes through before FE server is shut down
 
     with frontend_server(tmpdir, "rra@a.co") as frontend_url:
         browser.get(url(frontend_url, "/groups/test-group/join"))

--- a/itests/fe/group_join_test.py
+++ b/itests/fe/group_join_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+import time
 from selenium.common.exceptions import NoSuchElementException
 
 from grouper.entities.group import GroupJoinPolicy
@@ -100,6 +101,8 @@ def test_require_clickthru(tmpdir: LocalPath, setup: SetupTest, browser: Chrome)
         create_group_modal.set_join_policy(GroupJoinPolicy.CAN_JOIN)
         create_group_modal.click_require_clickthru_checkbox()
         create_group_modal.confirm()
+
+    time.sleep(0.5)  # Help prevent flakiness of unclear cause
 
     with frontend_server(tmpdir, "rra@a.co") as frontend_url:
         browser.get(url(frontend_url, "/groups/test-group/join"))

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 
 from mock import ANY
 
+import time
+
 from grouper.constants import PERMISSION_GRANT
 from grouper.entities.permission_grant import GroupPermissionGrant
 from itests.pages.groups import GroupViewPage
@@ -121,6 +123,8 @@ def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
         permission_request_page.set_argument_freeform("  arg u  ment  ")
         permission_request_page.set_reason("testing whitespace")
         permission_request_page.submit()
+
+    time.sleep(0.5)  # Help prevent flakiness of unclear cause
 
     with frontend_server(tmpdir, "zorkian@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/requests?status=pending"))

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -122,8 +122,7 @@ def test_end_to_end_whitespace_in_argument(tmpdir, setup, browser):
         permission_request_page.set_argument_freeform("  arg u  ment  ")
         permission_request_page.set_reason("testing whitespace")
         permission_request_page.submit()
-
-    time.sleep(0.5)  # Help prevent flakiness of unclear cause
+        time.sleep(0.5)  # Ensure submit() goes through before FE server shut down
 
     with frontend_server(tmpdir, "zorkian@a.co") as frontend_url:
         browser.get(url(frontend_url, "/permissions/requests?status=pending"))

--- a/itests/fe/permission_request_test.py
+++ b/itests/fe/permission_request_test.py
@@ -1,8 +1,7 @@
+import time
 from typing import TYPE_CHECKING
 
 from mock import ANY
-
-import time
 
 from grouper.constants import PERMISSION_GRANT
 from grouper.entities.permission_grant import GroupPermissionGrant

--- a/tests/api/handlers_test.py
+++ b/tests/api/handlers_test.py
@@ -435,6 +435,7 @@ def test_request_logging(session, users, http_client, base_url):  # noqa: F811
     assert mock_plugin.log_request.call_args_list[0][0][1] == 200
     # the reported value should be within 1s of our own observation
     assert abs(mock_plugin.log_request.call_args_list[0][0][2] - duration_ms) <= 1000
+    assert mock_plugin.log_request.call_args_list[0][0][3].path == "/users/zorkian@a.co"
 
     mock_plugin.log_request.reset_mock()
     start_time = time.time()
@@ -449,3 +450,4 @@ def test_request_logging(session, users, http_client, base_url):  # noqa: F811
     assert mock_plugin.log_request.call_args_list[0][0][1] == 404
     # the reported value should be within 1s of our own observation
     assert abs(mock_plugin.log_request.call_args_list[0][0][2] - duration_ms) <= 1000
+    assert mock_plugin.log_request.call_args_list[0][0][3].path == "/groups/does-not-exist"

--- a/tests/fe/handlers_test.py
+++ b/tests/fe/handlers_test.py
@@ -886,6 +886,7 @@ def test_request_logging(session, users, http_client, base_url):  # noqa: F811
     assert mock_plugin.log_request.call_args_list[0][0][1] == 200
     # the reported value should be within 1s of our own observation
     assert abs(mock_plugin.log_request.call_args_list[0][0][2] - duration_ms) <= 1000
+    assert mock_plugin.log_request.call_args_list[0][0][3].path == "/users"
 
     mock_plugin.log_request.reset_mock()
     start_time = time.time()
@@ -900,3 +901,4 @@ def test_request_logging(session, users, http_client, base_url):  # noqa: F811
     assert mock_plugin.log_request.call_args_list[0][0][1] == 404
     # the reported value should be within 1s of our own observation
     assert abs(mock_plugin.log_request.call_args_list[0][0][2] - duration_ms) <= 1000
+    assert mock_plugin.log_request.call_args_list[0][0][3].path == "/groups/does-not-exist"

--- a/tests/passwords_test.py
+++ b/tests/passwords_test.py
@@ -53,8 +53,10 @@ def test_passwords(session, users):  # noqa: F811
 
     session.rollback()
 
-    # Technically there's a very very very small O(1/2^160) chance that this will fail for a
+    # NOTE: Technically there's a very very very small O(1/2^160) chance that this will fail for a
     # correct implementation.
+    # NOTE: This test may fail for systems on which crypt(3) defaults to a weak method that can
+    # only use 2 character salts, as all salts used are prefixed with $6$ to indicate SHA512
     assert (
         password.password_hash != password2.password_hash
     ), "2 passwords that are identical should hash differently because of the salts"

--- a/tests/passwords_test.py
+++ b/tests/passwords_test.py
@@ -53,8 +53,8 @@ def test_passwords(session, users):  # noqa: F811
 
     session.rollback()
 
-    # NOTE: Technically there's a very very very small O(1/2^160) chance that this will fail for a
-    # correct implementation.
+    # NOTE: Technically there's a very very very small O(1/2^160) chance that this will
+    # fail for a correct implementation.
     # NOTE: This test may fail for systems on which crypt(3) defaults to a weak method that can
     # only use 2 character salts, as all salts used are prefixed with $6$ to indicate SHA512
     assert (

--- a/tests/usecases/grant_permission_to_group_test.py
+++ b/tests/usecases/grant_permission_to_group_test.py
@@ -36,9 +36,7 @@ def test_permissions_grantable(setup):
     mock_ui = MagicMock()
 
     usecase = setup.usecase_factory.create_grant_permission_to_group_usecase("rra@a.co", mock_ui)
-    expected = [
-        ("some-permission", "*"),
-    ]
+    expected = [("some-permission", "*")]
     assert usecase.permissions_grantable() == expected
 
     all_permissions = ["some-permission", "other-permission", PERMISSION_ADMIN, PERMISSION_GRANT]
@@ -56,9 +54,7 @@ def test_permissions_grantable(setup):
     usecase = setup.usecase_factory.create_grant_permission_to_group_usecase(
         "granter@svc.localhost", mock_ui
     )
-    expected = [
-        ("some-permission", "arg"),
-    ]
+    expected = [("some-permission", "arg")]
     assert usecase.permissions_grantable() == expected
 
     usecase = setup.usecase_factory.create_grant_permission_to_group_usecase("gary@a.co", mock_ui)

--- a/tests/usecases/view_permission_test.py
+++ b/tests/usecases/view_permission_test.py
@@ -183,9 +183,7 @@ def test_view_permissions(setup):
     ]
 
     # Limit the number of audit log entries.
-    permission_usecase.view_permission(
-        "disabled-permission", "gary@a.co", 1,
-    )
+    permission_usecase.view_permission("disabled-permission", "gary@a.co", 1)
     audit_log_entries = [
         (e.actor, e.action, e.on_permission) for e in mock_permission_ui.audit_log_entries
     ]
@@ -196,7 +194,7 @@ def test_view_permissions(setup):
         "argumented-permission", "gary@a.co", group_paginate, "foo-arg"
     )
     sa_usecase.view_granted_permission(
-        "argumented-permission", "gary@a.co", service_account_paginate, "foo-arg",
+        "argumented-permission", "gary@a.co", service_account_paginate, "foo-arg"
     )
     permission_usecase.view_permission("argumented-permission", "gary@a.co", 20)
 
@@ -207,9 +205,7 @@ def test_view_permissions(setup):
     assert not mock_permission_ui.permission.audited
     assert mock_permission_ui.permission.enabled
     group_grants = [(g.group, g.permission, g.argument) for g in mock_group_ui.grants.values]
-    assert group_grants == [
-        ("some-group", "argumented-permission", "foo-arg"),
-    ]
+    assert group_grants == [("some-group", "argumented-permission", "foo-arg")]
     service_account_grants = [
         (g.service_account, g.permission, g.argument)
         for g in mock_service_account_ui.grants.values
@@ -223,7 +219,7 @@ def test_view_permissions(setup):
         "argumented-permission", "gary@a.co", group_paginate, "foo"
     )
     sa_usecase.view_granted_permission(
-        "argumented-permission", "gary@a.co", service_account_paginate, "foo",
+        "argumented-permission", "gary@a.co", service_account_paginate, "foo"
     )
     permission_usecase.view_permission("argumented-permission", "gary@a.co", 20)
 


### PR DESCRIPTION
Allow for more detailed logging by passing in the full Tornado request.

Requires a simultaneous change of any implementations of the `log_request` plugin, since the plugin's invocation is changed..