### PR TITLE
introduce basic regex log redaction

### DIFF
--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -14,7 +14,6 @@ from grouper.plugin.proxy import PluginProxy
 from grouper.repositories.factory import SessionFactory, SingletonSessionFactory
 from grouper.settings import default_settings_path
 from grouper.setup import setup_logging
-from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session

--- a/grouper/ctl/main.py
+++ b/grouper/ctl/main.py
@@ -13,13 +13,12 @@ from grouper.plugin.exceptions import PluginsDirectoryDoesNotExist
 from grouper.plugin.proxy import PluginProxy
 from grouper.repositories.factory import SessionFactory, SingletonSessionFactory
 from grouper.settings import default_settings_path
+from grouper.setup import setup_logging
 from grouper.util import get_loglevel
 
 if TYPE_CHECKING:
     from grouper.models.base.session import Session
     from typing import List, Optional
-
-sa_log = logging.getLogger("sqlalchemy.engine.base.Engine")
 
 
 def main(sys_argv=sys.argv, session=None):
@@ -63,18 +62,14 @@ def main(sys_argv=sys.argv, session=None):
     if args.database_url:
         settings.database = args.database_url
 
+    setup_logging(args, settings.log_format)
+
     # Construct a session factory, which is passed into all the legacy commands that haven't been
     # converted to usecases yet.
     if session:
         session_factory = SingletonSessionFactory(session)  # type: SessionFactory
     else:
         session_factory = SessionFactory(settings)
-
-    log_level = get_loglevel(args, base=logging.INFO)
-    logging.basicConfig(level=log_level, format=settings.log_format)
-
-    if log_level < 0:
-        sa_log.setLevel(logging.INFO)
 
     # Initialize plugins.  The global plugin proxy is used by legacy code.
     try:

--- a/grouper/log_redact.py
+++ b/grouper/log_redact.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 import logging
 import re
 
+
 @dataclass
 class RedactionPattern:
     # regular expression to match for redaction
@@ -9,12 +10,9 @@ class RedactionPattern:
     # sensitive string will be replaced by this "redacted_message" in the log output
     redacted_message: str
 
+
 class RedactingFormatter(logging.Formatter):
-    """
-    RedactingFormatter masks sensitive regular expressions from log entries.
-    
-    Configure the sensitive log regular expressions in settings.log_redact_patterns.
-    """
+    """RedactingFormatter masks sensitive regular expressions from log entries."""
 
     _REDACT_PATTERNS = [
         RedactionPattern(  # mysql url
@@ -31,12 +29,17 @@ class RedactingFormatter(logging.Formatter):
         ),
     ]
 
-    def _filter(self, log_string: str) -> str:
+    def _redact(self, log_string: str) -> str:
         new_string = log_string
         for pattern in RedactingFormatter._REDACT_PATTERNS:
-            new_string = re.sub(pattern.regex, f"<{pattern.redacted_message}>", new_string)
+            new_string = re.sub(
+                pattern.regex,
+                f"<{pattern.redacted_message}>",
+                new_string,
+                flags=re.IGNORECASE,
+            )
         return new_string
-    
+
     def format(self, record: logging.LogRecord) -> str:
-        original_log_message = logging.Formatter.format(self, record)
-        return self._filter(original_log_message)
+        original_log_message = super().format(record)
+        return self._redact(original_log_message)

--- a/grouper/log_redact.py
+++ b/grouper/log_redact.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
 import logging
 import re
+from dataclasses import dataclass
 
 
 @dataclass

