### PR TITLE
added description to PermissionGrantForm

### DIFF
--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -64,7 +64,11 @@ class PublicKeyForm(Form):
 
 class PermissionGrantForm(Form):
     permission = SelectField(
-        "Permission", [validators.DataRequired()], choices=[["", "(select one)"]], default=""
+        "Permission",
+        [validators.DataRequired()],
+        choices=[["", "(select one)"]],
+        default="",
+        description="Note: The 'arguments' provided in this selector are not really arguments...they are more like suggestions.  you still need to type the argument in the 'Argument' textbox below.",
     )
     argument = StringField(
         "Argument",


### PR DESCRIPTION
3 engineers and a manager were fooled by the "arguments suggestion" feature in "permission" field on the GrantPermission form.

This pull request adds a description to help users understand that those "suggestions" don't do anything, and you've got to type the argument in the "Argument" field.