### PR TITLE
Fix overly permissive ssh public key validation

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -18,6 +18,8 @@ SSH_KEY_BAD = "ssh-rsa AAAblahblahkey some-comment"
 
 SSH_KEY_BAD_MULTILINE = SSH_KEY_1 + "\r" + SSH_KEY_2
 
+SSH_KEY_BAD_HAS_OPTIONS = 'command="bash" ' + SSH_KEY_1
+
 SSH2_KEY_BAD = """\
 ---- BEGIN SSH2 PUBLIC KEY ----
 foobar: this is a chance to hide bad things
@@ -30,6 +32,8 @@ SSH_KEY_RSA_1024 = (
     "pOPvEb/785Act4En1VFvwMwTj25VurbG3XI984csiNdWPlM1ke4lHK2PQepSYyZVYn+hhXhzSILNDixhBYeDVv4GOfJM1"
     "HBO2AEtupOMHOqtnQLjV1UnQ== rsa-1024"
 )
+
+SSH_KEY_BAD_NO_SPACE = SSH_KEY_RSA_1024.replace("== rsa-1024", "==rsa-1024")
 
 SSH_KEY_DSA = (
     "ssh-dss AAAAB3NzaC1kc3MAAACBAKdCbYh9GgDPFppJmyRcpWhFn3Xc5vcljGE20df84KYQeBVCQg3zTLkwynHyrpEwT"

--- a/tests/public_key_test.py
+++ b/tests/public_key_test.py
@@ -11,7 +11,14 @@ from grouper.public_key import (
     get_public_keys_of_user,
     PublicKeyParseError,
 )
-from tests.constants import SSH2_KEY_BAD, SSH_KEY_1, SSH_KEY_BAD, SSH_KEY_BAD_MULTILINE
+from tests.constants import (
+    SSH2_KEY_BAD,
+    SSH_KEY_1,
+    SSH_KEY_BAD,
+    SSH_KEY_BAD_HAS_OPTIONS,
+    SSH_KEY_BAD_MULTILINE,
+    SSH_KEY_BAD_NO_SPACE,
+)
 from tests.fixtures import session, users  # noqa: F401
 
 
@@ -32,11 +39,12 @@ def test_duplicate_key(session, users):  # noqa: F811
     assert len(get_public_keys_of_user(session, user.id)) == 1
 
 
-def test_bad_key(session, users):  # noqa: F811
+@pytest.mark.parametrize("key", [SSH_KEY_BAD, SSH_KEY_BAD_NO_SPACE])
+def test_bad_key(key, session, users):  # noqa: F811
     user = users["cbguder@a.co"]
 
     with pytest.raises(PublicKeyParseError):
-        add_public_key(session, user, SSH_KEY_BAD)
+        add_public_key(session, user, key)
 
     assert get_public_keys_of_user(session, user.id) == []
 
@@ -47,6 +55,15 @@ def test_multiline_key(key, session, users):  # noqa: F811
 
     with pytest.raises(PublicKeyParseError, match="Public key cannot have newlines"):
         add_public_key(session, user, key)
+
+    assert get_public_keys_of_user(session, user.id) == []
+
+
+def test_key_with_options(session, users):  # noqa: F811
+    user = users["cbguder@a.co"]
+
+    with pytest.raises(BadPublicKey, match="Public key cannot have options"):
+        add_public_key(session, user, SSH_KEY_BAD_HAS_OPTIONS)
 
     assert get_public_keys_of_user(session, user.id) == []
 


### PR DESCRIPTION
- don't allow missing space between key and comment
- don't allow prefixing key with options