### PR TITLE
add permission to service account grant duplicate validation

### DIFF
--- a/grouper/fe/handlers/permission_grants_service_account_view.py
+++ b/grouper/fe/handlers/permission_grants_service_account_view.py
@@ -33,7 +33,6 @@ class PermissionGrantsServiceAccountView(GrouperHandler, ViewPermissionServiceAc
     def viewed_permission(
         self, permission: Permission, grants: PaginatedList[ServiceAccountPermissionGrant]
     ) -> None:
-
         sort_key = self.get_sort_key().name.lower()
         sort_dir = self.get_argument("order", "asc")
 

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -50,6 +50,13 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
         self._form.permission.errors.append(f"Unknown permission {permission}")
         self._render_template(self._form, service, self._owner)
 
+    def grant_permission_to_service_account_failed_permission_already_granted(
+        self, permission: str, argument: str, service: str
+    ) -> None:
+        self._form.permission.errors.append(f"Permission {permission} with argument {argument} "
+                                            f"has already been granted to this service account")
+        self._render_template(self._form, service, self._owner)
+
     def grant_permission_to_service_account_failed_service_account_not_found(
         self, service: str
     ) -> None:

--- a/grouper/fe/handlers/service_account_permission_grant.py
+++ b/grouper/fe/handlers/service_account_permission_grant.py
@@ -53,8 +53,10 @@ class ServiceAccountPermissionGrant(GrouperHandler, GrantPermissionToServiceAcco
     def grant_permission_to_service_account_failed_permission_already_granted(
         self, permission: str, argument: str, service: str
     ) -> None:
-        self._form.permission.errors.append(f"Permission {permission} with argument {argument} "
-                                            f"has already been granted to this service account")
+        self._form.permission.errors.append(
+            f"Permission {permission} with argument {argument} "
+            f"has already been granted to this service account"
+        )
         self._render_template(self._form, service, self._owner)
 
     def grant_permission_to_service_account_failed_service_account_not_found(

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -39,7 +39,9 @@ class GrantPermissionToServiceAccountUI(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def grant_permission_to_service_account_failed_permission_already_granted(self, permission, argument, service):
+    def grant_permission_to_service_account_failed_permission_already_granted(
+        self, permission, argument, service
+    ):
         # type: (str, str, str) -> None
         pass
 

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -1,11 +1,12 @@
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
+from sqlalchemy.exc import IntegrityError
+
 from grouper.entities.permission import PermissionNotFoundException
 from grouper.usecases.authorization import Authorization
 from grouper.util import matches_glob
 
-from sqlalchemy.exc import IntegrityError
 
 if TYPE_CHECKING:
     from grouper.usecases.interfaces import (

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -5,6 +5,8 @@ from grouper.entities.permission import PermissionNotFoundException
 from grouper.usecases.authorization import Authorization
 from grouper.util import matches_glob
 
+from sqlalchemy.exc import IntegrityError
+
 if TYPE_CHECKING:
     from grouper.usecases.interfaces import (
         GroupInterface,
@@ -34,6 +36,11 @@ class GrantPermissionToServiceAccountUI(metaclass=ABCMeta):
     @abstractmethod
     def grant_permission_to_service_account_failed_permission_not_found(self, permission, service):
         # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def grant_permission_to_service_account_failed_permission_already_granted(self, permission, argument, service):
+        # type: (str, str, str) -> None
         pass
 
     @abstractmethod
@@ -139,6 +146,11 @@ class GrantPermissionToServiceAccount:
                 # Leaving the logic here however in case that changes in the future.
                 self.ui.grant_permission_to_service_account_failed_permission_not_found(
                     permission, service
+                )
+                return
+            except IntegrityError:
+                self.ui.grant_permission_to_service_account_failed_permission_already_granted(
+                    permission, argument, service
                 )
                 return
         self.ui.granted_permission_to_service_account(permission, argument, service)

--- a/grouper/usecases/grant_permission_to_service_account.py
+++ b/grouper/usecases/grant_permission_to_service_account.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -151,11 +152,18 @@ class GrantPermissionToServiceAccount:
                     permission, service
                 )
                 return
-            except IntegrityError:
-                self.ui.grant_permission_to_service_account_failed_permission_already_granted(
-                    permission, argument, service
-                )
-                return
+            except IntegrityError as err:
+                if "Duplicate entry" in str(err):
+                    logging.error(
+                        f"Duplicate entry for service account permission grant found for "
+                        f"permission {permission}, argument {argument}, service {service}"
+                    )
+                    self.ui.grant_permission_to_service_account_failed_permission_already_granted(
+                        permission, argument, service
+                    )
+                    return
+
+                raise err
         self.ui.granted_permission_to_service_account(permission, argument, service)
 
     def service_account_exists_with_owner(self, service, owner):


### PR DESCRIPTION
**Overview**

There is currently no validation for duplicate service account permission grant (it silently throws 500 error when users try to grant the same permission with the same argument to the same service account). Adding validation along with error message when it already exists.

**Testing Done**

Granted the same permission with the same argument to a service account locally, reproduced the issue before the fix and confirmed the error message instead of 500 shows up after the fix.