### PR TITLE
Implement context manager in UseCaseFactory and create SqlAlchemy engine manager

### DIFF
--- a/grouper/models/base/session.py
+++ b/grouper/models/base/session.py
@@ -88,7 +88,7 @@ class _DbEngineManager:
 
      Attributes:
         None
-     """
+    """
 
     def __init__(self):
         # type: () -> None

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from grouper.graph import Graph
-from grouper.models.base.session import get_db_engine, Session
+from grouper.models.base.session import DbEngineManager, Session
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.group import GroupRepository
@@ -42,10 +42,11 @@ class SessionFactory:
     def __init__(self, settings):
         # type: (Settings) -> None
         self.settings = settings
+        self._db_engine_manager = DbEngineManager()
 
     def create_session(self):
         # type: () -> Session
-        db_engine = get_db_engine(self.settings.database)
+        db_engine = self._db_engine_manager.get_db_engine(self.settings.database)
         Session.configure(bind=db_engine)
         return Session()
 

--- a/grouper/usecases/factory.py
+++ b/grouper/usecases/factory.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING
 
 from grouper.usecases.convert_user_to_service_account import ConvertUserToServiceAccount
@@ -46,6 +47,20 @@ class UseCaseFactory:
         self.settings = settings
         self.plugins = plugins
         self.service_factory = service_factory
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            session = self.service_factory.repository_factory.session
+            session.close()
+        except Exception:
+            logging.error(
+                "Unable to close Session, service will continue to operate but may result in DB "
+                "connections leak",
+                exc_info=True,
+            )
 
     def create_create_service_account_usecase(self, actor, ui):
         # type: (str, CreateServiceAccountUI) -> CreateServiceAccount

--- a/tests/factories/usecase_factory_test.py
+++ b/tests/factories/usecase_factory_test.py
@@ -1,0 +1,65 @@
+from unittest import mock
+from unittest.mock import patch
+
+from grouper.initialization import create_graph_usecase_factory
+
+
+@patch("grouper.settings.Settings")
+@patch("grouper.plugin.proxy.PluginProxy")
+@patch("sqlalchemy.orm.Session")
+def test_session_closing_successful(session, plugin_proxy, settings):
+    with mock.patch.object(session, "close") as session_closed:
+        with create_graph_usecase_factory(settings, plugin_proxy) as use_case_factory:
+            # swap with mocked session
+            use_case_factory.service_factory.repository_factory._session = session
+
+        session_closed.assert_called()
+
+
+@patch("grouper.settings.Settings")
+@patch("grouper.plugin.proxy.PluginProxy")
+@patch("sqlalchemy.orm.Session")
+def test_session_closing_failed(session, plugin_proxy, settings):
+    with mock.patch.object(session, "close") as session_closed:
+        with create_graph_usecase_factory(settings, plugin_proxy) as use_case_factory:
+            # null out dependency, force exception, graceful handling expected
+            use_case_factory.service_factory.repository_factory = None
+
+        session_closed.assert_not_called()
+
+
+@patch("grouper.plugin.proxy.PluginProxy")
+def test_same_db_url_same_engine_used(plugin_proxy):
+    with mock.patch("grouper.settings.Settings") as settings:
+        with mock.patch("grouper.models.base.session.get_db_engine"):
+            old_use_case_factory = create_graph_usecase_factory(settings, plugin_proxy)
+            old_engine_id = id(
+                old_use_case_factory.service_factory.repository_factory.session.bind
+            )
+
+        with mock.patch("grouper.models.base.session.get_db_engine"):
+            new_use_case_factory = create_graph_usecase_factory(settings, plugin_proxy)
+            new_engine_id = id(
+                new_use_case_factory.service_factory.repository_factory.session.bind
+            )
+
+    assert old_engine_id == new_engine_id
+
+
+@patch("grouper.plugin.proxy.PluginProxy")
+def test_diff_db_url_diff_engine_used(plugin_proxy):
+    with mock.patch("grouper.settings.Settings") as settings:
+        with mock.patch("grouper.models.base.session.get_db_engine"):
+            old_use_case_factory = create_graph_usecase_factory(settings, plugin_proxy)
+            old_engine_id = id(
+                old_use_case_factory.service_factory.repository_factory.session.bind
+            )
+
+    with mock.patch("grouper.settings.Settings") as settings:
+        with mock.patch("grouper.models.base.session.get_db_engine"):
+            new_use_case_factory = create_graph_usecase_factory(settings, plugin_proxy)
+            new_engine_id = id(
+                new_use_case_factory.service_factory.repository_factory.session.bind
+            )
+
+    assert old_engine_id != new_engine_id


