### PR TITLE
Extend permission argument length to 128 characters

### DIFF
--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -79,7 +79,8 @@ RESERVED_NAMES = [
 # Maximum length a name can be. This applies to user names.
 MAX_NAME_LENGTH = 128
 
-# Maximum length a permission argument can be. This applies to permission_requests and permissions_map arguments.
+# Maximum length a permission argument can be. This applies to permission_requests and
+# permissions_map arguments.
 MAX_ARGUMENT_LENGTH = 128
 
 # Grouper used UserMetadata data_keys

--- a/grouper/constants.py
+++ b/grouper/constants.py
@@ -76,8 +76,11 @@ RESERVED_NAMES = [
     r".*\|.*",
 ]
 
-# Maximum length a name can be. This applies to user names and permission arguments.
+# Maximum length a name can be. This applies to user names.
 MAX_NAME_LENGTH = 128
+
+# Maximum length a permission argument can be. This applies to permission_requests and permissions_map arguments.
+MAX_ARGUMENT_LENGTH = 128
 
 # Grouper used UserMetadata data_keys
 USER_METADATA_SHELL_KEY = "shell"

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -220,7 +220,10 @@ class PermissionRequestForm(Form):
     permission = SelectField("Permission", [validators.DataRequired()])
     argument = StringField(
         "Argument",
-        [validators.Length(min=0, max=constants.MAX_ARGUMENT_LENGTH), ValidateRegex(constants.ARGUMENT_VALIDATION)],
+        [
+            validators.Length(min=0, max=constants.MAX_ARGUMENT_LENGTH),
+            ValidateRegex(constants.ARGUMENT_VALIDATION),
+        ],
     )
     reason = TextAreaField("Reason", [validators.DataRequired()])
 

--- a/grouper/fe/forms.py
+++ b/grouper/fe/forms.py
@@ -220,7 +220,7 @@ class PermissionRequestForm(Form):
     permission = SelectField("Permission", [validators.DataRequired()])
     argument = StringField(
         "Argument",
-        [validators.Length(min=0, max=64), ValidateRegex(constants.ARGUMENT_VALIDATION)],
+        [validators.Length(min=0, max=constants.MAX_ARGUMENT_LENGTH), ValidateRegex(constants.ARGUMENT_VALIDATION)],
     )
     reason = TextAreaField("Reason", [validators.DataRequired()])
 

--- a/grouper/models/permission_map.py
+++ b/grouper/models/permission_map.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
-from grouper.constants import MAX_NAME_LENGTH
+from grouper.constants import MAX_ARGUMENT_LENGTH
 from grouper.models.base.model_base import Model
 
 
@@ -27,7 +27,7 @@ class PermissionMap(Model):
     group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
     group = relationship("Group", foreign_keys=[group_id])
 
-    argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
+    argument = Column(String(length=MAX_ARGUMENT_LENGTH), nullable=True)
     granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     @staticmethod

--- a/grouper/models/permission_request.py
+++ b/grouper/models/permission_request.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
+from grouper.constants import MAX_ARGUMENT_LENGTH
 from grouper.models.base.constants import REQUEST_STATUS_CHOICES
 from grouper.models.base.model_base import Model
 from grouper.settings import settings
@@ -22,7 +23,7 @@ class PermissionRequest(Model):
 
     permission_id = Column(Integer, ForeignKey("permissions.id"), nullable=False)
     permission = relationship("Permission", foreign_keys=[permission_id])
-    argument = Column(String(length=64), nullable=True)
+    argument = Column(String(length=MAX_ARGUMENT_LENGTH), nullable=True)
 
     group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
     group = relationship("Group", foreign_keys=[group_id])

--- a/grouper/models/service_account_permission_map.py
+++ b/grouper/models/service_account_permission_map.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import relationship
 
-from grouper.constants import MAX_NAME_LENGTH
+from grouper.constants import MAX_ARGUMENT_LENGTH
 from grouper.models.base.model_base import Model
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class ServiceAccountPermissionMap(Model):
     service_account_id = Column(Integer, ForeignKey("service_accounts.id"), nullable=False)
     service_account = relationship("ServiceAccount", foreign_keys=[service_account_id])
 
-    argument = Column(String(length=MAX_NAME_LENGTH), nullable=True)
+    argument = Column(String(length=MAX_ARGUMENT_LENGTH), nullable=True)
     granted_on = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     @staticmethod

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -371,7 +371,8 @@ def test_permission_request_flow(
         body=urlencode(
             {
                 "permission": "grantable.one",
-                "argument": "some argument longer than 64 character, some argument longer than 64 character, some argument longer than 64 character",
+                "argument": "some argument longer than 64 character, some argument longer than "
+                            "64 character, some argument longer than 64 character",
                 "reason": "blah blah black sheep",
             }
         ),

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -364,6 +364,22 @@ def test_permission_request_flow(
     emails = _get_unsent_and_mark_as_sent_emails(session)
     assert len(emails) == 0, "no emails queued"
 
+    # REQUEST: permission with argument longer than 64 characters
+    resp = yield http_client.fetch(
+        fe_url,
+        method="POST",
+        body=urlencode(
+            {
+                "permission": "grantable.one",
+                "argument": "some argument longer than 64 character, some argument longer than 64 character, some argument longer than 64 character",
+                "reason": "blah blah black sheep",
+            }
+        ),
+        headers={"X-Grouper-User": username},
+    )
+    assert resp.code == 200
+    assert b"Field must be between" not in resp.body
+
     # REQUEST: 'grantable.one', 'some argument' for 'serving-team'
     resp = yield http_client.fetch(
         fe_url,

--- a/tests/permissions_test.py
+++ b/tests/permissions_test.py
@@ -372,7 +372,7 @@ def test_permission_request_flow(
             {
                 "permission": "grantable.one",
                 "argument": "some argument longer than 64 character, some argument longer than "
-                            "64 character, some argument longer than 64 character",
+                "64 character, some argument longer than 64 character",
                 "reason": "blah blah black sheep",
             }
         ),


### PR DESCRIPTION
When requesting permissions with a long argument the requester will get rejected with message "Argument Field must be between 0 and 64 characters long." 

**The fix requires both code and DB schema change. As part of this PR, the following was changed:**

- Permission form validator max argument length increased to 128 (extracted out as a separate constant in case we want to increase it to 255 or more in the future)
- Changed `permission_requests` model to reflect this change
- Added Unit test

**Testing:**
- Started local FE instance, verified in UI (see screenshot below)
- Spun out local MySql instance and pointed FE locally to it - verified no column length constraint errors
- Ran Unit tests - all passed

**Before:**
<img width="1725" alt="Screen Shot 2022-04-28 at 2 04 44 PM" src="https://user-images.githubusercontent.com/104218996/165864265-87f363b9-7d1c-4ea3-8613-880442ebef2e.png">

**After:**
<img width="1717" alt="Screen Shot 2022-04-28 at 2 11 23 PM" src="https://user-images.githubusercontent.com/104218996/165864274-a2bb80ba-7f9b-4773-abb3-b93ce2c3da10.png">

 