--- a/grouper/log_redact.py
+++ b/grouper/log_redact.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+import logging
+import re
+
+@dataclass
+class RedactionPattern:
+    # regular expression to match for redaction
+    regex: str
+    # sensitive string will be replaced by this "redacted_message" in the log output
+    redacted_message: str
+
+class RedactingFormatter(logging.Formatter):
+    """
+    RedactingFormatter masks sensitive regular expressions from log entries.
+    
+    Configure the sensitive log regular expressions in settings.log_redact_patterns.
+    """
+
+    _REDACT_PATTERNS = [
+        RedactionPattern(  # mysql url
+            r"mysql://\S*",
+            "DB_URL_REDACTED",
+        ),
+        RedactionPattern(  # sqlite url
+            r"sqlite://\S*",
+            "DB_URL_REDACTED",
+        ),
+        RedactionPattern(  # anything with password=
+            r"password=\S+",
+            "PASSWORD_REDACTED",
+        ),
+    ]
+
+    def _filter(self, log_string: str) -> str:
+        new_string = log_string
+        for pattern in RedactingFormatter._REDACT_PATTERNS:
+            new_string = re.sub(pattern.regex, f"<{pattern.redacted_message}>", new_string)
+        return new_string
+    
+    def format(self, record: logging.LogRecord) -> str:
+        original_log_message = logging.Formatter.format(self, record)
+        return self._filter(original_log_message)

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -79,7 +79,6 @@ class Settings:
         self.http_proxy_host = None  # type: Optional[str]
         self.http_proxy_port = None  # type: Optional[int]
         self.log_format = "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
-        self.log_redact_patterns = [] # type: List[str]
         self.plugin_dirs = []  # type: List[str]
         self.plugin_module_paths = []  # type: List[str]
         self.restricted_ownership_permissions = []  # type: List[str]

--- a/grouper/settings.py
+++ b/grouper/settings.py
@@ -79,6 +79,7 @@ class Settings:
         self.http_proxy_host = None  # type: Optional[str]
         self.http_proxy_port = None  # type: Optional[int]
         self.log_format = "%(asctime)-15s\t%(levelname)s\t%(message)s  [%(name)s]"
+        self.log_redact_patterns = [] # type: List[str]
         self.plugin_dirs = []  # type: List[str]
         self.plugin_module_paths = []  # type: List[str]
         self.restricted_ownership_permissions = []  # type: List[str]

--- a/tests/log_redact_test.py
+++ b/tests/log_redact_test.py
@@ -1,4 +1,5 @@
 import re
+
 from grouper.log_redact import RedactingFormatter
 
 

--- a/tests/log_redact_test.py
+++ b/tests/log_redact_test.py
@@ -1,0 +1,26 @@
+import re
+from grouper.log_redact import RedactingFormatter
+
+def test_redact_regex() -> None:
+    """Test regular expressions compile correctly."""
+    for pattern in RedactingFormatter._REDACT_PATTERNS:
+        re.compile(pattern.regex)
+
+
+def test_known_bad_strings() -> None:
+    """Test the redaction filter on known sensitive log strings.
+    
+    The actual value of the password in each sample is replaced
+    with the string "PASSWORD".
+    """
+    bad_strings = [
+        "mysql://grouper:PASSWORD@localhost:3306/grouper",
+        "mysql://localhost:3306?username=grouper&password=PASSWORD"
+        "sqlite:////srv/grouper.db?password=PASSWORD",
+    ]
+
+    redactor = RedactingFormatter()
+
+    for sample in bad_strings:
+        filtered = redactor._filter(sample)
+        assert "PASSWORD" not in filtered

--- a/tests/log_redact_test.py
+++ b/tests/log_redact_test.py
@@ -1,6 +1,7 @@
 import re
 from grouper.log_redact import RedactingFormatter
 
+
 def test_redact_regex() -> None:
     """Test regular expressions compile correctly."""
     for pattern in RedactingFormatter._REDACT_PATTERNS:
@@ -9,7 +10,7 @@ def test_redact_regex() -> None:
 
 def test_known_bad_strings() -> None:
     """Test the redaction filter on known sensitive log strings.
-    
+
     The actual value of the password in each sample is replaced
     with the string "PASSWORD".
     """
@@ -22,5 +23,5 @@ def test_known_bad_strings() -> None:
     redactor = RedactingFormatter()
 
     for sample in bad_strings:
-        filtered = redactor._filter(sample)
+        filtered = redactor._redact(sample)
         assert "PASSWORD" not in filtered


### PR DESCRIPTION
In response to the recent incident regarding database password leaks, this PR adds a log formatter to all python loggers which will match plaintext db url strings and redact them from the log output. It does not eliminate the risk, but it adds an additional layer of protection against accidental logging of sensitive credentials.