### PR DESCRIPTION
We discovered a DB connections leak which resulted in our MySQL connection pool saturation and eventually lead to new connections being rejected. 

**There are 2 separate issues contributing to the leak:**

- UseCaseFactory creating a new SqlAlchemy Engine/ConnectionPool every time new factory instance is created. There should be only 1 Engine/ConnectionPool per DB URL for the entire lifecycle of the application.
- UseCaseFactory, when instantiated, creates a new SqlAlchemy Session which is injected into multiple underlying components but is never closed leading to them holding onto DB connections and not returning them to the pool. Garbage collection eventually cleans those dangling references up, but under certain load this may not happen quick enough leading to connections accumulating. Clients that use this factory should be responsible for closing the session however factory doesn't have any good API for session closing.

 **The fix for the above includes:**

- New **DbEngineManager** thread-safe singleton is introduced. It lazily initializes and caches Engine/ConnectionPool for a given URL, subsequent requests with the same URL return the same Engine instance:

``` 
db_engine_manager = DbEngineManager() 
db_engine = db_engine_manager.get_db_engine(URL)
Session.configure(bind=db_engine)
```

- To ensure UseCaseFactory underlying Session gets closed, use it as follows:

```
with UseCaseFactory(settings, plugins, service_factory) as usecase_factory:
     # use your factory in this block
     # when exiting the block underlying session will be closed automatically
```

**Notes and Limitations:**

None of the internal grouper stuff has been migrated to use **UseCaseFactory** as context manager yet. This migration will be done separately after the change has been tested and verified with one of our clients.

**Testing:**

- Added new unit test
- Verified DB connections leak is resolved via our external grpc client (see snapshots) both single and multi-threaded.

**Before (note both connections count increase and idle time on some of them):**

```
mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:60364 | grouper_prod | Sleep   |   10 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
3 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:60364 | grouper_prod | Sleep   |   13 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
3 rows in set (0.01 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 25 | esdev_20190403_w | localhost:60396 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 26 | esdev_20190403_w | localhost:60398 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 27 | esdev_20190403_w | localhost:60402 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 29 | esdev_20190403_w | localhost:60406 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
6 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 25 | esdev_20190403_w | localhost:60396 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 26 | esdev_20190403_w | localhost:60398 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 27 | esdev_20190403_w | localhost:60402 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 29 | esdev_20190403_w | localhost:60406 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
6 rows in set (0.00 sec)

mysql> show full processlist;
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id  | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|   6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|   7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  25 | esdev_20190403_w | localhost:60396 | grouper_prod | Sleep   |   18 |          | NULL                  |         0 |             0 |
|  32 | esdev_20190403_w | localhost:60412 | grouper_prod | Sleep   |   15 |          | NULL                  |         0 |             0 |
|  33 | esdev_20190403_w | localhost:60414 | grouper_prod | Sleep   |   15 |          | NULL                  |         0 |             0 |
|  34 | esdev_20190403_w | localhost:60416 | grouper_prod | Sleep   |   15 |          | NULL                  |         0 |             0 |
|  41 | esdev_20190403_w | localhost:60430 | grouper_prod | Sleep   |   11 |          | NULL                  |         0 |             0 |
|  42 | esdev_20190403_w | localhost:60432 | grouper_prod | Sleep   |   12 |          | NULL                  |         0 |             0 |
|  43 | esdev_20190403_w | localhost:60434 | grouper_prod | Sleep   |   11 |          | NULL                  |         0 |             0 |
|  50 | esdev_20190403_w | localhost:60450 | grouper_prod | Sleep   |    8 |          | NULL                  |         0 |             0 |
|  51 | esdev_20190403_w | localhost:60452 | grouper_prod | Sleep   |    8 |          | NULL                  |         0 |             0 |
|  52 | esdev_20190403_w | localhost:60454 | grouper_prod | Sleep   |    8 |          | NULL                  |         0 |             0 |
|  59 | esdev_20190403_w | localhost:60468 | grouper_prod | Sleep   |    5 |          | NULL                  |         0 |             0 |
|  60 | esdev_20190403_w | localhost:60470 | grouper_prod | Sleep   |    5 |          | NULL                  |         0 |             0 |
|  61 | esdev_20190403_w | localhost:60472 | grouper_prod | Sleep   |    5 |          | NULL                  |         0 |             0 |
|  68 | esdev_20190403_w | localhost:60486 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  69 | esdev_20190403_w | localhost:60488 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  70 | esdev_20190403_w | localhost:60490 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  71 | esdev_20190403_w | localhost:60492 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  76 | esdev_20190403_w | localhost:60502 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  77 | esdev_20190403_w | localhost:60504 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  78 | esdev_20190403_w | localhost:60506 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  79 | esdev_20190403_w | localhost:60508 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  82 | esdev_20190403_w | localhost:60514 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  83 | esdev_20190403_w | localhost:60516 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  86 | esdev_20190403_w | localhost:60522 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  87 | esdev_20190403_w | localhost:60524 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  88 | esdev_20190403_w | localhost:60526 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  95 | esdev_20190403_w | localhost:60540 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  96 | esdev_20190403_w | localhost:60542 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  97 | esdev_20190403_w | localhost:60544 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  98 | esdev_20190403_w | localhost:60546 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  99 | esdev_20190403_w | localhost:60548 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 100 | esdev_20190403_w | localhost:60550 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 101 | esdev_20190403_w | localhost:60552 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 102 | esdev_20190403_w | localhost:60554 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 103 | esdev_20190403_w | localhost:60556 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 104 | esdev_20190403_w | localhost:60558 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
38 rows in set (0.00 sec)

mysql> show full processlist;
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id  | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|   6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|   7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  25 | esdev_20190403_w | localhost:60396 | grouper_prod | Sleep   |   19 |          | NULL                  |         0 |             0 |
|  32 | esdev_20190403_w | localhost:60412 | grouper_prod | Sleep   |   16 |          | NULL                  |         0 |             0 |
|  33 | esdev_20190403_w | localhost:60414 | grouper_prod | Sleep   |   16 |          | NULL                  |         0 |             0 |
|  34 | esdev_20190403_w | localhost:60416 | grouper_prod | Sleep   |   16 |          | NULL                  |         0 |             0 |
|  41 | esdev_20190403_w | localhost:60430 | grouper_prod | Sleep   |   12 |          | NULL                  |         0 |             0 |
|  42 | esdev_20190403_w | localhost:60432 | grouper_prod | Sleep   |   13 |          | NULL                  |         0 |             0 |
|  43 | esdev_20190403_w | localhost:60434 | grouper_prod | Sleep   |   12 |          | NULL                  |         0 |             0 |
|  50 | esdev_20190403_w | localhost:60450 | grouper_prod | Sleep   |    9 |          | NULL                  |         0 |             0 |
|  51 | esdev_20190403_w | localhost:60452 | grouper_prod | Sleep   |    9 |          | NULL                  |         0 |             0 |
|  52 | esdev_20190403_w | localhost:60454 | grouper_prod | Sleep   |    9 |          | NULL                  |         0 |             0 |
|  59 | esdev_20190403_w | localhost:60468 | grouper_prod | Sleep   |    6 |          | NULL                  |         0 |             0 |
|  60 | esdev_20190403_w | localhost:60470 | grouper_prod | Sleep   |    6 |          | NULL                  |         0 |             0 |
|  61 | esdev_20190403_w | localhost:60472 | grouper_prod | Sleep   |    6 |          | NULL                  |         0 |             0 |
|  68 | esdev_20190403_w | localhost:60486 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  69 | esdev_20190403_w | localhost:60488 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  70 | esdev_20190403_w | localhost:60490 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  71 | esdev_20190403_w | localhost:60492 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  76 | esdev_20190403_w | localhost:60502 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  77 | esdev_20190403_w | localhost:60504 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  78 | esdev_20190403_w | localhost:60506 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  79 | esdev_20190403_w | localhost:60508 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  82 | esdev_20190403_w | localhost:60514 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  83 | esdev_20190403_w | localhost:60516 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  86 | esdev_20190403_w | localhost:60522 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  87 | esdev_20190403_w | localhost:60524 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  88 | esdev_20190403_w | localhost:60526 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  95 | esdev_20190403_w | localhost:60540 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  96 | esdev_20190403_w | localhost:60542 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  97 | esdev_20190403_w | localhost:60544 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  98 | esdev_20190403_w | localhost:60546 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
|  99 | esdev_20190403_w | localhost:60548 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
| 100 | esdev_20190403_w | localhost:60550 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
| 101 | esdev_20190403_w | localhost:60552 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
| 102 | esdev_20190403_w | localhost:60554 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
| 103 | esdev_20190403_w | localhost:60556 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
| 104 | esdev_20190403_w | localhost:60558 | grouper_prod | Sleep   |    2 |          | NULL                  |         0 |             0 |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
38 rows in set (0.00 sec)

mysql> show full processlist;
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id  | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|   6 | esdev_20190403_w | localhost:60358 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|   7 | esdev_20190403_w | localhost:60360 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  25 | esdev_20190403_w | localhost:60396 | grouper_prod | Sleep   |   20 |          | NULL                  |         0 |             0 |
|  32 | esdev_20190403_w | localhost:60412 | grouper_prod | Sleep   |   17 |          | NULL                  |         0 |             0 |
|  33 | esdev_20190403_w | localhost:60414 | grouper_prod | Sleep   |   17 |          | NULL                  |         0 |             0 |
|  34 | esdev_20190403_w | localhost:60416 | grouper_prod | Sleep   |   17 |          | NULL                  |         0 |             0 |
|  41 | esdev_20190403_w | localhost:60430 | grouper_prod | Sleep   |   13 |          | NULL                  |         0 |             0 |
|  42 | esdev_20190403_w | localhost:60432 | grouper_prod | Sleep   |   14 |          | NULL                  |         0 |             0 |
|  43 | esdev_20190403_w | localhost:60434 | grouper_prod | Sleep   |   13 |          | NULL                  |         0 |             0 |
|  50 | esdev_20190403_w | localhost:60450 | grouper_prod | Sleep   |   10 |          | NULL                  |         0 |             0 |
|  51 | esdev_20190403_w | localhost:60452 | grouper_prod | Sleep   |   10 |          | NULL                  |         0 |             0 |
|  52 | esdev_20190403_w | localhost:60454 | grouper_prod | Sleep   |   10 |          | NULL                  |         0 |             0 |
|  59 | esdev_20190403_w | localhost:60468 | grouper_prod | Sleep   |    7 |          | NULL                  |         0 |             0 |
|  60 | esdev_20190403_w | localhost:60470 | grouper_prod | Sleep   |    7 |          | NULL                  |         0 |             0 |
|  61 | esdev_20190403_w | localhost:60472 | grouper_prod | Sleep   |    7 |          | NULL                  |         0 |             0 |
|  68 | esdev_20190403_w | localhost:60486 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  69 | esdev_20190403_w | localhost:60488 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  70 | esdev_20190403_w | localhost:60490 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  71 | esdev_20190403_w | localhost:60492 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  76 | esdev_20190403_w | localhost:60502 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  77 | esdev_20190403_w | localhost:60504 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  78 | esdev_20190403_w | localhost:60506 | grouper_prod | Sleep   |    4 |          | NULL                  |         0 |             0 |
|  79 | esdev_20190403_w | localhost:60508 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  82 | esdev_20190403_w | localhost:60514 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  83 | esdev_20190403_w | localhost:60516 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  86 | esdev_20190403_w | localhost:60522 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  87 | esdev_20190403_w | localhost:60524 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  88 | esdev_20190403_w | localhost:60526 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  95 | esdev_20190403_w | localhost:60540 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  96 | esdev_20190403_w | localhost:60542 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  97 | esdev_20190403_w | localhost:60544 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
|  98 | esdev_20190403_w | localhost:60546 | grouper_prod | Sleep   |    3 |          | NULL                  |         0 |             0 |
| 104 | esdev_20190403_w | localhost:60558 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 107 | esdev_20190403_w | localhost:60566 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 108 | esdev_20190403_w | localhost:60568 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 113 | esdev_20190403_w | localhost:60580 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 114 | esdev_20190403_w | localhost:60584 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 115 | esdev_20190403_w | localhost:60586 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 116 | esdev_20190403_w | localhost:60588 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 117 | esdev_20190403_w | localhost:60590 | grouper_prod | Sleep   |    0 |          | NULL                  |         1 |             1 |
| 118 | esdev_20190403_w | localhost:60592 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 119 | esdev_20190403_w | localhost:60594 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 121 | esdev_20190403_w | localhost:60598 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 122 | esdev_20190403_w | localhost:60600 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
+-----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
44 rows in set (0.00 sec)

```

**After:**

```
mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

mysql> show full processlist;
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
| Id | User             | Host            | db           | Command | Time | State    | Info                  | Rows_sent | Rows_examined |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
|  4 | esdev_20190403_w | localhost:45654 | NULL         | Query   |    0 | starting | show full processlist |         0 |             0 |
|  8 | esdev_20190403_w | localhost:45662 | grouper_prod | Sleep   |    0 |          | NULL                  |         0 |             0 |
|  9 | esdev_20190403_w | localhost:45664 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 21 | esdev_20190403_w | localhost:45694 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 22 | esdev_20190403_w | localhost:45696 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 23 | esdev_20190403_w | localhost:45700 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
| 24 | esdev_20190403_w | localhost:45702 | grouper_prod | Sleep   |    1 |          | NULL                  |         0 |             0 |
+----+------------------+-----------------+--------------+---------+------+----------+-----------------------+-----------+---------------+
7 rows in set (0.00 sec)

```